### PR TITLE
fix: 🐛 serve the asserts from nginx instead of starlette

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -112,8 +112,16 @@ server {
   listen [::]:80;
   server_name datasets-preview.huggingface.tech;
 
+  add_header 'Access-Control-Allow-Origin' '*';
+
   access_log /var/log/nginx/reverse-access.log;
   error_log /var/log/nginx/reverse-error.log;
+
+  # due to https://github.com/encode/starlette/issues/950, which generates errors in Safari: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/CreatingVideoforSafarioniPhone/CreatingVideoforSafarioniPhone.html#//apple_ref/doc/uid/TP40006514-SW6
+  # we serve the static files from nginx instead of starlette
+  location /assets {
+    root /home/hf/.cache/datasets_preview_backend_assets
+  }
 
   location / {
     proxy_pass http://localhost:8000/;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 authors = ["Sylvain Lesage <severo@rednegra.net>"]
 description = "API to extract rows of 🤗 datasets"
 name = "datasets-preview-backend"
-version = "0.15.7"
+version = "0.15.8"
 
 [tool.poetry.dependencies]
 Pillow = "^8.4.0"

--- a/src/datasets_preview_backend/io/asset.py
+++ b/src/datasets_preview_backend/io/asset.py
@@ -13,7 +13,7 @@ from datasets_preview_backend.config import ASSETS_DIRECTORY
 logger = logging.getLogger(__name__)
 
 DATASET_SEPARATOR = "--"
-ASSET_DIR_MODE = 755
+ASSET_DIR_MODE = 0o755
 
 # set it to the default cache location on the machine, if ASSETS_DIRECTORY is null
 assets_directory = user_cache_dir("datasets_preview_backend_assets") if ASSETS_DIRECTORY is None else ASSETS_DIRECTORY


### PR DESCRIPTION
Starlette cannot serve ranges for static files, see
https://github.com/encode/starlette/issues/950.

Also: fix the rights of the assets directory
Also: add the CORS header (doc)