### PR TITLE
Small tweaks on Helm charts

### DIFF
--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# Helm envs
+env

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -118,6 +118,8 @@ reverseProxy:
       operator: Equal
 
 ingress:
+  tls:
+    hosts: "datasets-server.huggingface.co"
   annotations:
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:707930574880:certificate/971187a3-2baa-40e5-bcae-94d6ec55cd24
     alb.ingress.kubernetes.io/load-balancer-name: "hub-datasets-server-prod"

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -119,7 +119,8 @@ reverseProxy:
 
 ingress:
   tls:
-    hosts: "datasets-server.huggingface.co"
+    - hosts:
+      - "datasets-server.huggingface.co"
   annotations:
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:707930574880:certificate/971187a3-2baa-40e5-bcae-94d6ec55cd24
     alb.ingress.kubernetes.io/load-balancer-name: "hub-datasets-server-prod"

--- a/chart/templates/_envCommon.tpl
+++ b/chart/templates/_envCommon.tpl
@@ -10,7 +10,11 @@
   {{- if .Values.secrets.appHfToken.fromSecret }}
   valueFrom:
     secretKeyRef:
+      {{- if eq .Values.secrets.appHfToken.secretName "" }}
+      name: {{ .Release.Name }}-datasets-server-app-token
+      {{- else }}
       name: {{ .Values.secrets.appHfToken.secretName | quote }}
+      {{- end }}
       key: HF_TOKEN
       optional: false
   {{- else }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -6,12 +6,7 @@ metadata:
   name: {{ include "release" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- if .Values.ingress.tls.enabled }}
-  tls:
-    - hosts:
-        - {{ .Values.hostname }}
-      secretName: {{ .Values.ingress.tls.secretName }}
-  {{- end}}
+  tls: {{ toYaml .Values.ingress.tls | nindent 4 }}
   rules:
     - host: {{ .Values.hostname }}
       http:

--- a/chart/templates/jobs/mongodb-migration/job.yaml
+++ b/chart/templates/jobs/mongodb-migration/job.yaml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
 
+{{- if .Values.dockerImage.jobs.mongodbMigration }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -24,3 +25,4 @@ spec:
       volumes: {{ include "volumeData" . | nindent 8 }}
       securityContext: {{ include "securityContext" . | nindent 8 }}
   backoffLimit: 0
+{{- end}}

--- a/chart/templates/worker/first-rows/_container.tpl
+++ b/chart/templates/worker/first-rows/_container.tpl
@@ -4,7 +4,7 @@
 {{- define "containerWorkerFirstRows" -}}
 - name: "{{ include "name" . }}-worker-first-rows"
   image: {{ .Values.dockerImage.workers.datasets_based }}
-  imagePullPolicy: IfNotPresent
+  imagePullPolicy: {{ .Values.docker.pullPolicy }}
   env:
   - name: DATASETS_BASED_ENDPOINT
     value: "/first-rows"

--- a/chart/templates/worker/parquet/_container.tpl
+++ b/chart/templates/worker/parquet/_container.tpl
@@ -4,7 +4,7 @@
 {{- define "containerWorkerParquet" -}}
 - name: "{{ include "name" . }}-worker-parquet"
   image: {{ .Values.dockerImage.workers.datasets_based }}
-  imagePullPolicy: IfNotPresent
+  imagePullPolicy: {{ .Values.docker.pullPolicy }}
   env:
   - name: DATASETS_BASED_ENDPOINT
     value: "/parquet"

--- a/chart/templates/worker/splits/_container.tpl
+++ b/chart/templates/worker/splits/_container.tpl
@@ -4,7 +4,7 @@
 {{- define "containerWorkerSplits" -}}
 - name: "{{ include "name" . }}-worker-splits"
   image: {{ .Values.dockerImage.workers.datasets_based }}
-  imagePullPolicy: {{ .Values.dockerImage.pullPolicy }}
+  imagePullPolicy: {{ .Values.docker.pullPolicy }}
   env:
   - name: DATASETS_BASED_ENDPOINT
     value: "/splits"

--- a/chart/templates/worker/splits/_container.tpl
+++ b/chart/templates/worker/splits/_container.tpl
@@ -4,7 +4,7 @@
 {{- define "containerWorkerSplits" -}}
 - name: "{{ include "name" . }}-worker-splits"
   image: {{ .Values.dockerImage.workers.datasets_based }}
-  imagePullPolicy: IfNotPresent
+  imagePullPolicy: {{ .Values.dockerImage.pullPolicy }}
   env:
   - name: DATASETS_BASED_ENDPOINT
     value: "/splits"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -9,7 +9,7 @@ secrets:
     value: mongo://
   appHfToken:
     fromSecret: false
-    secretName: "datasets-server-hf-token"
+    secretName: ""
     value: hf_app
   userHfToken:
     fromSecret: false
@@ -39,6 +39,7 @@ imagePullSecrets: []
 
 # overridden by docker-images.yaml (which must be in JSON format!)
 dockerImage:
+  pullPolicy: IfNotPresent
   reverseProxy: ""
   jobs:
     mongodb_migration: ""
@@ -135,15 +136,8 @@ reverseProxy:
   tolerations: []
 
 ingress:
-  tls:
-    enabled: false
-    secretName: ""
-  annotations:
-    alb.ingress.kubernetes.io/healthcheck-path: "/healthcheck"
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80, "HTTPS": 443}]'
-    alb.ingress.kubernetes.io/scheme: "internet-facing"
-    alb.ingress.kubernetes.io/group.name: "datasets-server"
-    kubernetes.io/ingress.class: "alb"
+  tls: []
+  annotations: {}
 
 # --- services ---
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -37,9 +37,11 @@ mongodb:
 
 imagePullSecrets: []
 
-# overridden by docker-images.yaml (which must be in JSON format!)
-dockerImage:
+docker:
   pullPolicy: IfNotPresent
+
+# overridden by docker-images.yaml (which must be in JSON format!). See Makefile for details.
+dockerImage:
   reverseProxy: ""
   jobs:
     mongodb_migration: ""


### PR DESCRIPTION
- Ignore env files in packaged charts
- Add ability to completely specify `ingress.tls`
- Automatic value for `token.secretName` if not specified
- Do not submit `mongodb-migration` job if image not specified
- Add ability to specify `imagePullPolicy`