### PR TITLE
feat: 🎸 remove obsolete DATASETS_REVISION

### DIFF
--- a/chart/docker-images.yaml
+++ b/chart/docker-images.yaml
@@ -4,8 +4,8 @@
     "api": "huggingface/datasets-server-services-api:sha-db1a233",
     "reverseProxy": "docker.io/nginx:1.20",
     "worker": {
-      "splits": "huggingface/datasets-server-workers-splits:sha-e9ce81d",
-      "firstRows": "huggingface/datasets-server-workers-first_rows:sha-e9ce81d"
+      "splits": "huggingface/datasets-server-workers-splits:sha-68b31e3",
+      "firstRows": "huggingface/datasets-server-workers-first_rows:sha-f7cfa4a"
     }
   }
 }

--- a/chart/templates/worker/first-rows/_container.tpl
+++ b/chart/templates/worker/first-rows/_container.tpl
@@ -8,8 +8,6 @@
     value: "{{ include "assets.baseUrl" . }}"
   - name: ASSETS_DIRECTORY
     value: {{ .Values.worker.firstRows.assetsDirectory | quote }}
-  - name: DATASETS_REVISION
-    value: {{ .Values.worker.firstRows.datasetsRevision | quote }}
   - name: HF_DATASETS_CACHE
     value: "{{ .Values.worker.firstRows.cacheDirectory }}/datasets"
   - name: HF_ENDPOINT

--- a/chart/templates/worker/splits/_container.tpl
+++ b/chart/templates/worker/splits/_container.tpl
@@ -4,8 +4,6 @@
 {{- define "containerWorkerSplits" -}}
 - name: "{{ include "name" . }}-worker-splits"
   env:
-  - name: DATASETS_REVISION
-    value: {{ .Values.worker.splits.datasetsRevision | quote }}
   - name: HF_DATASETS_CACHE
     value: "{{ .Values.worker.splits.cacheDirectory }}/datasets"
   - name: HF_ENDPOINT

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -116,8 +116,6 @@ worker:
 
     # Directory of the "datasets" library cache (for the datasets, not the modules)
     cacheDirectory: "/cache"
-    # Git reference for the canonical datasets on https://github.com/huggingface/datasets
-    datasetsRevision: "main"
     # Log level
     logLevel: "INFO"
     # Maximum number of jobs running at the same time for the same dataset
@@ -146,8 +144,6 @@ worker:
     assetsDirectory: "/assets"
     # Directory of the "datasets" library cache (for the datasets, not the modules)
     cacheDirectory: "/cache"
-    # Git reference for the canonical datasets on https://github.com/huggingface/datasets
-    datasetsRevision: "main"
     # User Access Token (see https://huggingface.co/settings/token, only the `read` role is required)
     hfToken: ""
     # Log level

--- a/workers/first_rows/README.md
+++ b/workers/first_rows/README.md
@@ -8,7 +8,6 @@ Set environment variables to configure the following aspects:
 
 - `ASSETS_BASE_URL`: base URL for the assets files. It should be set accordingly to the datasets-server domain, eg https://datasets-server.huggingface.co/assets. Defaults to `assets`.
 - `ASSETS_DIRECTORY`: directory where the asset files are stored. Defaults to empty, in which case the assets are located in the `datasets_server_assets` subdirectory inside the OS default cache directory.
-- `DATASETS_REVISION`: git reference for the canonical datasets on https://github.com/huggingface/datasets. Defaults to `main`.
 - `HF_DATASETS_CACHE`: directory where the `datasets` library will store the cached datasets data. Defaults to `~/.cache/huggingface/datasets`.
 - `HF_MODULES_CACHE`: directory where the `datasets` library will store the cached datasets scripts. Defaults to `~/.cache/huggingface/modules`.
 - `HF_ENDPOINT`: URL of the HuggingFace Hub. Defaults to `https://huggingface.co`.

--- a/workers/first_rows/src/first_rows/config.py
+++ b/workers/first_rows/src/first_rows/config.py
@@ -10,7 +10,6 @@ from libutils.utils import get_int_value, get_str_or_none_value, get_str_value
 from first_rows.constants import (
     DEFAULT_ASSETS_BASE_URL,
     DEFAULT_ASSETS_DIRECTORY,
-    DEFAULT_DATASETS_REVISION,
     DEFAULT_HF_ENDPOINT,
     DEFAULT_HF_TOKEN,
     DEFAULT_LOG_LEVEL,
@@ -30,7 +29,6 @@ from first_rows.constants import (
 
 ASSETS_BASE_URL = get_str_value(d=os.environ, key="ASSETS_BASE_URL", default=DEFAULT_ASSETS_BASE_URL)
 ASSETS_DIRECTORY = get_str_or_none_value(d=os.environ, key="ASSETS_DIRECTORY", default=DEFAULT_ASSETS_DIRECTORY)
-DATASETS_REVISION = get_str_value(d=os.environ, key="DATASETS_REVISION", default=DEFAULT_DATASETS_REVISION)
 HF_ENDPOINT = get_str_value(d=os.environ, key="HF_ENDPOINT", default=DEFAULT_HF_ENDPOINT)
 HF_TOKEN = get_str_or_none_value(d=os.environ, key="HF_TOKEN", default=DEFAULT_HF_TOKEN)
 LOG_LEVEL = get_str_value(d=os.environ, key="LOG_LEVEL", default=DEFAULT_LOG_LEVEL)
@@ -47,9 +45,6 @@ ROWS_MAX_NUMBER = get_int_value(os.environ, "ROWS_MAX_NUMBER", DEFAULT_ROWS_MAX_
 ROWS_MIN_NUMBER = get_int_value(os.environ, "ROWS_MIN_NUMBER", DEFAULT_ROWS_MIN_NUMBER)
 WORKER_SLEEP_SECONDS = get_int_value(os.environ, "WORKER_SLEEP_SECONDS", DEFAULT_WORKER_SLEEP_SECONDS)
 
-# Ensure the datasets library uses the expected revision for canonical datasets
-# this one has to be set via an env variable unlike the others - this might be fixed in `datasets` at one point
-os.environ["HF_SCRIPTS_VERSION"] = DATASETS_REVISION
 # Ensure the datasets library uses the expected HuggingFace endpoint
 datasets.config.HF_ENDPOINT = HF_ENDPOINT
 # Don't increase the datasets download counts on huggingface.co

--- a/workers/first_rows/src/first_rows/constants.py
+++ b/workers/first_rows/src/first_rows/constants.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 DEFAULT_ASSETS_BASE_URL: str = "assets"
 DEFAULT_ASSETS_DIRECTORY: None = None
-DEFAULT_DATASETS_REVISION: str = "main"
 DEFAULT_HF_ENDPOINT: str = "https://huggingface.co"
 DEFAULT_HF_TOKEN: Optional[str] = None
 DEFAULT_LOG_LEVEL: str = "INFO"

--- a/workers/splits/README.md
+++ b/workers/splits/README.md
@@ -6,7 +6,6 @@
 
 Set environment variables to configure the following aspects:
 
-- `DATASETS_REVISION`: git reference for the canonical datasets on https://github.com/huggingface/datasets. Defaults to `main`.
 - `HF_DATASETS_CACHE`: directory where the `datasets` library will store the cached datasets data. Defaults to `~/.cache/huggingface/datasets`.
 - `HF_MODULES_CACHE`: directory where the `datasets` library will store the cached datasets scripts. Defaults to `~/.cache/huggingface/modules`.
 - `HF_ENDPOINT`: URL of the HuggingFace Hub. Defaults to `https://huggingface.co`.

--- a/workers/splits/src/splits/config.py
+++ b/workers/splits/src/splits/config.py
@@ -8,7 +8,6 @@ from datasets.utils.logging import log_levels, set_verbosity
 from libutils.utils import get_int_value, get_str_or_none_value, get_str_value
 
 from splits.constants import (
-    DEFAULT_DATASETS_REVISION,
     DEFAULT_HF_ENDPOINT,
     DEFAULT_HF_TOKEN,
     DEFAULT_LOG_LEVEL,
@@ -21,7 +20,6 @@ from splits.constants import (
     DEFAULT_WORKER_SLEEP_SECONDS,
 )
 
-DATASETS_REVISION = get_str_value(d=os.environ, key="DATASETS_REVISION", default=DEFAULT_DATASETS_REVISION)
 HF_ENDPOINT = get_str_value(d=os.environ, key="HF_ENDPOINT", default=DEFAULT_HF_ENDPOINT)
 HF_TOKEN = get_str_or_none_value(d=os.environ, key="HF_TOKEN", default=DEFAULT_HF_TOKEN)
 LOG_LEVEL = get_str_value(d=os.environ, key="LOG_LEVEL", default=DEFAULT_LOG_LEVEL)
@@ -33,9 +31,6 @@ MONGO_QUEUE_DATABASE = get_str_value(d=os.environ, key="MONGO_QUEUE_DATABASE", d
 MONGO_URL = get_str_value(d=os.environ, key="MONGO_URL", default=DEFAULT_MONGO_URL)
 WORKER_SLEEP_SECONDS = get_int_value(os.environ, "WORKER_SLEEP_SECONDS", DEFAULT_WORKER_SLEEP_SECONDS)
 
-# Ensure the datasets library uses the expected revision for canonical datasets
-# this one has to be set via an env variable unlike the others - this might be fixed in `datasets` at one point
-os.environ["HF_SCRIPTS_VERSION"] = DATASETS_REVISION
 # Ensure the datasets library uses the expected HuggingFace endpoint
 datasets.config.HF_ENDPOINT = HF_ENDPOINT
 # Don't increase the datasets download counts on huggingface.co

--- a/workers/splits/src/splits/constants.py
+++ b/workers/splits/src/splits/constants.py
@@ -3,7 +3,6 @@
 
 from typing import Optional
 
-DEFAULT_DATASETS_REVISION: str = "main"
 DEFAULT_HF_ENDPOINT: str = "https://huggingface.co"
 DEFAULT_HF_TOKEN: Optional[str] = None
 DEFAULT_LOG_LEVEL: str = "INFO"


### PR DESCRIPTION
Now that the canonical datasets are loaded from the Hub, DATASETS_REVISION (or HF_SCRIPTS_VERSION in datasets) is useless.