### PR TITLE
fix: 🐛 don't check if dataset is supported when we know it is

### DIFF
--- a/.github/workflows/_unit-tests-python.yml
+++ b/.github/workflows/_unit-tests-python.yml
@@ -59,5 +59,5 @@ jobs:
         with:
           working-directory: ${{ inputs.working-directory }}
           files: ./coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           flags: ${{ env.codecov_flag }}

--- a/libs/libcommon/src/libcommon/dataset.py
+++ b/libs/libcommon/src/libcommon/dataset.py
@@ -216,4 +216,8 @@ def check_support(
 
 
 def get_supported_datasets(hf_endpoint: str, hf_token: Optional[str] = None) -> list[str]:
-    return [d.id for d in HfApi(endpoint=hf_endpoint, token=hf_token).list_datasets() if d.id is not None]
+    return [
+        d.id
+        for d in HfApi(endpoint=hf_endpoint, token=hf_token).list_datasets()
+        if d.id is not None and d.private is False
+    ]

--- a/libs/libcommon/src/libcommon/dataset.py
+++ b/libs/libcommon/src/libcommon/dataset.py
@@ -219,5 +219,5 @@ def get_supported_datasets(hf_endpoint: str, hf_token: Optional[str] = None) -> 
     return [
         d.id
         for d in HfApi(endpoint=hf_endpoint, token=hf_token).list_datasets()
-        if d.id is not None and d.private is False
+        if d.id and not d.private
     ]

--- a/libs/libcommon/src/libcommon/dataset.py
+++ b/libs/libcommon/src/libcommon/dataset.py
@@ -216,8 +216,4 @@ def check_support(
 
 
 def get_supported_datasets(hf_endpoint: str, hf_token: Optional[str] = None) -> list[str]:
-    return [
-        d.id
-        for d in HfApi(endpoint=hf_endpoint, token=hf_token).list_datasets()
-        if d.id and not d.private
-    ]
+    return [d.id for d in HfApi(endpoint=hf_endpoint, token=hf_token).list_datasets() if d.id and not d.private]

--- a/libs/libcommon/src/libcommon/operations.py
+++ b/libs/libcommon/src/libcommon/operations.py
@@ -26,7 +26,7 @@ def update_dataset(
     hf_token: Optional[str] = None,
     force: bool = False,
     priority: Priority = Priority.NORMAL,
-    skip_check_support: bool = False,
+    do_check_support: bool = True,
 ) -> None:
     """
     Update a dataset
@@ -38,14 +38,14 @@ def update_dataset(
         hf_token (Optional[str], optional): The HF token. Defaults to None.
         force (bool, optional): Force the update. Defaults to False.
         priority (Priority, optional): The priority of the job. Defaults to Priority.NORMAL.
-        skip_check_support (bool, optional): Skip the check if the dataset is supported. Defaults to False.
+        do_check_support (bool, optional): Check if the dataset is supported. Defaults to True.
 
     Returns: None.
 
     Raises:
         - [`~libcommon.dataset.DatasetError`]: if the dataset could not be accessed or is not supported
     """
-    if not skip_check_support:
+    if do_check_support:
         check_support(dataset=dataset, hf_endpoint=hf_endpoint, hf_token=hf_token)
     logging.debug(f"refresh dataset='{dataset}'")
     for init_processing_step in init_processing_steps:

--- a/libs/libcommon/src/libcommon/operations.py
+++ b/libs/libcommon/src/libcommon/operations.py
@@ -26,6 +26,7 @@ def update_dataset(
     hf_token: Optional[str] = None,
     force: bool = False,
     priority: Priority = Priority.NORMAL,
+    skip_check_support: bool = False,
 ) -> None:
     """
     Update a dataset
@@ -37,13 +38,15 @@ def update_dataset(
         hf_token (Optional[str], optional): The HF token. Defaults to None.
         force (bool, optional): Force the update. Defaults to False.
         priority (Priority, optional): The priority of the job. Defaults to Priority.NORMAL.
+        skip_check_support (bool, optional): Skip the check if the dataset is supported. Defaults to False.
 
     Returns: None.
 
     Raises:
         - [`~libcommon.dataset.DatasetError`]: if the dataset could not be accessed or is not supported
     """
-    check_support(dataset=dataset, hf_endpoint=hf_endpoint, hf_token=hf_token)
+    if not skip_check_support:
+        check_support(dataset=dataset, hf_endpoint=hf_endpoint, hf_token=hf_token)
     logging.debug(f"refresh dataset='{dataset}'")
     for init_processing_step in init_processing_steps:
         if init_processing_step.input_type == "dataset":

--- a/services/admin/src/admin/routes/backfill.py
+++ b/services/admin/src/admin/routes/backfill.py
@@ -42,7 +42,7 @@ def create_backfill_endpoint(
                     hf_token=hf_token,
                     force=False,
                     priority=Priority.LOW,
-                    skip_check_support=True,
+                    do_check_support=False,
                 )
             # ^ we simply ask an update for all the datasets on the Hub, supported by the datasets-server
             # we could be more precise and only ask for updates for the datasets that have some missing

--- a/services/admin/src/admin/routes/backfill.py
+++ b/services/admin/src/admin/routes/backfill.py
@@ -42,6 +42,7 @@ def create_backfill_endpoint(
                     hf_token=hf_token,
                     force=False,
                     priority=Priority.LOW,
+                    skip_check_support=True,
                 )
             # ^ we simply ask an update for all the datasets on the Hub, supported by the datasets-server
             # we could be more precise and only ask for updates for the datasets that have some missing


### PR DESCRIPTION
As we are running a loop of updates on supported datasets, it's useless to check if the dataset is supported inside the `update_dataset` method.