### PR TITLE
fix: 🐛 use a new name for the numba cache preparation

### DIFF
--- a/infra/charts/datasets-server/templates/_initContainerNumbaCache.tpl
+++ b/infra/charts/datasets-server/templates/_initContainerNumbaCache.tpl
@@ -1,5 +1,5 @@
 {{- define "initContainerNumbaCache" -}}
-- name: prepare-cache
+- name: prepare-numba-cache
   image: ubuntu:focal
   imagePullPolicy: IfNotPresent
   command: ["/bin/sh", "-c"]


### PR DESCRIPTION
it was ignored since it had the same name as for the datasets cache