### PR TITLE
ci: 🎡 separate docker workflows

### DIFF
--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -50,5 +50,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # see https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
-          cache-from: type=gha,scope=buildkit-${{ inputs.service }}
-          cache-to: type=gha,mode=max,scope=buildkit-${{ inputs.service }}
+          # cache-from: type=gha,scope=buildkit-${{ inputs.service }}
+          # cache-to: type=gha,mode=max,scope=buildkit-${{ inputs.service }}

--- a/.github/workflows/s-admin-build.yml
+++ b/.github/workflows/s-admin-build.yml
@@ -1,0 +1,19 @@
+name: services/admin
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'services/admin/Dockerfile'
+      - 'services/admin/src'
+      - 'services/admin/poetry.lock'
+      - 'services/admin/pyproject.toml'
+      - '.github/workflows/s-admin-build.yml'
+      - '.github/workflows/_docker.yml'
+jobs:
+  docker:
+    uses: ./.github/workflows/_docker.yml
+    with:
+      service: admin
+    secrets:
+      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/s-admin.yml
+++ b/.github/workflows/s-admin.yml
@@ -7,7 +7,6 @@ on:
       - '.github/workflows/s-admin.yml'
       - '.github/workflows/_quality-python.yml'
       - '.github/workflows/_unit-tests-python.yml'
-      - '.github/workflows/_docker.yml'
       - 'tools/Python.mk'
       - 'tools/docker-compose-mongo.yml'
 jobs:
@@ -21,10 +20,3 @@ jobs:
       working-directory: services/admin
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
-  docker:
-    uses: ./.github/workflows/_docker.yml
-    with:
-      service: admin
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/s-api-build.yml
+++ b/.github/workflows/s-api-build.yml
@@ -1,0 +1,19 @@
+name: services/api
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'services/api/Dockerfile'
+      - 'services/api/src'
+      - 'services/api/poetry.lock'
+      - 'services/api/pyproject.toml'
+      - '.github/workflows/s-api-build.yml'
+      - '.github/workflows/_docker.yml'
+jobs:
+  docker:
+    uses: ./.github/workflows/_docker.yml
+    with:
+      service: api
+    secrets:
+      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/s-api.yml
+++ b/.github/workflows/s-api.yml
@@ -7,7 +7,6 @@ on:
       - '.github/workflows/s-api.yml'
       - '.github/workflows/_quality-python.yml'
       - '.github/workflows/_unit-tests-python.yml'
-      - '.github/workflows/_docker.yml'
       - 'tools/Python.mk'
       - 'tools/docker-compose-mongo.yml'
 jobs:
@@ -21,10 +20,3 @@ jobs:
       working-directory: services/api
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
-  docker:
-    uses: ./.github/workflows/_docker.yml
-    with:
-      service: api
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/s-worker-build.yml
+++ b/.github/workflows/s-worker-build.yml
@@ -1,0 +1,19 @@
+name: services/worker
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'services/worker/Dockerfile'
+      - 'services/worker/src'
+      - 'services/worker/poetry.lock'
+      - 'services/worker/pyproject.toml'
+      - '.github/workflows/s-worker-build.yml'
+      - '.github/workflows/_docker.yml'
+jobs:
+  docker:
+    uses: ./.github/workflows/_docker.yml
+    with:
+      service: worker
+    secrets:
+      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/s-worker.yml
+++ b/.github/workflows/s-worker.yml
@@ -7,9 +7,9 @@ on:
       - '.github/workflows/s-worker.yml'
       - '.github/workflows/_quality-python.yml'
       - '.github/workflows/_unit-tests-python.yml'
-      - '.github/workflows/_docker.yml'
       - 'tools/Python.mk'
       - 'tools/docker-compose-mongo.yml'
+      - 'vendors/'
 jobs:
   quality:
     uses: ./.github/workflows/_quality-python.yml
@@ -26,10 +26,3 @@ jobs:
     secrets:
       hf-token: ${{ secrets.HF_TOKEN }}
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
-  docker:
-    uses: ./.github/workflows/_docker.yml
-    with:
-      service: worker
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
to build the images only when needed. Also, remove the cache, since it
seems counter-productive.