### PR TITLE
fix: 🐛 the blocked datasets must be blocked at cache invalidation

### DIFF
--- a/src/datasets_preview_backend/models/_guard.py
+++ b/src/datasets_preview_backend/models/_guard.py
@@ -1,0 +1,7 @@
+from datasets_preview_backend.constants import DATASETS_BLOCKLIST
+from datasets_preview_backend.exceptions import Status400Error
+
+
+def guard_blocked_datasets(dataset_name: str) -> None:
+    if dataset_name in DATASETS_BLOCKLIST:
+        raise Status400Error("this dataset is not supported for now.")

--- a/src/datasets_preview_backend/models/dataset.py
+++ b/src/datasets_preview_backend/models/dataset.py
@@ -5,6 +5,7 @@ from datasets import get_dataset_config_names, get_dataset_split_names
 
 from datasets_preview_backend.constants import FORCE_REDOWNLOAD
 from datasets_preview_backend.exceptions import Status400Error
+from datasets_preview_backend.models._guard import guard_blocked_datasets
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +19,7 @@ class SplitFullName(TypedDict):
 def get_dataset_split_full_names(dataset_name: str, hf_token: Optional[str] = None) -> List[SplitFullName]:
     logger.info(f"get dataset '{dataset_name}' split full names")
     try:
+        guard_blocked_datasets(dataset_name)
         return [
             {"dataset_name": dataset_name, "config_name": config_name, "split_name": split_name}
             for config_name in get_dataset_config_names(

--- a/src/datasets_preview_backend/models/split.py
+++ b/src/datasets_preview_backend/models/split.py
@@ -1,6 +1,7 @@
 import logging
 from typing import List, Optional, TypedDict
 
+from datasets_preview_backend.models._guard import guard_blocked_datasets
 from datasets_preview_backend.models.column import Column
 from datasets_preview_backend.models.info import get_info
 from datasets_preview_backend.models.row import Row
@@ -23,6 +24,7 @@ def get_split(
     max_size_fallback: Optional[int] = None,
 ) -> Split:
     logger.info(f"get split '{split_name}' for config '{config_name}' of dataset '{dataset_name}'")
+    guard_blocked_datasets(dataset_name)
     info = get_info(dataset_name, config_name, hf_token)
     fallback = (
         max_size_fallback is not None

--- a/src/datasets_preview_backend/routes/rows.py
+++ b/src/datasets_preview_backend/routes/rows.py
@@ -4,8 +4,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from datasets_preview_backend.config import MAX_AGE_LONG_SECONDS
-from datasets_preview_backend.constants import DATASETS_BLOCKLIST
-from datasets_preview_backend.exceptions import Status400Error, StatusError
+from datasets_preview_backend.exceptions import StatusError
 from datasets_preview_backend.io.cache import get_rows_response
 from datasets_preview_backend.routes._utils import get_response
 
@@ -21,8 +20,6 @@ async def rows_endpoint(request: Request) -> Response:
     try:
         if not isinstance(dataset_name, str) or not isinstance(config_name, str) or not isinstance(split_name, str):
             raise StatusError("Parameters 'dataset', 'config' and 'split' are required", 400)
-        if dataset_name in DATASETS_BLOCKLIST:
-            raise Status400Error("this dataset is not supported for now.")
         rows_response, rows_error, status_code = get_rows_response(dataset_name, config_name, split_name)
         return get_response(rows_response or rows_error, status_code, MAX_AGE_LONG_SECONDS)
     except StatusError as err:

--- a/src/datasets_preview_backend/routes/splits.py
+++ b/src/datasets_preview_backend/routes/splits.py
@@ -4,7 +4,6 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from datasets_preview_backend.config import MAX_AGE_LONG_SECONDS
-from datasets_preview_backend.constants import DATASETS_BLOCKLIST
 from datasets_preview_backend.exceptions import Status400Error, StatusError
 from datasets_preview_backend.io.cache import get_splits_response
 from datasets_preview_backend.routes._utils import get_response
@@ -19,8 +18,6 @@ async def splits_endpoint(request: Request) -> Response:
     try:
         if not isinstance(dataset_name, str):
             raise Status400Error("Parameter 'dataset' is required")
-        if dataset_name in DATASETS_BLOCKLIST:
-            raise Status400Error("this dataset is not supported for now.")
         splits_response, splits_error, status_code = get_splits_response(dataset_name)
         return get_response(splits_response or splits_error, status_code, MAX_AGE_LONG_SECONDS)
     except StatusError as err:


### PR DESCRIPTION
They were blocked on user requests, instead of at cache invalidation,
which is the purpose of blocking them (not overwhelm the server with
memory overflow, see
https://github.com/huggingface/datasets-preview-backend/issues/91#issuecomment-952749773