### PR TITLE
feat: 🎸 adapt number of replicas to flush the queues

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -276,7 +276,7 @@ firstRows:
 
   nodeSelector:
     role-datasets-server: "true"
-  replicas: 60
+  replicas: 90
   resources:
     requests:
       cpu: 1

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -222,7 +222,7 @@ configNames:
 
   nodeSelector:
     role-datasets-server: "true"
-  replicas: 6
+  replicas: 8
   resources:
     requests:
       cpu: 1
@@ -239,7 +239,7 @@ splitNames:
 
   nodeSelector:
     role-datasets-server: "true"
-  replicas: 8
+  replicas: 12
   resources:
     requests:
       cpu: 1

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -222,7 +222,7 @@ configNames:
 
   nodeSelector:
     role-datasets-server: "true"
-  replicas: 8
+  replicas: 6
   resources:
     requests:
       cpu: 1
@@ -239,7 +239,7 @@ splitNames:
 
   nodeSelector:
     role-datasets-server: "true"
-  replicas: 12
+  replicas: 8
   resources:
     requests:
       cpu: 1
@@ -256,7 +256,7 @@ splits:
 
   nodeSelector:
     role-datasets-server: "true"
-  replicas: 12
+  replicas: 8
   resources:
     requests:
       cpu: 1
@@ -276,7 +276,7 @@ firstRows:
 
   nodeSelector:
     role-datasets-server: "true"
-  replicas: 24
+  replicas: 60
   resources:
     requests:
       cpu: 1
@@ -298,7 +298,7 @@ parquetAndDatasetInfo:
     maxJobsPerNamespace: 4
   nodeSelector:
     role-datasets-server: "true"
-  replicas: 24
+  replicas: 30
   resources:
     requests:
       cpu: 1
@@ -315,7 +315,7 @@ parquet:
     maxJobsPerNamespace: 2
   nodeSelector:
     role-datasets-server: "true"
-  replicas: 4
+  replicas: 2
   resources:
     requests:
       cpu: 1
@@ -332,7 +332,7 @@ datasetInfo:
     maxJobsPerNamespace: 2
   nodeSelector:
     role-datasets-server: "true"
-  replicas: 4
+  replicas: 2
   resources:
     requests:
       cpu: 1
@@ -349,7 +349,7 @@ sizes:
     maxJobsPerNamespace: 2
   nodeSelector:
     role-datasets-server: "true"
-  replicas: 4
+  replicas: 2
   resources:
     requests:
       cpu: 1


### PR DESCRIPTION
<img width="394" alt="Capture d’écran 2023-01-31 à 09 59 04" src="https://user-images.githubusercontent.com/1676121/215714662-1ede53b7-f50f-4a10-a367-115d49728e9b.png">


Current status: https://grafana.huggingface.tech/d/i7gwsO5Vz/global-view?orgId=1&from=now-15m&to=now&refresh=1m&var-slo_quantile_99_5=0.995&var-slo_quantile_85=0.85&var-slo_period=7d

A lot of jobs in /first-rows (critical for the Hub) and /parquet-and-dataset-info (less critical for now, only for parquet files)