### PR TITLE
feat: 🎸 make /first-rows depend on /split-names, not /splits

### DIFF
--- a/chart/docker-images.yaml
+++ b/chart/docker-images.yaml
@@ -2,14 +2,14 @@
   "dockerImage": {
     "reverseProxy": "docker.io/nginx:1.20",
     "jobs": {
-      "mongodbMigration": "huggingface/datasets-server-jobs-mongodb_migration:sha-690d1cd"
+      "mongodbMigration": "huggingface/datasets-server-jobs-mongodb_migration:sha-da3070a"
     },
     "services": {
-      "admin": "huggingface/datasets-server-services-admin:sha-4dc0383",
-      "api": "huggingface/datasets-server-services-api:sha-4dc0383"
+      "admin": "huggingface/datasets-server-services-admin:sha-da3070a",
+      "api": "huggingface/datasets-server-services-api:sha-da3070a"
     },
     "workers": {
-      "datasets_based": "huggingface/datasets-server-workers-datasets_based:sha-690d1cd"
+      "datasets_based": "huggingface/datasets-server-workers-datasets_based:sha-da3070a"
     }
   }
 }

--- a/libs/libcommon/src/libcommon/config.py
+++ b/libs/libcommon/src/libcommon/config.py
@@ -146,7 +146,7 @@ class ProcessingGraphConfig:
             "/config-names": {"input_type": "dataset"},
             "/split-names": {"input_type": "config", "requires": "/config-names"},
             "/splits": {"input_type": "dataset", "required_by_dataset_viewer": True},  # to be deprecated
-            "/first-rows": {"input_type": "split", "requires": "/splits", "required_by_dataset_viewer": True},
+            "/first-rows": {"input_type": "split", "requires": "/split-names", "required_by_dataset_viewer": True},
             "/parquet-and-dataset-info": {"input_type": "dataset"},
             "/parquet": {"input_type": "dataset", "requires": "/parquet-and-dataset-info"},
             "/dataset-info": {"input_type": "dataset", "requires": "/parquet-and-dataset-info"},

--- a/libs/libcommon/tests/test_processing_steps.py
+++ b/libs/libcommon/tests/test_processing_steps.py
@@ -24,18 +24,18 @@ def test_default_graph():
 
     assert split_names is not None
     assert split_names.parent is config_names
-    assert split_names.children == []
+    assert split_names.children == [first_rows]
     assert split_names.get_ancestors() == [config_names]
 
     assert splits is not None
     assert splits.parent is None
-    assert splits.children == [first_rows]
+    assert splits.children == []
     assert splits.get_ancestors() == []
 
     assert first_rows is not None
-    assert first_rows.parent is splits
+    assert first_rows.parent is split_names
     assert first_rows.children == []
-    assert first_rows.get_ancestors() == [splits]
+    assert first_rows.get_ancestors() == [config_names, split_names]
 
     assert parquet_and_dataset_info is not None
     assert parquet_and_dataset_info.parent is None


### PR DESCRIPTION
`/splits` fails if any config is broken. By depending on `/split-names`, the working configs will have `/first-rows`.

Follow-up to #702