### PR TITLE
feat: 🎸 force all the rows to have the same set of columns

### DIFF
--- a/src/datasets_preview_backend/models/typed_row.py
+++ b/src/datasets_preview_backend/models/typed_row.py
@@ -14,8 +14,6 @@ def get_typed_row(
 ) -> Row:
     return {
         column.name: column.get_cell_value(dataset_name, config_name, split_name, row_idx, row[column.name])
-        if column.name in row
-        else None
         for column in columns
     }
 


### PR DESCRIPTION
It reverts
https://github.com/huggingface/datasets-preview-backend/pull/145, as
discussed in https://github.com/huggingface/datasets/issues/3738 and
https://github.com/huggingface/datasets-preview-backend/issues/144. This
means that
https://huggingface.co/datasets/huggingface/transformers-metadata is
assumed to fail at showing the dataset viewer, since the files are
concatenated by the `datasets` library, but they have a different set of
columns (or fields).