### PR TITLE
feat: 🎸 change the meaning of a "valid" dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Beware: a "dataset" is considered valid if it has fetched correctly the configs 
 
 ### /valid
 
-> Give the list of the valid datasets. A dataset is considered valid if `/splits` and `/rows` for all the splits return a valid response. Note that stalled cache entries are considered valid.
+> Give the list of the valid datasets. Here, a dataset is considered valid if `/splits` returns a valid response, and if `/rows` returns a valid response for _at least one split_. Note that stalled cache entries are considered valid.
 
 Example: https://datasets-preview.huggingface.tech/valid
 
@@ -229,7 +229,7 @@ Responses:
 
 ### /is-valid
 
-> Tells if a dataset is valid. A dataset is considered valid if `/splits` and `/rows` for all the splits return a valid response. Note that stalled cache entries are considered valid.
+> Tells if a dataset is valid. A dataset is considered valid if `/splits` returns a valid response, and if `/rows` returns a valid response for _at least one split_. Note that stalled cache entries are considered valid.
 
 Example: https://datasets-preview.huggingface.tech/is-valid?dataset=glue
 

--- a/src/datasets_preview_backend/io/cache.py
+++ b/src/datasets_preview_backend/io/cache.py
@@ -522,7 +522,7 @@ def is_dataset_valid_or_stalled(dataset: DbDataset) -> bool:
         return False
 
     splits = DbSplit.objects(dataset_name=dataset.dataset_name).only("status")
-    return all(split.status in [Status.VALID, Status.STALLED] for split in splits)
+    return any(split.status in [Status.VALID, Status.STALLED] for split in splits)
 
 
 def is_dataset_name_valid_or_stalled(dataset_name: str) -> bool:


### PR DESCRIPTION
Now: a dataset is considered valid if "at least one split" is valid.

BREAKING CHANGE: 🧨 /valid and /is-valid consider as valid the datasets with at least one
valid split (before: all the splits were required to be valid)

Fixes https://github.com/huggingface/datasets-preview-backend/issues/139