### PR TITLE
fix: 🐛 give every servicemonitor its name

### DIFF
--- a/infra/charts/datasets-server/templates/admin/servicemonitor.yaml
+++ b/infra/charts/datasets-server/templates/admin/servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     {{ include "labels.admin" . | nindent 4 }}
-  name: {{ include "release" . }}
+  name: "{{ include "release" . }}-admin"
   namespace: {{ .Release.Namespace }}
 spec:
   endpoints:

--- a/infra/charts/datasets-server/templates/api/servicemonitor.yaml
+++ b/infra/charts/datasets-server/templates/api/servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     {{ include "labels.api" . | nindent 4 }}
-  name: {{ include "release" . }}
+  name: "{{ include "release" . }}-api"
   namespace: {{ .Release.Namespace }}
 spec:
   endpoints:


### PR DESCRIPTION
they both had the same name. Seen with "kubectl get servicemonitor"