### PR TITLE
chore: 🤖 speed-up docker build

### DIFF
--- a/jobs/mongodb_migration/Dockerfile
+++ b/jobs/mongodb_migration/Dockerfile
@@ -21,11 +21,12 @@ RUN pip install -U --no-cache-dir pip
 RUN pip install "poetry==$POETRY_VERSION"
 
 WORKDIR /src
-COPY libs/libcommon/dist ./libs/libcommon/dist
-COPY jobs/mongodb_migration/src ./jobs/mongodb_migration/src
 COPY jobs/mongodb_migration/poetry.lock ./jobs/mongodb_migration/poetry.lock
 COPY jobs/mongodb_migration/pyproject.toml ./jobs/mongodb_migration/pyproject.toml
+COPY libs/libcommon/dist ./libs/libcommon/dist
 WORKDIR /src/jobs/mongodb_migration/
+RUN poetry install
+COPY jobs/mongodb_migration/src ./src
 RUN poetry install
 
 ENTRYPOINT ["poetry", "run", "python", "src/mongodb_migration/main.py"]

--- a/services/admin/Dockerfile
+++ b/services/admin/Dockerfile
@@ -21,11 +21,12 @@ RUN pip install -U --no-cache-dir pip
 RUN pip install "poetry==$POETRY_VERSION"
 
 WORKDIR /src
-COPY libs/libcommon/dist ./libs/libcommon/dist
-COPY services/admin/src ./services/admin/src
 COPY services/admin/poetry.lock ./services/admin/poetry.lock
 COPY services/admin/pyproject.toml ./services/admin/pyproject.toml
+COPY libs/libcommon/dist ./libs/libcommon/dist
 WORKDIR /src/services/admin/
+RUN poetry install
+COPY services/admin/src ./src
 RUN poetry install
 
 ENTRYPOINT ["poetry", "run", "python", "src/admin/main.py"]

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -21,11 +21,12 @@ RUN pip install -U --no-cache-dir pip
 RUN pip install "poetry==$POETRY_VERSION"
 
 WORKDIR /src
-COPY libs/libcommon/dist ./libs/libcommon/dist
-COPY services/api/src ./services/api/src
 COPY services/api/poetry.lock ./services/api/poetry.lock
 COPY services/api/pyproject.toml ./services/api/pyproject.toml
+COPY libs/libcommon/dist ./libs/libcommon/dist
 WORKDIR /src/services/api/
+RUN poetry install
+COPY services/api/src ./src
 RUN poetry install
 
 ENTRYPOINT ["poetry", "run", "python", "src/api/main.py"]

--- a/workers/datasets_based/Dockerfile
+++ b/workers/datasets_based/Dockerfile
@@ -23,12 +23,13 @@ RUN pip install -U --no-cache-dir pip
 RUN pip install "poetry==$POETRY_VERSION"
 
 WORKDIR /src
-COPY libs/libcommon/dist ./libs/libcommon/dist
-COPY workers/datasets_based/src ./workers/datasets_based/src
+COPY workers/datasets_based/vendors ./workers/datasets_based/vendors/
 COPY workers/datasets_based/poetry.lock ./workers/datasets_based/poetry.lock
 COPY workers/datasets_based/pyproject.toml ./workers/datasets_based/pyproject.toml
-COPY workers/datasets_based/vendors ./workers/datasets_based/vendors/
+COPY libs/libcommon/dist ./libs/libcommon/dist
 WORKDIR /src/workers/datasets_based/
+RUN poetry install
+COPY workers/datasets_based/src ./src
 RUN poetry install
 
 ENTRYPOINT ["poetry", "run", "python", "src/datasets_based/main.py"]


### PR DESCRIPTION
in the next builds, the cache will be used if only src/ has been modified, which should help mostly with the workers/datasets_based image, because the poetry install of dependencies takes a lot of time.