### PR TITLE
ci: 🎡 use cache (gha) when building the docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,5 +49,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # see https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=buildkit-${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=buildkit-${{ matrix.service }}


### PR DESCRIPTION
Hopefully it will fit in the 10GB.

See
https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
and https://github.com/moby/buildkit/tree/master#github-actions-cache-experimental