### PR TITLE
fix: 🐛 only check webhook payload for what we are interested in

### DIFF
--- a/chart/docker-images.yaml
+++ b/chart/docker-images.yaml
@@ -6,7 +6,7 @@
     },
     "services": {
       "admin": "huggingface/datasets-server-services-admin:sha-6a36caa",
-      "api": "huggingface/datasets-server-services-api:sha-6a36caa"
+      "api": "huggingface/datasets-server-services-api:sha-a36b651"
     },
     "workers": {
       "datasets_based": "huggingface/datasets-server-workers-datasets_based:sha-6a36caa"

--- a/services/api/src/api/routes/webhook.py
+++ b/services/api/src/api/routes/webhook.py
@@ -19,22 +19,11 @@ schema = {
     "properties": {
         "event": {"type": "string", "enum": ["add", "remove", "update", "move"]},
         "movedTo": {"type": "string"},
-        "movedToAuthorId": {"type": "string"},
         "repo": {
             "type": "object",
             "properties": {
-                "id": {"type": "string"},
-                "authorId": {"type": "string"},
-                "gitalyUid": {"type": "string"},
-                "headSha": {"type": "string"},
                 "name": {"type": "string"},
-                "private": {"type": "boolean"},
-                "subdomain": {"type": "string"},
-                # ^ subdomain is for spaces
-                "tags": {"type": "array", "items": {"type": "string"}},
-                # ^ tags are only sent for models
                 "type": {"type": "string", "enum": ["dataset", "model", "space"]},
-                "url": {"type": "string", "format": "uri"},
             },
             "required": ["type", "name"],
         },
@@ -46,8 +35,6 @@ schema = {
 class MoonWebhookV2PayloadRepo(TypedDict):
     type: Literal["model", "dataset", "space"]
     name: str
-    gitalyUid: str
-    tags: Optional[List[str]]
 
 
 class MoonWebhookV2Payload(TypedDict):

--- a/services/api/tests/routes/test_webhook.py
+++ b/services/api/tests/routes/test_webhook.py
@@ -22,6 +22,32 @@ from api.routes.webhook import parse_payload
         ),
         ({"event": "add", "repo": {"type": "dataset", "name": "webhook-test"}}, False),
         ({"event": "doesnotexist", "repo": {"type": "dataset", "name": "webhook-test", "gitalyUid": "123"}}, True),
+        (
+            {
+                "event": "update",
+                "scope": "repo.content",
+                "repo": {
+                    "type": "dataset",
+                    "name": "AresEkb/prof_standards_sbert_large_mt_nlu_ru",
+                    "id": "63bab13ae0f4fee16cebf084",
+                    "private": False,
+                    "url": {
+                        "web": "https://huggingface.co/datasets/AresEkb/prof_standards_sbert_large_mt_nlu_ru",
+                        "api": "https://huggingface.co/api/datasets/AresEkb/prof_standards_sbert_large_mt_nlu_ru",
+                    },
+                    "headSha": "c926e6ce93cbd5a6eaf0895abd48776cc5bae638",
+                    "gitalyUid": "c5afeca93171cfa1f6c138ef683df4a53acffd8c86283ab8e7e338df369d2fff",
+                    "authorId": "6394b8740b746ac6a969bd51",
+                    "tags": [],
+                },
+                "webhook": {"id": "632c22b3df82fca9e3b46154", "version": 2},
+            },
+            False,
+        ),
+        (
+            {"event": "update", "repo": {"type": "dataset", "name": "AresEkb/prof_standards_sbert_large_mt_nlu_ru"}},
+            False,
+        ),
     ],
 )
 def test_parse_payload(


### PR DESCRIPTION
checking the payload in details (eg if the URL field is well formed) while not using it afterward is not useful. It even lead to breaking the webhook after https://github.com/huggingface/moon-landing/pull/4477 (internal link) where the "url" field format had changed.

cc @SBrandeis @coyotte508 fyi