### PR TITLE
feat: 🎸 fix the servicemonitor url

### DIFF
--- a/infra/charts/datasets-server/templates/admin/servicemonitor.yaml
+++ b/infra/charts/datasets-server/templates/admin/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   endpoints:
-    - path: /admin/metrics
+    - path: /metrics
       port: http
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
it must be relative to the service (ie/ /metrics), not the public URL
(/admin/metrics).