### PR TITLE
feat: 🎸 change the format of the image cells in /first-rows

### DIFF
--- a/chart/docker-images.yaml
+++ b/chart/docker-images.yaml
@@ -4,8 +4,8 @@
     "api": "huggingface/datasets-server-api:sha-92a9c8c",
     "reverseProxy": "docker.io/nginx:1.20",
     "worker": {
-      "splits": "huggingface/datasets-server-worker:sha-92a9c8c",
-      "firstRows": "huggingface/datasets-server-worker:sha-92a9c8c"
+      "splits": "huggingface/datasets-server-worker:sha-794e2d4",
+      "firstRows": "huggingface/datasets-server-worker:sha-794e2d4"
     }
   }
 }

--- a/chart/static-files/openapi.json
+++ b/chart/static-files/openapi.json
@@ -778,8 +778,22 @@
         }
       },
       "ImageCell": {
-        "type": "string",
-        "format": "uri"
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "src": {
+              "type": "string",
+              "format": "uri"
+            },
+            "height": {
+              "type": "integer"
+            },
+            "width": {
+              "type": "integer"
+            }
+          }
+        }
       },
       "ValidResponse": {
         "type": "object",
@@ -1451,32 +1465,64 @@
                         {
                           "row_idx": 0,
                           "row": {
-                            "imageA": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/0/imageA/image.jpg",
-                            "imageB": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/0/imageB/image.jpg"
+                            "imageA": {
+                              "url": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/0/imageA/image.jpg",
+                              "height": 256,
+                              "width": 256
+                            },
+                            "imageB": {
+                              "url": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/0/imageB/image.jpg",
+                              "height": 256,
+                              "width": 256
+                            }
                           },
                           "truncated_cells": []
                         },
                         {
                           "row_idx": 1,
                           "row": {
-                            "imageA": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/1/imageA/image.jpg",
-                            "imageB": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/1/imageB/image.jpg"
+                            "imageA": {
+                              "url": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/1/imageA/image.jpg",
+                              "height": 256,
+                              "width": 256
+                            },
+                            "imageB": {
+                              "url": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/1/imageB/image.jpg",
+                              "height": 256,
+                              "width": 256
+                            }
                           },
                           "truncated_cells": []
                         },
                         {
                           "row_idx": 2,
                           "row": {
-                            "imageA": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/2/imageA/image.jpg",
-                            "imageB": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/2/imageB/image.jpg"
+                            "imageA": {
+                              "url": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/2/imageA/image.jpg",
+                              "height": 256,
+                              "width": 256
+                            },
+                            "imageB": {
+                              "url": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/2/imageB/image.jpg",
+                              "height": 256,
+                              "width": 256
+                            }
                           },
                           "truncated_cells": []
                         },
                         {
                           "row_idx": 3,
                           "row": {
-                            "imageA": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/3/imageA/image.jpg",
-                            "imageB": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/3/imageB/image.jpg"
+                            "imageA": {
+                              "url": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/3/imageA/image.jpg",
+                              "height": 256,
+                              "width": 256
+                            },
+                            "imageB": {
+                              "url": "https://datasets-server.huggingface.co/assets/huggan/horse2zebra/--/huggan--horse2zebra-aligned/train/3/imageB/image.jpg",
+                              "height": 256,
+                              "width": 256
+                            }
                           },
                           "truncated_cells": []
                         }

--- a/services/worker/src/worker/asset.py
+++ b/services/worker/src/worker/asset.py
@@ -28,6 +28,12 @@ def create_asset_dir(dataset: str, config: str, split: str, row_idx: int, column
     return dir_path, url_dir_path
 
 
+class ImageSource(TypedDict):
+    src: str
+    height: int
+    width: int
+
+
 def create_image_file(
     dataset: str,
     config: str,
@@ -37,11 +43,15 @@ def create_image_file(
     filename: str,
     image: Image.Image,
     assets_base_url: str,
-) -> str:
+) -> ImageSource:
     dir_path, url_dir_path = create_asset_dir(dataset, config, split, row_idx, column)
     file_path = dir_path / filename
     image.save(file_path)
-    return f"{assets_base_url}/{url_dir_path}/{filename}"
+    return {
+        "src": f"{assets_base_url}/{url_dir_path}/{filename}",
+        "height": image.height,
+        "width": image.width,
+    }
 
 
 class AudioSource(TypedDict):

--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -347,7 +347,11 @@ def get_IMAGE_rows(dataset: str):
     dataset, config, split = get_default_config_split(dataset)
     return [
         {
-            "col": f"http://localhost/assets/{dataset}/--/{config}/{split}/0/col/image.jpg",
+            "col": {
+                "src": f"http://localhost/assets/{dataset}/--/{config}/{split}/0/col/image.jpg",
+                "height": 480,
+                "width": 640,
+            },
         }
     ]
 
@@ -368,8 +372,16 @@ def get_IMAGES_LIST_rows(dataset: str):
     return [
         {
             "col": [
-                f"http://localhost/assets/{dataset}/--/{config}/{split}/0/col/image-1d100e9.jpg",
-                f"http://localhost/assets/{dataset}/--/{config}/{split}/0/col/image-1d300ea.jpg",
+                {
+                    "src": f"http://localhost/assets/{dataset}/--/{config}/{split}/0/col/image-1d100e9.jpg",
+                    "height": 480,
+                    "width": 640,
+                },
+                {
+                    "src": f"http://localhost/assets/{dataset}/--/{config}/{split}/0/col/image-1d300ea.jpg",
+                    "height": 480,
+                    "width": 640,
+                },
             ]
         }
     ]

--- a/services/worker/tests/test_features.py
+++ b/services/worker/tests/test_features.py
@@ -128,7 +128,15 @@ def test_value(dataset_type, output_value, output_dtype, datasets) -> None:
         # - an :class:`Image` feature to store the absolute path to an image file, an :obj:`np.ndarray` object, a
         #   :obj:`PIL.Image.Image` object or a dictionary with the relative path to an image file ("path" key) and
         #   its bytes content ("bytes" key). This feature extracts the image data.
-        ("image", "http://localhost/assets/dataset/--/config/split/7/col/image.jpg", "Image"),
+        (
+            "image",
+            {
+                "src": "http://localhost/assets/dataset/--/config/split/7/col/image.jpg",
+                "height": 480,
+                "width": 640,
+            },
+            "Image",
+        ),
         # - :class:`datasets.Translation` and :class:`datasets.TranslationVariableLanguages`, the two features
         #   specific to Machine Translation
         ("translation", {"en": "the cat", "fr": "le chat"}, "Translation"),
@@ -141,8 +149,16 @@ def test_value(dataset_type, output_value, output_dtype, datasets) -> None:
         (
             "images_list",
             [
-                "http://localhost/assets/dataset/--/config/split/7/col/image-1d100e9.jpg",
-                "http://localhost/assets/dataset/--/config/split/7/col/image-1d300ea.jpg",
+                {
+                    "src": "http://localhost/assets/dataset/--/config/split/7/col/image-1d100e9.jpg",
+                    "height": 480,
+                    "width": 640,
+                },
+                {
+                    "src": "http://localhost/assets/dataset/--/config/split/7/col/image-1d300ea.jpg",
+                    "height": 480,
+                    "width": 640,
+                },
             ],
             [Image(decode=True, id=None)],
         ),
@@ -175,8 +191,16 @@ def test_value(dataset_type, output_value, output_dtype, datasets) -> None:
         (
             "images_sequence",
             [
-                "http://localhost/assets/dataset/--/config/split/7/col/image-1d100e9.jpg",
-                "http://localhost/assets/dataset/--/config/split/7/col/image-1d300ea.jpg",
+                {
+                    "src": "http://localhost/assets/dataset/--/config/split/7/col/image-1d100e9.jpg",
+                    "height": 480,
+                    "width": 640,
+                },
+                {
+                    "src": "http://localhost/assets/dataset/--/config/split/7/col/image-1d300ea.jpg",
+                    "height": 480,
+                    "width": 640,
+                },
             ],
             "Sequence",
         ),
@@ -211,8 +235,16 @@ def test_value(dataset_type, output_value, output_dtype, datasets) -> None:
             {
                 "a": 0,
                 "b": [
-                    "http://localhost/assets/dataset/--/config/split/7/col/image-89101db.jpg",
-                    "http://localhost/assets/dataset/--/config/split/7/col/image-89301dc.jpg",
+                    {
+                        "src": "http://localhost/assets/dataset/--/config/split/7/col/image-89101db.jpg",
+                        "height": 480,
+                        "width": 640,
+                    },
+                    {
+                        "src": "http://localhost/assets/dataset/--/config/split/7/col/image-89301dc.jpg",
+                        "height": 480,
+                        "width": 640,
+                    },
                 ],
                 "c": {
                     "ca": [


### PR DESCRIPTION
Instead of returning a string with the URL, we now return an object with: src: the URL, height and width: the dimensions of the image in pixels.

BREAKING CHANGE: 🧨 the image cell format is now an object {src, height, width}