### PR TITLE
fix: 🐛 fix the dependencies for macos m1/m2 (#593)

### DIFF
--- a/.github/workflows/_build_push_docker_aws.yml
+++ b/.github/workflows/_build_push_docker_aws.yml
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
 
-name: Build and push service docker image
-on: 
+name: Build and push service docker image to private AWS ECR
+on:
   workflow_call:
     inputs:
       service:

--- a/.github/workflows/_build_push_docker_hub.yml
+++ b/.github/workflows/_build_push_docker_hub.yml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+name: Build and push service docker image to public Docker Hub
+on:
+  workflow_call:
+    inputs:
+      service:
+        required: true
+        type: string
+    secrets:
+      dockerhub-username:
+        required: true
+      dockerhub-password:
+        required: true
+env:
+  repository-prefix: huggingface/datasets-server-
+jobs:
+  build-and-push-image:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Set outputs
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.dockerhub-username }}
+          password: ${{ secrets.dockerhub-password }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.repository-prefix }}${{ inputs.service }}
+          tags: |
+            type=raw,value=sha-${{ steps.vars.outputs.sha_short }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: services/${{ inputs.service }}/Dockerfile
+          build-args: COMMIT=${{ steps.vars.outputs.sha_short }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # see https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
+          # cache-from: type=gha,scope=buildkit-${{ inputs.service }}
+          # cache-to: type=gha,mode=max,scope=buildkit-${{ inputs.service }}

--- a/.github/workflows/s-admin-build-aws.yml
+++ b/.github/workflows/s-admin-build-aws.yml
@@ -10,11 +10,11 @@ on:
       - 'services/admin/src/**'
       - 'services/admin/poetry.lock'
       - 'services/admin/pyproject.toml'
-      - '.github/workflows/s-admin-build.yml'
-      - '.github/workflows/_docker.yml'
+      - '.github/workflows/s-admin-build-aws.yml'
+      - '.github/workflows/_build_push_docker_aws.yml'
 jobs:
   docker:
-    uses: ./.github/workflows/_docker.yml
+    uses: ./.github/workflows/_build_push_docker_aws.yml
     with:
       service: admin
     secrets:

--- a/.github/workflows/s-admin-build-docker.yml
+++ b/.github/workflows/s-admin-build-docker.yml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+name: services/admin
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'services/admin/Dockerfile'
+      - 'services/admin/src/**'
+      - 'services/admin/poetry.lock'
+      - 'services/admin/pyproject.toml'
+      - '.github/workflows/s-admin-build-docker.yml'
+      - '.github/workflows/_build_push_docker_hub.yml'
+jobs:
+  docker:
+    uses: ./.github/workflows/_build_push_docker_hub.yml
+    with:
+      service: admin
+    secrets:
+      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/s-api-build-aws.yml
+++ b/.github/workflows/s-api-build-aws.yml
@@ -10,11 +10,11 @@ on:
       - 'services/api/src/**'
       - 'services/api/poetry.lock'
       - 'services/api/pyproject.toml'
-      - '.github/workflows/s-api-build.yml'
-      - '.github/workflows/_docker.yml'
+      - '.github/workflows/s-api-build-aws.yml'
+      - '.github/workflows/_build_push_docker_aws.yml'
 jobs:
   docker:
-    uses: ./.github/workflows/_docker.yml
+    uses: ./.github/workflows/_build_push_docker_aws.yml
     with:
       service: api
     secrets:

--- a/.github/workflows/s-api-build-docker.yml
+++ b/.github/workflows/s-api-build-docker.yml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+name: services/api
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'services/api/Dockerfile'
+      - 'services/api/src/**'
+      - 'services/api/poetry.lock'
+      - 'services/api/pyproject.toml'
+      - '.github/workflows/s-api-build-docker.yml'
+      - '.github/workflows/_build_push_docker_hub.yml'
+jobs:
+  docker:
+    uses: ./.github/workflows/_build_push_docker_hub.yml
+    with:
+      service: api
+    secrets:
+      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/s-worker-build-aws.yml
+++ b/.github/workflows/s-worker-build-aws.yml
@@ -10,11 +10,11 @@ on:
       - 'services/worker/src/**'
       - 'services/worker/poetry.lock'
       - 'services/worker/pyproject.toml'
-      - '.github/workflows/s-worker-build.yml'
-      - '.github/workflows/_docker.yml'
+      - '.github/workflows/s-worker-build-aws.yml'
+      - '.github/workflows/_build_push_docker_aws.yml'
 jobs:
   docker:
-    uses: ./.github/workflows/_docker.yml
+    uses: ./.github/workflows/_build_push_docker_aws.yml
     with:
       service: worker
     secrets:

--- a/.github/workflows/s-worker-build-docker.yml
+++ b/.github/workflows/s-worker-build-docker.yml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+name: services/worker
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'services/worker/Dockerfile'
+      - 'services/worker/src/**'
+      - 'services/worker/poetry.lock'
+      - 'services/worker/pyproject.toml'
+      - '.github/workflows/s-worker-build-aws.yml'
+      - '.github/workflows/_build_push_docker_hub.yml'
+jobs:
+  docker:
+    uses: ./.github/workflows/_build_push_docker_hub.yml
+    with:
+      service: worker
+    secrets:
+      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/services/worker/poetry.lock
+++ b/services/worker/poetry.lock
@@ -372,13 +372,13 @@ xxhash = "*"
 apache-beam = ["apache-beam (>=2.26.0)"]
 audio = ["librosa"]
 benchmarks = ["numpy (==1.18.5)", "tensorflow (==2.3.0)", "torch (==1.7.1)", "transformers (==3.0.2)"]
-dev = ["absl-py", "pytest", "pytest-datadir", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch (<8.0.0)", "aiobotocore (>=2.0.1)", "boto3 (>=1.19.8)", "botocore (>=1.22.8)", "faiss-cpu (>=1.6.4)", "fsspec", "lz4", "moto[server,s3] (==2.0.4)", "rarfile (>=4.0)", "s3fs (>=2021.11.1)", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "torch", "torchaudio (<0.12.0)", "soundfile", "transformers", "bs4", "conllu", "h5py", "lxml", "mwparserfromhell", "openpyxl", "py7zr", "zstandard", "sentencepiece", "rouge-score", "sacremoses", "bert-score (>=0.3.6)", "jiwer", "langdetect", "mauve-text", "nltk", "sacrebleu", "scikit-learn", "scipy", "seqeval", "tldextract", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "six (>=1.15.0,<1.16.0)", "Pillow (>=6.2.1)", "librosa", "black (>=22.0,<23.0)", "flake8 (>=3.8.3)", "isort (>=5.0.0)", "pyyaml (>=5.3.1)"]
+dev = ["absl-py", "pytest", "pytest-datadir", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch (<8.0.0)", "aiobotocore (>=2.0.1)", "boto3 (>=1.19.8)", "botocore (>=1.22.8)", "faiss-cpu (>=1.6.4)", "fsspec", "lz4", "moto[s3,server] (==2.0.4)", "rarfile (>=4.0)", "s3fs (>=2021.11.1)", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "torch", "torchaudio (<0.12.0)", "soundfile", "transformers", "bs4", "conllu", "h5py", "lxml", "mwparserfromhell", "openpyxl", "py7zr", "zstandard", "sentencepiece", "rouge-score", "sacremoses", "bert-score (>=0.3.6)", "jiwer", "langdetect", "mauve-text", "nltk", "sacrebleu", "scikit-learn", "scipy", "seqeval", "tldextract", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "six (>=1.15.0,<1.16.0)", "Pillow (>=6.2.1)", "librosa", "black (>=22.0,<23.0)", "flake8 (>=3.8.3)", "isort (>=5.0.0)", "pyyaml (>=5.3.1)"]
 docs = ["s3fs"]
 quality = ["black (>=22.0,<23.0)", "flake8 (>=3.8.3)", "isort (>=5.0.0)", "pyyaml (>=5.3.1)"]
 s3 = ["fsspec", "boto3", "botocore", "s3fs"]
 tensorflow = ["tensorflow (>=2.2.0,!=2.6.0,!=2.6.1)"]
 tensorflow_gpu = ["tensorflow-gpu (>=2.2.0,!=2.6.0,!=2.6.1)"]
-tests = ["absl-py", "pytest", "pytest-datadir", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch (<8.0.0)", "aiobotocore (>=2.0.1)", "boto3 (>=1.19.8)", "botocore (>=1.22.8)", "faiss-cpu (>=1.6.4)", "fsspec", "lz4", "moto[server,s3] (==2.0.4)", "rarfile (>=4.0)", "s3fs (>=2021.11.1)", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "torch", "torchaudio (<0.12.0)", "soundfile", "transformers", "bs4", "conllu", "h5py", "lxml", "mwparserfromhell", "openpyxl", "py7zr", "zstandard", "sentencepiece", "rouge-score", "sacremoses", "bert-score (>=0.3.6)", "jiwer", "langdetect", "mauve-text", "nltk", "sacrebleu", "scikit-learn", "scipy", "seqeval", "tldextract", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "six (>=1.15.0,<1.16.0)", "Pillow (>=6.2.1)", "librosa"]
+tests = ["absl-py", "pytest", "pytest-datadir", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch (<8.0.0)", "aiobotocore (>=2.0.1)", "boto3 (>=1.19.8)", "botocore (>=1.22.8)", "faiss-cpu (>=1.6.4)", "fsspec", "lz4", "moto[s3,server] (==2.0.4)", "rarfile (>=4.0)", "s3fs (>=2021.11.1)", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "torch", "torchaudio (<0.12.0)", "soundfile", "transformers", "bs4", "conllu", "h5py", "lxml", "mwparserfromhell", "openpyxl", "py7zr", "zstandard", "sentencepiece", "rouge-score", "sacremoses", "bert-score (>=0.3.6)", "jiwer", "langdetect", "mauve-text", "nltk", "sacrebleu", "scikit-learn", "scipy", "seqeval", "tldextract", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "six (>=1.15.0,<1.16.0)", "Pillow (>=6.2.1)", "librosa"]
 torch = ["torch"]
 vision = ["Pillow (>=6.2.1)"]
 
@@ -423,7 +423,7 @@ python-versions = "*"
 
 [[package]]
 name = "dparse"
-version = "0.5.1"
+version = "0.6.2"
 description = "A parser for Python dependency files"
 category = "dev"
 optional = false
@@ -431,11 +431,11 @@ python-versions = ">=3.5"
 
 [package.dependencies]
 packaging = "*"
-pyyaml = "*"
 toml = "*"
 
 [package.extras]
 pipenv = ["pipenv"]
+conda = ["pyyaml"]
 
 [[package]]
 name = "et-xmlfile"
@@ -1670,7 +1670,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "safety"
-version = "2.1.1"
+version = "2.2.0"
 description = "Checks installed dependencies for known vulnerabilities and licenses."
 category = "dev"
 optional = false
@@ -1678,7 +1678,7 @@ python-versions = "*"
 
 [package.dependencies]
 Click = ">=8.0.2"
-dparse = ">=0.5.1"
+dparse = ">=0.6.2"
 packaging = ">=21.0"
 requests = "*"
 "ruamel.yaml" = ">=0.17.21"
@@ -1886,6 +1886,36 @@ tensorflow-aarch64 = ["tensorflow-aarch64 (>=2.9.0,<2.10.0)"]
 tensorflow-cpu = ["tensorflow-cpu (>=2.9.0,<2.10.0)"]
 tensorflow-gpu = ["tensorflow-gpu (>=2.9.0,<2.10.0)"]
 tensorflow-rocm = ["tensorflow-rocm (>=2.9.0,<2.10.0)"]
+
+[[package]]
+name = "tensorflow-macos"
+version = "2.9.2"
+description = "TensorFlow is an open source machine learning framework for everyone."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+absl-py = ">=1.0.0"
+astunparse = ">=1.6.0"
+flatbuffers = ">=1.12,<2"
+gast = ">=0.2.1,<=0.4.0"
+google-pasta = ">=0.1.1"
+grpcio = ">=1.24.3,<2.0"
+h5py = ">=2.9.0"
+keras = ">=2.9.0rc0,<2.10.0"
+keras-preprocessing = ">=1.1.1"
+libclang = ">=13.0.0"
+numpy = ">=1.20"
+opt-einsum = ">=2.3.2"
+packaging = "*"
+protobuf = ">=3.9.2,<3.20"
+six = ">=1.12.0"
+tensorboard = ">=2.9,<2.10"
+tensorflow-estimator = ">=2.9.0rc0,<2.10.0"
+termcolor = ">=1.1.0"
+typing-extensions = ">=3.6.6"
+wrapt = ">=1.11.0"
 
 [[package]]
 name = "termcolor"
@@ -2233,7 +2263,7 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "3.9.6"
-content-hash = "2d4aa333d0c236b3aa7bf34ea10e17e146989aa8265d5e53620959d784f3d17e"
+content-hash = "bbd3ac405cd06f7d0767acad3716132d0b7d212671e1f6b2ac90c9625380510e"
 
 [metadata.files]
 absl-py = [
@@ -2720,10 +2750,7 @@ dnspython = [
 docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
 ]
-dparse = [
-    {file = "dparse-0.5.1-py3-none-any.whl", hash = "sha256:e953a25e44ebb60a5c6efc2add4420c177f1d8404509da88da9729202f306994"},
-    {file = "dparse-0.5.1.tar.gz", hash = "sha256:a1b5f169102e1c894f9a7d5ccf6f9402a836a5d24be80a986c7ce9eaed78f367"},
-]
+dparse = []
 et-xmlfile = [
     {file = "et_xmlfile-1.1.0-py3-none-any.whl", hash = "sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada"},
     {file = "et_xmlfile-1.1.0.tar.gz", hash = "sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c"},
@@ -4056,6 +4083,7 @@ tensorflow-io-gcs-filesystem = [
     {file = "tensorflow_io_gcs_filesystem-0.26.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd285595afe03740553710ccdbd1397d69a8e48d758c731c0de1f1c5a71a9fe5"},
     {file = "tensorflow_io_gcs_filesystem-0.26.0-cp39-cp39-win_amd64.whl", hash = "sha256:2940b4ab6848ef5ec34dc3c140b5ae9eba0da13453da839c30ebe3461a6eb51d"},
 ]
+tensorflow-macos = []
 termcolor = [
     {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
 ]

--- a/services/worker/pyproject.toml
+++ b/services/worker/pyproject.toml
@@ -31,7 +31,8 @@ python = "3.9.6"
 rarfile = "^4.0"
 requests = "^2.27.1"
 sklearn = "^0.0"
-tensorflow = "^2.9.0"
+tensorflow = {version = "^2.9.0", platform = "linux || win32"}
+tensorflow-macos = {version = "^2.9.0", platform = "darwin"}
 tfrecord = "^1.14.1"
 torchaudio = "^0.10.1"
 transformers = "^4.11.3"


### PR DESCRIPTION
* fix: 🐛 fix the dependencies for macos m1/m2

Tensorflow does not support macos m1/m2 architectures, thus for these platforms we opt for installing tensorflow-mac instead, which is maintained by Apple. Note that it supports Macos intel too.

* chore: 🤖 update safety to fix vulnerability with dparse

funny that the vulnerability scanner was the one that introduced a vulnerability