### PR TITLE
feat: 🎸 add a /backfill admin endpoint

### DIFF
--- a/chart/docker-images.yaml
+++ b/chart/docker-images.yaml
@@ -2,14 +2,14 @@
   "dockerImage": {
     "reverseProxy": "docker.io/nginx:1.20",
     "jobs": {
-      "mongodbMigration": "huggingface/datasets-server-jobs-mongodb_migration:sha-48dee06"
+      "mongodbMigration": "huggingface/datasets-server-jobs-mongodb_migration:sha-1c9e36d"
     },
     "services": {
-      "admin": "huggingface/datasets-server-services-admin:sha-3de1315",
-      "api": "huggingface/datasets-server-services-api:sha-3de1315"
+      "admin": "huggingface/datasets-server-services-admin:sha-bb27740",
+      "api": "huggingface/datasets-server-services-api:sha-1c9e36d"
     },
     "workers": {
-      "datasets_based": "huggingface/datasets-server-workers-datasets_based:sha-3de1315"
+      "datasets_based": "huggingface/datasets-server-workers-datasets_based:sha-1c9e36d"
     }
   }
 }

--- a/libs/libcommon/src/libcommon/dataset.py
+++ b/libs/libcommon/src/libcommon/dataset.py
@@ -213,3 +213,7 @@ def check_support(
         - ['~requests.exceptions.HTTPError']: any other error when asking access
     """
     get_dataset_info_for_supported_datasets(dataset=dataset, hf_endpoint=hf_endpoint, hf_token=hf_token)
+
+
+def get_supported_datasets(hf_endpoint: str, hf_token: Optional[str] = None) -> list[str]:
+    return [d.id for d in HfApi(endpoint=hf_endpoint, token=hf_token).list_datasets() if d.id is not None]

--- a/libs/libcommon/src/libcommon/operations.py
+++ b/libs/libcommon/src/libcommon/operations.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 from libcommon.dataset import check_support
 from libcommon.exceptions import LoggedError
 from libcommon.processing_graph import ProcessingStep
-from libcommon.queue import Queue
+from libcommon.queue import Priority, Queue
 from libcommon.simple_cache import DoesNotExist, delete_dataset_responses, get_response
 
 
@@ -25,6 +25,7 @@ def update_dataset(
     hf_endpoint: str,
     hf_token: Optional[str] = None,
     force: bool = False,
+    priority: Priority = Priority.NORMAL,
 ) -> None:
     """
     Update a dataset
@@ -35,6 +36,7 @@ def update_dataset(
         hf_endpoint (str): the HF endpoint
         hf_token (Optional[str], optional): The HF token. Defaults to None.
         force (bool, optional): Force the update. Defaults to False.
+        priority (Priority, optional): The priority of the job. Defaults to Priority.NORMAL.
 
     Returns: None.
 
@@ -45,7 +47,7 @@ def update_dataset(
     logging.debug(f"refresh dataset='{dataset}'")
     for init_processing_step in init_processing_steps:
         if init_processing_step.input_type == "dataset":
-            Queue(type=init_processing_step.job_type).upsert_job(dataset=dataset, force=force)
+            Queue(type=init_processing_step.job_type).upsert_job(dataset=dataset, force=force, priority=priority)
 
 
 def delete_dataset(dataset: str) -> None:
@@ -68,6 +70,7 @@ def move_dataset(
     hf_endpoint: str,
     hf_token: Optional[str] = None,
     force: bool = False,
+    priority: Priority = Priority.NORMAL,
 ) -> None:
     """
     Move a dataset
@@ -82,6 +85,7 @@ def move_dataset(
         hf_endpoint (str): the HF endpoint
         hf_token (Optional[str], optional): The HF token. Defaults to None.
         force (bool, optional): Force the update. Defaults to False.
+        priority (Priority, optional): The priority of the job. Defaults to Priority.NORMAL.
 
     Returns: None.
 
@@ -95,6 +99,7 @@ def move_dataset(
         hf_endpoint=hf_endpoint,
         hf_token=hf_token,
         force=force,
+        priority=priority,
     )
     # ^ can raise
     delete_dataset(dataset=from_dataset)
@@ -142,6 +147,8 @@ def check_in_process(
                 init_processing_steps=init_processing_steps,
                 hf_endpoint=hf_endpoint,
                 hf_token=hf_token,
+                force=False,
+                priority=Priority.NORMAL,
             )
             return
         if result["http_status"] != HTTPStatus.OK:
@@ -153,5 +160,7 @@ def check_in_process(
         init_processing_steps=init_processing_steps,
         hf_endpoint=hf_endpoint,
         hf_token=hf_token,
+        force=False,
+        priority=Priority.NORMAL,
     )
     return

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -71,6 +71,7 @@ class JobInfo(TypedDict):
     config: Optional[str]
     split: Optional[str]
     force: bool
+    priority: Priority
 
 
 class CountByStatus(TypedDict):
@@ -379,6 +380,7 @@ class Queue:
             "config": next_waiting_job.config,
             "split": next_waiting_job.split,
             "force": next_waiting_job.force,
+            "priority": next_waiting_job.priority,
         }
 
     def finish_job(self, job_id: str, finished_status: Literal[Status.SUCCESS, Status.ERROR, Status.SKIPPED]) -> None:

--- a/services/admin/src/admin/app.py
+++ b/services/admin/src/admin/app.py
@@ -11,11 +11,11 @@ from starlette_prometheus import PrometheusMiddleware
 
 from admin.config import AppConfig, UvicornConfig
 from admin.prometheus import Prometheus
+from admin.routes.backfill import create_backfill_endpoint
 from admin.routes.cache_reports import create_cache_reports_endpoint
 from admin.routes.cache_reports_with_content import (
     create_cache_reports_with_content_endpoint,
 )
-from admin.routes.backfill import create_backfill_endpoint
 from admin.routes.cancel_jobs import create_cancel_jobs_endpoint
 from admin.routes.force_refresh import create_force_refresh_endpoint
 from admin.routes.healthcheck import healthcheck_endpoint

--- a/services/admin/src/admin/app.py
+++ b/services/admin/src/admin/app.py
@@ -15,6 +15,7 @@ from admin.routes.cache_reports import create_cache_reports_endpoint
 from admin.routes.cache_reports_with_content import (
     create_cache_reports_with_content_endpoint,
 )
+from admin.routes.backfill import create_backfill_endpoint
 from admin.routes.cancel_jobs import create_cancel_jobs_endpoint
 from admin.routes.force_refresh import create_force_refresh_endpoint
 from admin.routes.healthcheck import healthcheck_endpoint
@@ -64,6 +65,19 @@ def create_app() -> Starlette:
                 methods=["POST"],
             )
             for processing_step in processing_steps
+        ]
+        + [
+            Route(
+                "/backfill",
+                endpoint=create_backfill_endpoint(
+                    init_processing_steps=app_config.processing_graph.graph.get_first_steps(),
+                    hf_endpoint=app_config.common.hf_endpoint,
+                    hf_token=app_config.common.hf_token,
+                    external_auth_url=app_config.external_auth_url,
+                    organization=app_config.admin.hf_organization,
+                ),
+                methods=["POST"],
+            )
         ]
         + [
             Route(

--- a/services/admin/src/admin/routes/backfill.py
+++ b/services/admin/src/admin/routes/backfill.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+import logging
+from typing import Optional
+
+from libcommon.dataset import get_supported_datasets
+from libcommon.operations import update_dataset
+from libcommon.processing_graph import ProcessingStep
+from libcommon.queue import Priority
+from starlette.requests import Request
+from starlette.responses import Response
+
+from admin.authentication import auth_check
+from admin.utils import (
+    AdminCustomError,
+    Endpoint,
+    UnexpectedError,
+    get_json_admin_error_response,
+    get_json_ok_response,
+)
+
+
+def create_backfill_endpoint(
+    init_processing_steps: list[ProcessingStep],
+    hf_endpoint: str,
+    hf_token: Optional[str] = None,
+    external_auth_url: Optional[str] = None,
+    organization: Optional[str] = None,
+) -> Endpoint:
+    async def backfill_endpoint(request: Request) -> Response:
+        try:
+            logging.info("/backfill")
+
+            # if auth_check fails, it will raise an exception that will be caught below
+            auth_check(external_auth_url=external_auth_url, request=request, organization=organization)
+            for dataset in get_supported_datasets(hf_endpoint=hf_endpoint, hf_token=hf_token):
+                update_dataset(
+                    dataset=dataset,
+                    init_processing_steps=init_processing_steps,
+                    hf_endpoint=hf_endpoint,
+                    hf_token=hf_token,
+                    force=False,
+                    priority=Priority.LOW,
+                )
+            # ^ we simply ask an update for all the datasets on the Hub, supported by the datasets-server
+            # we could be more precise and only ask for updates for the datasets that have some missing
+            # cache entries, but it's not easy to check.
+            # Also: we could try to do a batch update of the database, instead of one query per dataset
+            return get_json_ok_response(
+                {"status": "ok"},
+                max_age=0,
+            )
+        except AdminCustomError as e:
+            return get_json_admin_error_response(e, max_age=0)
+        except Exception:
+            return get_json_admin_error_response(UnexpectedError("Unexpected error."), max_age=0)
+
+    return backfill_endpoint

--- a/services/api/src/api/routes/webhook.py
+++ b/services/api/src/api/routes/webhook.py
@@ -8,6 +8,7 @@ from jsonschema import ValidationError, validate  # type: ignore
 from libcommon.dataset import DatasetError
 from libcommon.operations import delete_dataset, move_dataset, update_dataset
 from libcommon.processing_graph import ProcessingStep
+from libcommon.queue import Priority
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -71,6 +72,7 @@ def process_payload(
             hf_endpoint=hf_endpoint,
             hf_token=hf_token,
             force=False,
+            priority=Priority.NORMAL,
         )
     elif event == "remove":
         delete_dataset(dataset=dataset)
@@ -85,6 +87,7 @@ def process_payload(
             hf_endpoint=hf_endpoint,
             hf_token=hf_token,
             force=False,
+            priority=Priority.NORMAL,
         )
 
 

--- a/workers/datasets_based/src/datasets_based/worker.py
+++ b/workers/datasets_based/src/datasets_based/worker.py
@@ -10,7 +10,7 @@ from libcommon.config import CommonConfig
 from libcommon.dataset import DatasetNotFoundError, get_dataset_git_revision
 from libcommon.exceptions import CustomError
 from libcommon.processing_graph import ProcessingStep
-from libcommon.queue import JobInfo, Queue, Status
+from libcommon.queue import JobInfo, Priority, Queue, Status
 from libcommon.simple_cache import (
     SplitFullName,
     delete_response,
@@ -106,7 +106,7 @@ class Worker(ABC):
     Args:
         job_info (:obj:`JobInfo`):
             The job to process. It contains the job_id, the job type, the dataset, the config, the split
-            and the force flag.
+            the force flag, and the priority level.
         common_config (:obj:`CommonConfig`):
             The common config.
         processing_step (:obj:`ProcessingStep`):
@@ -118,6 +118,7 @@ class Worker(ABC):
     config: Optional[str] = None
     split: Optional[str] = None
     force: bool
+    priority: Priority
     common_config: CommonConfig
     processing_step: ProcessingStep
 
@@ -143,6 +144,7 @@ class Worker(ABC):
         self.config = job_info["config"]
         self.split = job_info["split"]
         self.force = job_info["force"]
+        self.priority = job_info["priority"]
         self.common_config = common_config
         self.processing_step = processing_step
         self.setup()
@@ -379,6 +381,7 @@ class Worker(ABC):
                     config=split_full_name.config,
                     split=split_full_name.split,
                     force=self.force,
+                    priority=self.priority,
                 )
             logging.debug(
                 f"{len(new_split_full_names)} jobs"

--- a/workers/datasets_based/tests/test_worker_factory.py
+++ b/workers/datasets_based/tests/test_worker_factory.py
@@ -4,6 +4,7 @@
 from typing import Optional
 
 import pytest
+from libcommon.queue import Priority
 
 from datasets_based.config import AppConfig
 from datasets_based.worker import JobInfo
@@ -32,6 +33,7 @@ def test_create_worker(app_config: AppConfig, job_type: str, expected_worker: Op
         "split": "split",
         "job_id": "job_id",
         "force": False,
+        "priority": Priority.NORMAL,
     }
     if expected_worker is None:
         with pytest.raises(ValueError):

--- a/workers/datasets_based/tests/workers/test__datasets_based_worker.py
+++ b/workers/datasets_based/tests/workers/test__datasets_based_worker.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping, Optional
 
 import datasets.config
 import pytest
+from libcommon.queue import Priority
 
 from datasets_based.config import AppConfig
 from datasets_based.workers._datasets_based_worker import DatasetsBasedWorker
@@ -47,6 +48,7 @@ def get_worker(
             "split": split,
             "job_id": "job_id",
             "force": force,
+            "priority": Priority.NORMAL,
         },
         app_config=app_config,
     )

--- a/workers/datasets_based/tests/workers/test_config_names.py
+++ b/workers/datasets_based/tests/workers/test_config_names.py
@@ -6,6 +6,7 @@ from http import HTTPStatus
 
 import pytest
 from libcommon.exceptions import CustomError
+from libcommon.queue import Priority
 from libcommon.simple_cache import DoesNotExist, get_response
 
 from datasets_based.config import AppConfig
@@ -27,6 +28,7 @@ def get_worker(
             "split": None,
             "job_id": "job_id",
             "force": force,
+            "priority": Priority.NORMAL,
         },
         app_config=app_config,
     )

--- a/workers/datasets_based/tests/workers/test_dataset_info.py
+++ b/workers/datasets_based/tests/workers/test_dataset_info.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 from typing import Any
 
 import pytest
+from libcommon.queue import Priority
 from libcommon.simple_cache import _clean_cache_database, upsert_response
 
 from datasets_based.config import AppConfig
@@ -30,6 +31,7 @@ def get_worker(dataset: str, app_config: AppConfig, force: bool = False) -> Data
             "split": None,
             "job_id": "job_id",
             "force": force,
+            "priority": Priority.NORMAL,
         },
         app_config=app_config,
     )

--- a/workers/datasets_based/tests/workers/test_first_rows.py
+++ b/workers/datasets_based/tests/workers/test_first_rows.py
@@ -7,6 +7,7 @@ from http import HTTPStatus
 import pytest
 from datasets.packaged_modules import csv
 from libcommon.exceptions import CustomError
+from libcommon.queue import Priority
 from libcommon.simple_cache import DoesNotExist, get_response
 
 from datasets_based.config import AppConfig, FirstRowsConfig
@@ -31,6 +32,7 @@ def get_worker(
             "split": split,
             "job_id": "job_id",
             "force": force,
+            "priority": Priority.NORMAL,
         },
         app_config=app_config,
         first_rows_config=first_rows_config,

--- a/workers/datasets_based/tests/workers/test_parquet.py
+++ b/workers/datasets_based/tests/workers/test_parquet.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 from typing import Any
 
 import pytest
+from libcommon.queue import Priority
 from libcommon.simple_cache import _clean_cache_database, upsert_response
 
 from datasets_based.config import AppConfig
@@ -30,6 +31,7 @@ def get_worker(dataset: str, app_config: AppConfig, force: bool = False) -> Parq
             "split": None,
             "job_id": "job_id",
             "force": force,
+            "priority": Priority.NORMAL,
         },
         app_config=app_config,
     )

--- a/workers/datasets_based/tests/workers/test_parquet_and_dataset_info.py
+++ b/workers/datasets_based/tests/workers/test_parquet_and_dataset_info.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 import requests
 from libcommon.exceptions import CustomError
+from libcommon.queue import Priority
 from libcommon.simple_cache import DoesNotExist, get_response
 
 from datasets_based.config import AppConfig, ParquetAndDatasetInfoConfig
@@ -65,6 +66,7 @@ def get_worker(
             "split": None,
             "job_id": "job_id",
             "force": force,
+            "priority": Priority.NORMAL,
         },
         app_config=app_config,
         parquet_and_dataset_info_config=parquet_and_dataset_info_config,

--- a/workers/datasets_based/tests/workers/test_sizes.py
+++ b/workers/datasets_based/tests/workers/test_sizes.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 from typing import Any
 
 import pytest
+from libcommon.queue import Priority
 from libcommon.simple_cache import _clean_cache_database, upsert_response
 
 from datasets_based.config import AppConfig
@@ -30,6 +31,7 @@ def get_worker(dataset: str, app_config: AppConfig, force: bool = False) -> Size
             "split": None,
             "job_id": "job_id",
             "force": force,
+            "priority": Priority.NORMAL,
         },
         app_config=app_config,
     )

--- a/workers/datasets_based/tests/workers/test_split_names.py
+++ b/workers/datasets_based/tests/workers/test_split_names.py
@@ -6,6 +6,7 @@ from http import HTTPStatus
 
 import pytest
 from libcommon.exceptions import CustomError
+from libcommon.queue import Priority
 from libcommon.simple_cache import DoesNotExist, get_response
 
 from datasets_based.config import AppConfig
@@ -28,6 +29,7 @@ def get_worker(
             "split": None,
             "job_id": "job_id",
             "force": force,
+            "priority": Priority.NORMAL,
         },
         app_config=app_config,
     )

--- a/workers/datasets_based/tests/workers/test_splits.py
+++ b/workers/datasets_based/tests/workers/test_splits.py
@@ -6,6 +6,7 @@ from http import HTTPStatus
 
 import pytest
 from libcommon.exceptions import CustomError
+from libcommon.queue import Priority
 from libcommon.simple_cache import DoesNotExist, get_response
 
 from datasets_based.config import AppConfig
@@ -27,6 +28,7 @@ def get_worker(
             "split": None,
             "job_id": "job_id",
             "force": force,
+            "priority": Priority.NORMAL,
         },
         app_config=app_config,
     )


### PR DESCRIPTION
The logic is very basic: it updates all the datasets of the Hub, with a low priority. Note that most of the jobs will be skipped, because the response will already be in the cache.

We might want to take a more detailed approach later to reduce the number of unnecessary jobs by specifically creating jobs for the missing data only.

Apart of this, the PR also fixes the creation of children jobs: the priority is preserved (ie low priority jobs created low priority children jobs)