### PR TITLE
feat: 🎸 truncate cell contents instead of removing rows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,9 @@
 # Max number of rows in the /rows endpoint response
 # ROWS_MAX_NUMBER=100
 
+# Min number of rows in the /rows endpoint response
+# ROWS_MIN_NUMBER=10
+
 # Number of uvicorn workers
 # WEB_CONCURRENCY = 2
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,6 +28,7 @@ jobs:
         run: sudo docker run -d -p 27018:27017 mongo:latest
       - name: Run unit tests
         env:
+          ROWS_MIN_NUMBER: 2
           ROWS_MAX_NUMBER: 5
           MONGO_CACHE_DATABASE: datasets_preview_cache_test
           MONGO_QUEUE_DATABASE: datasets_preview_queue_test

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ watch:
 
 .PHONY: test
 test:
-	ROWS_MAX_NUMBER=5 MONGO_CACHE_DATABASE="datasets_preview_cache_test" MONGO_QUEUE_DATABASE="datasets_preview_queue_test" poetry run python -m pytest -x tests
+	ROWS_MIN_NUMBER=2 ROWS_MAX_NUMBER=5 MONGO_CACHE_DATABASE="datasets_preview_cache_test" MONGO_QUEUE_DATABASE="datasets_preview_queue_test" poetry run python -m pytest -x tests
 
 .PHONY: coverage
 coverage:
-	ROWS_MAX_NUMBER=5 MONGO_CACHE_DATABASE="datasets_preview_cache_test" MONGO_QUEUE_DATABASE="datasets_preview_queue_test" poetry run python -m pytest -s --cov --cov-report xml:coverage.xml --cov-report=term tests
+	ROWS_MIN_NUMBER=2 ROWS_MAX_NUMBER=5 MONGO_CACHE_DATABASE="datasets_preview_cache_test" MONGO_QUEUE_DATABASE="datasets_preview_queue_test" poetry run python -m pytest -s --cov --cov-report xml:coverage.xml --cov-report=term tests
 
 # Check that source code meets quality standards + security
 .PHONY: quality

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Set environment variables to configure the following aspects:
 - `MONGO_URL`: the URL used to connect to the mongo db server. Defaults to `"mongodb://localhost:27018"`.
 - `ROWS_MAX_BYTES`: max size of the /rows endpoint response in bytes. Defaults to `1_000_000` (1 MB).
 - `ROWS_MAX_NUMBER`: max number of rows in the /rows endpoint response. Defaults to `100`.
+- `ROWS_MIN_NUMBER`: min number of rows in the /rows endpoint response. Defaults to `10`.
 - `WEB_CONCURRENCY`: the number of workers. For now, it's ignored and hardcoded to 1 because the cache is not shared yet. Defaults to `2`.
 
 For example:
@@ -605,7 +606,7 @@ Parameters:
 
 Responses:
 
-- `200`: JSON content that provides the types of the columns (see features at https://huggingface.co/docs/datasets/about_dataset_features.html) and the data rows, with the following structure. Note that the features are ordered and this order can be used to display the columns in a table for example. Binary values are transmitted in UTF-8 encoded base64 strings. The number of rows depends on `ROWS_MAX_BYTES` and `ROWS_MAX_NUMBER`.
+- `200`: JSON content that provides the types of the columns (see features at https://huggingface.co/docs/datasets/about_dataset_features.html) and the data rows, with the following structure. Note that the features are ordered and this order can be used to display the columns in a table for example. Binary values are transmitted in UTF-8 encoded base64 strings. The number of rows depends on `ROWS_MAX_BYTES`, `ROWS_MIN_NUMBER` and `ROWS_MAX_NUMBER`. Note that the content of a cell might be truncated to fit within the limits, in which case the `truncated_cells` array will contain the name of the cell (see the last element in the example), and the cell content will always be a string.
 
   ```json
   {
@@ -654,7 +655,8 @@ Responses:
           "hypothesis": "The cat did not sit on the mat.",
           "label": -1,
           "idx": 0
-        }
+        },
+        "truncated_cells": []
       },
       {
         "dataset": "glue",
@@ -666,7 +668,8 @@ Responses:
           "hypothesis": "The cat sat on the mat.",
           "label": -1,
           "idx": 1
-        }
+        },
+        "truncated_cells": []
       },
       {
         "dataset": "glue",
@@ -674,11 +677,12 @@ Responses:
         "split": "test",
         "row_idx": 2,
         "row": {
-          "premise": "When you've got no snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.",
-          "hypothesis": "When you've got snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.",
+          "premise": "When you've got no snow, it's really hard to learn a snow sport so we lo",
+          "hypothesis": "When you've got snow, it's really hard to learn a snow sport so we looke",
           "label": -1,
           "idx": 2
-        }
+        },
+        "truncated_cells": ["premise", "hypothesis"]
       }
     ]
   }

--- a/src/datasets_preview_backend/config.py
+++ b/src/datasets_preview_backend/config.py
@@ -16,6 +16,7 @@ from datasets_preview_backend.constants import (
     DEFAULT_MONGO_URL,
     DEFAULT_ROWS_MAX_BYTES,
     DEFAULT_ROWS_MAX_NUMBER,
+    DEFAULT_ROWS_MIN_NUMBER,
     DEFAULT_WEB_CONCURRENCY,
 )
 from datasets_preview_backend.utils import (
@@ -43,6 +44,7 @@ MONGO_QUEUE_DATABASE = get_str_value(d=os.environ, key="MONGO_QUEUE_DATABASE", d
 MONGO_URL = get_str_value(d=os.environ, key="MONGO_URL", default=DEFAULT_MONGO_URL)
 ROWS_MAX_BYTES = get_int_value(d=os.environ, key="ROWS_MAX_BYTES", default=DEFAULT_ROWS_MAX_BYTES)
 ROWS_MAX_NUMBER = get_int_value(d=os.environ, key="ROWS_MAX_NUMBER", default=DEFAULT_ROWS_MAX_NUMBER)
+ROWS_MIN_NUMBER = get_int_value(d=os.environ, key="ROWS_MIN_NUMBER", default=DEFAULT_ROWS_MIN_NUMBER)
 WEB_CONCURRENCY = get_int_value(d=os.environ, key="WEB_CONCURRENCY", default=DEFAULT_WEB_CONCURRENCY)
 
 # Ensure datasets library uses the expected revision for canonical datasets

--- a/src/datasets_preview_backend/constants.py
+++ b/src/datasets_preview_backend/constants.py
@@ -13,6 +13,7 @@ DEFAULT_MONGO_QUEUE_DATABASE: str = "datasets_preview_queue"
 DEFAULT_MONGO_URL: str = "mongodb://localhost:27018"
 DEFAULT_ROWS_MAX_BYTES: int = 1_000_000
 DEFAULT_ROWS_MAX_NUMBER: int = 100
+DEFAULT_ROWS_MIN_NUMBER: int = 10
 DEFAULT_WEB_CONCURRENCY: int = 2
 
 DEFAULT_HF_TOKEN: Optional[str] = None
@@ -24,6 +25,9 @@ DEFAULT_WORKER_SLEEP_SECONDS: int = 5
 DEFAULT_WORKER_QUEUE: str = "datasets"
 
 DEFAULT_REFRESH_PCT: int = 1
+
+# below 100 bytes, the cell content will not be truncated
+DEFAULT_MIN_CELL_BYTES: int = 100
 
 # these datasets take too much time, we block them beforehand
 DATASETS_BLOCKLIST: List[str] = [

--- a/src/datasets_preview_backend/models/row.py
+++ b/src/datasets_preview_backend/models/row.py
@@ -31,11 +31,9 @@ def get_rows(
     elif not isinstance(dataset, Dataset):
         raise TypeError("load_dataset should return a Dataset")
     rows_plus_one = list(itertools.islice(dataset, ROWS_MAX_NUMBER + 1))
-    # ^^ to be able to detect if a split has exactly DEFAULT_ROWS_MAX_NUMBER rows
+    # ^^ to be able to detect if a split has exactly ROWS_MAX_NUMBER rows
     if len(rows_plus_one) <= ROWS_MAX_NUMBER:
         logger.debug(f"all the rows in the split have been fetched ({len(rows_plus_one)})")
     else:
         logger.debug(f"the rows in the split have been truncated ({ROWS_MAX_NUMBER} rows)")
     return rows_plus_one[:ROWS_MAX_NUMBER]
-    # ^^ note that DEFAULT_ROWS_MAX_BYTES is not enforced here, but in typed_row.py
-    # after the type of the fields is known (ie: the row can be converted to JSON)

--- a/src/datasets_preview_backend/routes/rows.py
+++ b/src/datasets_preview_backend/routes/rows.py
@@ -3,7 +3,11 @@ import logging
 from starlette.requests import Request
 from starlette.responses import Response
 
-from datasets_preview_backend.config import MAX_AGE_LONG_SECONDS, ROWS_MAX_BYTES
+from datasets_preview_backend.config import (
+    MAX_AGE_LONG_SECONDS,
+    ROWS_MAX_BYTES,
+    ROWS_MIN_NUMBER,
+)
 from datasets_preview_backend.exceptions import StatusError
 from datasets_preview_backend.io.cache import get_rows_response
 from datasets_preview_backend.routes._utils import get_response
@@ -21,7 +25,7 @@ async def rows_endpoint(request: Request) -> Response:
         if not isinstance(dataset_name, str) or not isinstance(config_name, str) or not isinstance(split_name, str):
             raise StatusError("Parameters 'dataset', 'config' and 'split' are required", 400)
         rows_response, rows_error, status_code = get_rows_response(
-            dataset_name, config_name, split_name, ROWS_MAX_BYTES
+            dataset_name, config_name, split_name, ROWS_MAX_BYTES, ROWS_MIN_NUMBER
         )
         return get_response(rows_response or rows_error, status_code, MAX_AGE_LONG_SECONDS)
     except StatusError as err:


### PR DESCRIPTION
Add a ROWS_MIN_NUMBER environment variable, which defines how many rows
should be returned as a minimum. If the size of these rows is greater
than the ROWS_MAX_BYTES limit, then the cells themselves are truncated
(transformed to strings, then truncated to 100 bytes which is an
hardcoded limit). In that case, the new field "truncated_cells" contain
the list of cells (column names) that are truncated.

BREAKING CHANGE: 🧨 The /rows response format has changed