### PR TITLE
fix: 🐛 add cpu for the first-rows worker

### DIFF
--- a/infra/charts/datasets-server/env/prod.yaml
+++ b/infra/charts/datasets-server/env/prod.yaml
@@ -145,7 +145,7 @@ worker:
         cpu: 1
         memory: "8Gi"
       limits:
-        cpu: 1
+        cpu: 2
         memory: "30Gi"
 
     # Log level


### PR DESCRIPTION
we had a lot of alerts "CPUThrottlingHigh", eg "43.1% throttling of
CPU".