### PR TITLE
Add priority field to queue

### DIFF
--- a/chart/docker-images.yaml
+++ b/chart/docker-images.yaml
@@ -2,14 +2,14 @@
   "dockerImage": {
     "reverseProxy": "docker.io/nginx:1.20",
     "jobs": {
-      "mongodbMigration": "huggingface/datasets-server-jobs-mongodb_migration:sha-da3070a"
+      "mongodbMigration": "huggingface/datasets-server-jobs-mongodb_migration:sha-3de1315"
     },
     "services": {
-      "admin": "huggingface/datasets-server-services-admin:sha-da3070a",
-      "api": "huggingface/datasets-server-services-api:sha-da3070a"
+      "admin": "huggingface/datasets-server-services-admin:sha-3de1315",
+      "api": "huggingface/datasets-server-services-api:sha-3de1315"
     },
     "workers": {
-      "datasets_based": "huggingface/datasets-server-workers-datasets_based:sha-da3070a"
+      "datasets_based": "huggingface/datasets-server-workers-datasets_based:sha-3de1315"
     }
   }
 }

--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -11,6 +11,7 @@ from mongodb_migration.migrations._20221116133500_queue_job_add_force import (
 from mongodb_migration.migrations._20221117223000_cache_generic_response import (
     MigrationMoveToGenericCachedResponse,
 )
+from mongodb_migration.migrations._20230126164900_queue_job_add_priority import MigrationAddPriorityToJob
 
 
 # TODO: add a way to automatically collect migrations from the migrations/ folder
@@ -24,5 +25,9 @@ class MigrationsCollector:
             MigrationMoveToGenericCachedResponse(
                 version="20221117223000",
                 description="replace SplitsResponse and FirstRowsResponse with a generic CachedResponse",
+            ),
+            MigrationAddPriorityToJob(
+                version="20230126164900",
+                description="add 'priority' field to jobs in queue database",
             ),
         ]

--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -11,7 +11,9 @@ from mongodb_migration.migrations._20221116133500_queue_job_add_force import (
 from mongodb_migration.migrations._20221117223000_cache_generic_response import (
     MigrationMoveToGenericCachedResponse,
 )
-from mongodb_migration.migrations._20230126164900_queue_job_add_priority import MigrationAddPriorityToJob
+from mongodb_migration.migrations._20230126164900_queue_job_add_priority import (
+    MigrationAddPriorityToJob,
+)
 
 
 # TODO: add a way to automatically collect migrations from the migrations/ folder

--- a/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230126164900_queue_job_add_priority.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230126164900_queue_job_add_priority.py
@@ -36,8 +36,8 @@ class MigrationAddPriorityToJob(Migration):
                 raise ValueError("priority should be 'normal'")
 
         check_documents(DocCls=JobSnapshot, sample_size=10, custom_validation=custom_validation)
-        if JobSnapshot.objects(force=False).count() != JobSnapshot.objects.count():
-            raise ValueError('All the objects should have the "force" field, set to False')
+        if JobSnapshot.objects(priority=Priority.NORMAL).count() != JobSnapshot.objects.count():
+            raise ValueError('All the objects should have the "priority" field, set to "normal"')
 
 
 # --- JobSnapshot ---

--- a/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230126164900_queue_job_add_priority.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230126164900_queue_job_add_priority.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+import enum
+import logging
+import types
+from typing import Generic, Type, TypeVar
+
+from mongoengine import Document
+from mongoengine.connection import get_db
+from mongoengine.fields import BooleanField, DateTimeField, EnumField, StringField
+from mongoengine.queryset.queryset import QuerySet
+
+from mongodb_migration.check import check_documents
+from mongodb_migration.migration import Migration
+
+
+# connection already occurred in the main.py (caveat: we use globals)
+class MigrationAddPriorityToJob(Migration):
+    def up(self) -> None:
+        # See https://docs.mongoengine.org/guide/migration.html#example-1-addition-of-a-field
+        logging.info("Add the priority field, with the default value ('normal'), to all the jobs")
+        db = get_db("queue")
+        db["jobsBlue"].update_many({}, {"$set": {"priority": "normal"}})
+
+    def down(self) -> None:
+        logging.info("Remove the priority field from all the jobs")
+        db = get_db("queue")
+        db["jobsBlue"].update_many({}, {"$unset": {"priority": ""}})
+
+    def validate(self) -> None:
+        logging.info("Ensure that a random selection of jobs have the 'priority' field set to 'normal'")
+
+        def custom_validation(doc: JobSnapshot) -> None:
+            if doc.priority != "normal":
+                raise ValueError("priority should be 'normal'")
+
+        check_documents(DocCls=JobSnapshot, sample_size=10, custom_validation=custom_validation)
+        if JobSnapshot.objects(force=False).count() != JobSnapshot.objects.count():
+            raise ValueError('All the objects should have the "force" field, set to False')
+
+
+# --- JobSnapshot ---
+# copied from libcommon.queue.Job, as a snapshot of when the migration was created
+class Status(enum.Enum):
+    WAITING = "waiting"
+    STARTED = "started"
+    SUCCESS = "success"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+    SKIPPED = "skipped"
+
+
+class Priority(enum.Enum):
+    NORMAL = "normal"
+    LOW = "low"
+
+
+# START monkey patching ### hack ###
+# see https://github.com/sbdchd/mongo-types#install
+U = TypeVar("U", bound=Document)
+
+
+def no_op(self, x):  # type: ignore
+    return self
+
+
+QuerySet.__class_getitem__ = types.MethodType(no_op, QuerySet)
+
+
+class QuerySetManager(Generic[U]):
+    def __get__(self, instance: object, cls: Type[U]) -> QuerySet[U]:
+        return QuerySet(cls, cls._get_collection())
+
+
+# END monkey patching ### hack ###
+
+
+class JobSnapshot(Document):
+    """A job in the mongoDB database
+
+    Args:
+        type (`str`): The type of the job, identifies the queue
+        dataset (`str`): The dataset on which to apply the job.
+        config (`str`, optional): The config on which to apply the job.
+        split (`str`, optional): The config on which to apply the job.
+        unicity_id (`str`): A string that identifies the job uniquely. Only one job with the same unicity_id can be in
+          the started state.
+        namespace (`str`): The dataset namespace (user or organization) if any, else the dataset name (canonical name).
+        force (`bool`, optional): If True, the job SHOULD not be skipped. Defaults to False.
+        priority (`Priority`, optional): The priority of the job. Defaults to Priority.NORMAL.
+        status (`Status`, optional): The status of the job. Defaults to Status.WAITING.
+        created_at (`datetime`): The creation date of the job.
+        started_at (`datetime`, optional): When the job has started.
+        finished_at (`datetime`, optional): When the job has finished.
+    """
+
+    meta = {
+        "collection": "jobsBlue",
+        "db_alias": "queue",
+        "indexes": [
+            "status",
+            ("type", "status"),
+            ("type", "dataset", "status"),
+            ("type", "dataset", "config", "split", "status", "force", "priority"),
+            ("status", "type", "created_at", "namespace", "unicity_id", "priority"),
+            "-created_at",
+        ],
+    }
+    type = StringField(required=True)
+    dataset = StringField(required=True)
+    config = StringField()
+    split = StringField()
+    unicity_id = StringField(required=True)
+    namespace = StringField(required=True)
+    force = BooleanField(default=False)
+    priority = EnumField(Priority, default=Priority.NORMAL)
+    status = EnumField(Status, default=Status.WAITING)
+    created_at = DateTimeField(required=True)
+    started_at = DateTimeField()
+    finished_at = DateTimeField()
+
+    objects = QuerySetManager["JobSnapshot"]()

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
 
+import contextlib
 import enum
 import logging
 import types
@@ -43,6 +44,11 @@ class Status(enum.Enum):
     SKIPPED = "skipped"
 
 
+class Priority(enum.Enum):
+    NORMAL = "normal"
+    LOW = "low"
+
+
 class JobDict(TypedDict):
     type: str
     dataset: str
@@ -51,6 +57,7 @@ class JobDict(TypedDict):
     unicity_id: str
     namespace: str
     force: bool
+    priority: str
     status: str
     created_at: datetime
     started_at: Optional[datetime]
@@ -110,6 +117,7 @@ class Job(Document):
           the started state.
         namespace (`str`): The dataset namespace (user or organization) if any, else the dataset name (canonical name).
         force (`bool`, optional): If True, the job SHOULD not be skipped. Defaults to False.
+        priority (`Priority`, optional): The priority of the job. Defaults to Priority.NORMAL.
         status (`Status`, optional): The status of the job. Defaults to Status.WAITING.
         created_at (`datetime`): The creation date of the job.
         started_at (`datetime`, optional): When the job has started.
@@ -123,8 +131,8 @@ class Job(Document):
             "status",
             ("type", "status"),
             ("type", "dataset", "status"),
-            ("type", "dataset", "config", "split", "status"),
-            ("status", "type", "created_at", "namespace", "unicity_id"),
+            ("type", "dataset", "config", "split", "status", "force", "priority"),
+            ("status", "type", "created_at", "namespace", "unicity_id", "priority"),
             "-created_at",
         ],
     }
@@ -135,6 +143,7 @@ class Job(Document):
     unicity_id = StringField(required=True)
     namespace = StringField(required=True)
     force = BooleanField(default=False)
+    priority = EnumField(Priority, default=Priority.NORMAL)
     status = EnumField(Status, default=Status.WAITING)
     created_at = DateTimeField(required=True)
     started_at = DateTimeField()
@@ -149,6 +158,7 @@ class Job(Document):
             "unicity_id": self.unicity_id,
             "namespace": self.namespace,
             "force": self.force,
+            "priority": self.priority.value,
             "status": self.status.value,
             "created_at": self.created_at,
             "started_at": self.started_at,
@@ -167,9 +177,10 @@ class Queue:
     It's a FIFO queue, with the following properties:
     - a job is identified by its input arguments: unicity_id (type, dataset, config and split)
     - a job can be in one of the following states: waiting, started, success, error, cancelled, skipped
-    - a job can be in the queue only once (unicity_id) in the "started" state
-    - a job can be in the queue multiple times in the other states (waiting, success, error, cancelled, skipped)
-    - the queue is ordered by the creation date of the jobs
+    - a job can be in the queue only once (unicity_id) in the "started" or "waiting" state
+    - a job can be in the queue multiple times in the other states (success, error, cancelled, skipped)
+    - a job has a priority (two levels: NORMAL and LOW)
+    - the queue is ordered by priority then by the creation date of the jobs
     - datasets and users that already have started jobs are de-prioritized (using namespace)
     - no more than `max_jobs_per_namespace` started jobs can exist for the same namespace
 
@@ -188,7 +199,12 @@ class Queue:
         )
 
     def _add_job(
-        self, dataset: str, config: Optional[str] = None, split: Optional[str] = None, force: bool = False
+        self,
+        dataset: str,
+        config: Optional[str] = None,
+        split: Optional[str] = None,
+        force: bool = False,
+        priority: Priority = Priority.NORMAL,
     ) -> Job:
         """Add a job to the queue in the waiting state.
 
@@ -199,6 +215,7 @@ class Queue:
             config (`str`, optional): The config on which to apply the job.
             split (`str`, optional): The config on which to apply the job.
             force (`bool`, optional): If True, the job SHOULD not be skipped. Defaults to False.
+            priority (`Priority`, optional): The priority of the job. Defaults to Priority.NORMAL.
 
         Returns: the job
         """
@@ -210,38 +227,48 @@ class Queue:
             unicity_id=f"Job[{self.type}][{dataset}][{config}][{split}]",
             namespace=dataset.split("/")[0],
             force=force,
+            priority=priority,
             created_at=get_datetime(),
             status=Status.WAITING,
         ).save()
 
     def upsert_job(
-        self, dataset: str, config: Optional[str] = None, split: Optional[str] = None, force: bool = False
+        self,
+        dataset: str,
+        config: Optional[str] = None,
+        split: Optional[str] = None,
+        force: bool = False,
+        priority: Priority = Priority.NORMAL,
     ) -> Job:
         """Add, or update, a job to the queue in the waiting state.
 
         If jobs already exist with the same parameters in the waiting state, they are cancelled and replaced by a new
         one.
         Note that the new job inherits the force=True property if one of the previous waiting jobs had it.
+        In the same way, the new job inherits the highest priority.
 
         Args:
             dataset (`str`): The dataset on which to apply the job.
             config (`str`, optional): The config on which to apply the job.
             split (`str`, optional): The config on which to apply the job.
             force (`bool`, optional): If True, the job SHOULD not be skipped. Defaults to False.
+            priority (`Priority`, optional): The priority of the job. Defaults to Priority.NORMAL.
 
         Returns: the job
         """
         existing = Job.objects(type=self.type, dataset=dataset, config=config, split=split, status=Status.WAITING)
         if existing(force=True).count() > 0:
             force = True
+        if existing(priority=Priority.NORMAL).count() > 0:
+            priority = Priority.NORMAL
         existing.update(finished_at=get_datetime(), status=Status.CANCELLED)
-        return self._add_job(dataset=dataset, config=config, split=split, force=force)
+        return self._add_job(dataset=dataset, config=config, split=split, force=force, priority=priority)
 
-    def get_next_waiting_job(self) -> Job:
-        """Get the next job in the queue.
+    def _get_next_waiting_job_for_priority(self, priority: Priority) -> Job:
+        """Get the next job in the queue for a given priority.
 
-        Get the waiting job with the oldest creation date:
-        - first, among the datasets that still have no started job.
+        For a given priority, get the waiting job with the oldest creation date:
+        - among the datasets that still have no started job.
         - if none, among the datasets that have the least started jobs:
           - in the limit of `max_jobs_per_namespace` jobs per namespace
           - ensuring that the unicity_id field is unique among the started jobs.
@@ -259,6 +286,7 @@ class Queue:
                 type=self.type,
                 status=Status.WAITING,
                 namespace__nin=set(started_job_namespaces),
+                priority=priority,
             )
             .order_by("+created_at")
             .only("dataset", "config", "split", "force")
@@ -294,6 +322,7 @@ class Queue:
                     status=Status.WAITING,
                     namespace__in=least_common_namespaces_group,
                     unicity_id__nin=started_unicity_ids,
+                    priority=priority,
                 )
                 .order_by("+created_at")
                 .only("dataset", "config", "split", "force")
@@ -302,6 +331,29 @@ class Queue:
             )
             if next_waiting_job is not None:
                 return next_waiting_job
+        raise EmptyQueueError(
+            f"no job available with the priority (within the limit of {self.max_jobs_per_namespace} started jobs per"
+            " namespace)"
+        )
+
+    def get_next_waiting_job(self) -> Job:
+        """Get the next job in the queue.
+
+        Get the waiting job with the oldest creation date with the following criteria:
+        - among the highest priority jobs,
+        - among the datasets that still have no started job.
+        - if none, among the datasets that have the least started jobs:
+          - in the limit of `max_jobs_per_namespace` jobs per namespace
+          - ensuring that the unicity_id field is unique among the started jobs.
+
+        Raises:
+            EmptyQueueError: if there is no waiting job in the queue that satisfies the restrictions above.
+
+        Returns: the job
+        """
+        for priority in [Priority.NORMAL, Priority.LOW]:
+            with contextlib.suppress(EmptyQueueError):
+                return self._get_next_waiting_job_for_priority(priority)
         raise EmptyQueueError(
             f"no job available (within the limit of {self.max_jobs_per_namespace} started jobs per namespace)"
         )

--- a/libs/libcommon/tests/test_queue.py
+++ b/libs/libcommon/tests/test_queue.py
@@ -78,10 +78,10 @@ def test_upsert_job() -> None:
     assert job_info["dataset"] == test_dataset
     assert job_info["config"] is None
     assert job_info["split"] is None
-    assert job_info["force"] is False
+    assert job_info["force"] is True  # the new job inherits from waiting forced jobs
     assert queue.is_job_in_process(dataset=test_dataset) is True
     # adding the job while the first one has not finished yet adds a new waiting job
-    queue.upsert_job(dataset=test_dataset, force=True)
+    queue.upsert_job(dataset=test_dataset, force=False)
     with pytest.raises(EmptyQueueError):
         # but: it's not possible to start two jobs with the same arguments
         queue.start_job()
@@ -91,7 +91,7 @@ def test_upsert_job() -> None:
     assert queue.is_job_in_process(dataset=test_dataset) is True
     # process the second job
     job_info = queue.start_job()
-    assert job_info["force"] is True
+    assert job_info["force"] is False  # the new jobs does not inherit from started forced jobs
     queue.finish_job(job_id=job_info["job_id"], finished_status=Status.SUCCESS)
     # the queue is empty
     assert queue.is_job_in_process(dataset=test_dataset) is False


### PR DESCRIPTION
In this PR:
- the jobs have a new field called `priority`: `normal` (default) or `low`
- the `normal` jobs are fetched before the `low` ones (but respecting `max_jobs_per_namespace`)
- when updating a job, i.e., if a dataset has been updated again, the priority is inherited, never lowered, even if the priority field is set. This way: when launching backfill (with a low priority) on a dataset that was already waiting for update, we don't deprioritize it.
- same logic with the existing "force" field: when updating a job, if force was true, we maintain it.