### PR TITLE
fix: 🐛 restore the check on the webhook payload

### DIFF
--- a/chart/docker-images.yaml
+++ b/chart/docker-images.yaml
@@ -1,7 +1,7 @@
 {
   "dockerImage": {
     "admin": "707930574880.dkr.ecr.us-east-1.amazonaws.com/hub-datasets-server-admin:sha-49a60c5",
-    "api": "707930574880.dkr.ecr.us-east-1.amazonaws.com/hub-datasets-server-api:sha-8d9e37d",
+    "api": "707930574880.dkr.ecr.us-east-1.amazonaws.com/hub-datasets-server-api:sha-5d183a4",
     "reverseProxy": "docker.io/nginx:1.20",
     "worker": {
       "splits": "707930574880.dkr.ecr.us-east-1.amazonaws.com/hub-datasets-server-worker:sha-0dff3bf",

--- a/services/api/src/api/routes/webhook.py
+++ b/services/api/src/api/routes/webhook.py
@@ -39,11 +39,9 @@ def get_dataset_name(id: Optional[str]) -> Optional[str]:
     if id is None:
         return None
     dataset_name = id.removeprefix("datasets/")
-    # temporarily disabled to fix a bug with the webhook
-    # (see https://github.com/huggingface/datasets-server/issues/380#issuecomment-1254670923)
-    # if id == dataset_name:
-    #     logger.info(f"ignored because a full dataset id must starts with 'datasets/': {id}")
-    #     return None
+    if id == dataset_name:
+        logger.info(f"ignored because a full dataset id must starts with 'datasets/': {id}")
+        return None
     return dataset_name if is_non_empty_string(dataset_name) else None
 
 


### PR DESCRIPTION
The upstream issue has been fixed on the Hub. It's important to restore the test, because it avoids collision between datasets and models (models don't have a prefix in the webhook v1).