### PR TITLE
feat: 🎸 update the docker image for api

### DIFF
--- a/infra/charts/datasets-server/templates/admin/_container.tpl
+++ b/infra/charts/datasets-server/templates/admin/_container.tpl
@@ -19,7 +19,7 @@
         key: MONGO_URL
         optional: false
   {{- end }}
-  image: "{{ .Values.admin.image.repository }}/{{ .Values.admin.image.name }}:{{ .Values.docker.tag }}"
+  image: "{{ .Values.admin.image.repository }}/{{ .Values.admin.image.name }}:{{ .Values.admin.image.tag }}"
   imagePullPolicy: {{ .Values.admin.image.pullPolicy }}
   volumeMounts:
   - mountPath: {{ .Values.admin.assetsDirectory | quote }}

--- a/infra/charts/datasets-server/templates/api/_container.tpl
+++ b/infra/charts/datasets-server/templates/api/_container.tpl
@@ -29,7 +29,7 @@
         key: MONGO_URL
         optional: false
   {{- end }}
-  image: "{{ .Values.api.image.repository }}/{{ .Values.api.image.name }}:{{ .Values.docker.tag }}"
+  image: "{{ .Values.api.image.repository }}/{{ .Values.api.image.name }}:{{ .Values.api.image.tag }}"
   imagePullPolicy: {{ .Values.api.image.pullPolicy }}
   volumeMounts:
   - mountPath: {{ .Values.api.assetsDirectory | quote }}

--- a/infra/charts/datasets-server/templates/datasets-worker/_container.tpl
+++ b/infra/charts/datasets-server/templates/datasets-worker/_container.tpl
@@ -56,7 +56,7 @@
   - name: WORKER_QUEUE
     # Job queue the worker will pull jobs from: 'datasets' or 'splits'
     value: "datasets"
-  image: "{{ .Values.datasetsWorker.image.repository }}/{{ .Values.datasetsWorker.image.name }}:{{ .Values.docker.tag }}"
+  image: "{{ .Values.datasetsWorker.image.repository }}/{{ .Values.datasetsWorker.image.name }}:{{ .Values.datasetsWorker.image.tag }}"
   imagePullPolicy: {{ .Values.datasetsWorker.image.pullPolicy }}
   volumeMounts:
   - mountPath: {{ .Values.datasetsWorker.assetsDirectory | quote }}

--- a/infra/charts/datasets-server/templates/splits-worker/_container.tpl
+++ b/infra/charts/datasets-server/templates/splits-worker/_container.tpl
@@ -56,7 +56,7 @@
   - name: WORKER_QUEUE
     # Job queue the worker will pull jobs from: 'datasets' or 'splits'
     value: "splits"
-  image: "{{ .Values.splitsWorker.image.repository }}/{{ .Values.splitsWorker.image.name }}:{{ .Values.docker.tag }}"
+  image: "{{ .Values.splitsWorker.image.repository }}/{{ .Values.splitsWorker.image.name }}:{{ .Values.splitsWorker.image.tag }}"
   imagePullPolicy: {{ .Values.splitsWorker.image.pullPolicy }}
   volumeMounts:
   - mountPath: {{ .Values.splitsWorker.assetsDirectory | quote }}

--- a/infra/charts/datasets-server/values.yaml
+++ b/infra/charts/datasets-server/values.yaml
@@ -27,9 +27,6 @@ gid: 3000
 # Datasets blocklist
 datasetsBlocklist: ""
 
-docker:
-  tag: sha-da86243
-
 reverseProxy:
   image:
     repository: docker.io
@@ -70,6 +67,7 @@ api:
   image:
     repository: 707930574880.dkr.ecr.us-east-1.amazonaws.com
     name: hub-datasets-server-api
+    tag: sha-ab6473e
     pullPolicy: IfNotPresent
 
   replicas: 1
@@ -110,6 +108,7 @@ datasetsWorker:
   image:
     repository: 707930574880.dkr.ecr.us-east-1.amazonaws.com
     name: hub-datasets-server-worker
+    tag: sha-da86243
     pullPolicy: IfNotPresent
 
   replicas: 1
@@ -155,6 +154,7 @@ splitsWorker:
   image:
     repository: 707930574880.dkr.ecr.us-east-1.amazonaws.com
     name: hub-datasets-server-worker
+    tag: sha-da86243
     pullPolicy: IfNotPresent
   replicas: 1
   
@@ -198,6 +198,7 @@ admin:
   image:
     repository: 707930574880.dkr.ecr.us-east-1.amazonaws.com
     name: hub-datasets-server-admin
+    tag: sha-da86243
     pullPolicy: IfNotPresent
 
   replicas: 1


### PR DESCRIPTION
also: allow the deployments to use different docker image tags, so that
the workers are not redeployed if only the api has changed, for example.