### PR TITLE
perf: ⚡️ reduce the number of workers

### DIFF
--- a/infra/charts/datasets-server/env/prod.yaml
+++ b/infra/charts/datasets-server/env/prod.yaml
@@ -19,7 +19,7 @@ monitoring:
 domain: "datasets-server.huggingface.tech"
 
 # Datasets blocklist
-datasetsBlocklist: "bigscience/P3,echarlaix/gqa-lxmert,Graphcore/gqa-lxmert,Graphcore/vqa-lxmert,echarlaix/vqa-lxmert,LIUM/tedlium,Shitao/MSMARCOForLibVQ,imthanhlv/binhvq_news21_raw,abdusahmbzuai/masc_dev"
+datasetsBlocklist: "bigscience/P3,echarlaix/gqa-lxmert,Graphcore/gqa-lxmert,Graphcore/vqa-lxmert,echarlaix/vqa-lxmert,LIUM/tedlium,Shitao/MSMARCOForLibVQ,imthanhlv/binhvq_news21_raw,abdusahmbzuai/masc_dev,MLCommons/peoples_speech"
 
 reverseProxy:
   replicas: 2
@@ -59,7 +59,7 @@ reverseProxy:
       memory: "256Mi"
 
 api:
-  replicas: 2
+  replicas: 1
 
   nodeSelector:
     role-datasets-server: 'true'
@@ -87,7 +87,7 @@ datasetsWorker:
 
 
 splitsWorker:
-  replicas: 10
+  replicas: 4
 
   nodeSelector:
     role-datasets-server: 'true'
@@ -101,6 +101,8 @@ splitsWorker:
 
   # Log level
   logLevel: "DEBUG"
+  # Maximum number of jobs running at the same time for the same dataset
+  maxJobsPerDataset: 2
 
 admin:
   replicas: 1


### PR DESCRIPTION
also: use only one API pod (seems like the other one is never called...
to investigate).

Note: the healthcheck was timeouting (the reverse proxy replied, but the
api was not responding quickly enough). See
https://betteruptime.com/team/14149/incidents/229868663.