### PR TITLE
feat: 🎸 allow empty features

### DIFF
--- a/src/datasets_preview_backend/dataset_entries.py
+++ b/src/datasets_preview_backend/dataset_entries.py
@@ -150,9 +150,12 @@ def get_info(dataset: str, config: str) -> Info:
 
 
 def get_features(info: Info) -> List[Feature]:
-    if "features" not in info or info["features"] is None:
-        raise Status400Error("a dataset config info should contain a 'features' property")
-    return [{"name": name, "content": content} for (name, content) in info["features"].items()]
+    try:
+        features = [] if info["features"] is None else info["features"].items()
+        return [{"name": name, "content": content} for (name, content) in features]
+    except Exception as err:
+        # note that no exception will be raised if features exists, but is empty
+        raise Status400Error("features not found in dataset config info", err)
 
 
 def get_config_name(config_entry: Config) -> str:

--- a/tests/test_dataset_entries.py
+++ b/tests/test_dataset_entries.py
@@ -38,6 +38,13 @@ def test_get_dataset_cache_status_error() -> None:
 
 
 # get_features
+def test_empty_features() -> None:
+    configs = get_config_names("allenai/c4")
+    info = get_info("allenai/c4", configs[0])
+    features = get_features(info)
+    assert len(features) == 0
+
+
 def test_get_features() -> None:
     info = get_info("acronym_identification", DEFAULT_CONFIG_NAME)
     features = get_features(info)


### PR DESCRIPTION
Anyway: we don't check if the number of features correspond to the
number of columns in the rows, so... why not let the features be empty.
The client will have to guess the types.