### PR TITLE
fix: 🐛 fix nfs mount

### DIFF
--- a/infra/charts/datasets-server/env/prod.yaml
+++ b/infra/charts/datasets-server/env/prod.yaml
@@ -78,6 +78,9 @@ reverseProxy:
 api:
   replicas: 2
 
+  nodeSelector:
+    role-datasets-server: 'true'
+
   resources:
     requests:
       cpu: 1
@@ -87,6 +90,9 @@ api:
 datasetsWorker:
   replicas: 3
 
+  nodeSelector:
+    role-datasets-server: 'true'
+
   resources:
     requests:
       cpu: 0.01
@@ -95,6 +101,9 @@ datasetsWorker:
 
 splitsWorker:
   replicas: 12
+
+  nodeSelector:
+    role-datasets-server: 'true'
 
   resources:
     requests:


### PR DESCRIPTION
In production, the nodes must be selected with `role-datasets-server:
'true'` to have access to the NFS. Fixes #270