### PR TITLE
fix: 🐛 disable the metrics about cache and queue

### DIFF
--- a/services/api/src/api/prometheus.py
+++ b/services/api/src/api/prometheus.py
@@ -55,6 +55,7 @@ class Prometheus:
             self.metrics["cache_entries_total"].labels(cache="splits", status=status).set(total)
 
     def endpoint(self, request: Request) -> Response:
-        self.updateMetrics()
+        # disabled for now to fix https://github.com/huggingface/datasets-server/issues/279
+        # self.updateMetrics()
 
         return Response(generate_latest(self.getRegistry()), headers={"Content-Type": CONTENT_TYPE_LATEST})

--- a/services/api/tests/test_app.py
+++ b/services/api/tests/test_app.py
@@ -343,5 +343,6 @@ def test_metrics(client: TestClient) -> None:
     assert name in metrics
     assert metrics[name] > 0
     name = "process_start_time_seconds"
-    assert 'queue_jobs_total{queue="datasets",status="waiting"}' in metrics
-    assert 'cache_entries_total{cache="datasets",status="empty"}' in metrics
+    # Disabled for now
+    # assert 'queue_jobs_total{queue="datasets",status="waiting"}' in metrics
+    # assert 'cache_entries_total{cache="datasets",status="empty"}' in metrics


### PR DESCRIPTION
because it makes several queries to the database on every call to
/metrics (which is every second)