### PR TITLE
update the logic to skip a job

### DIFF
--- a/workers/datasets_based/src/datasets_based/worker.py
+++ b/workers/datasets_based/src/datasets_based/worker.py
@@ -12,6 +12,7 @@ from libcommon.exceptions import CustomError
 from libcommon.processing_graph import ProcessingStep
 from libcommon.queue import JobInfo, Priority, Queue, Status
 from libcommon.simple_cache import (
+    DoesNotExist,
     SplitFullName,
     delete_response,
     get_response,
@@ -27,6 +28,9 @@ WorkerErrorCode = Literal[
     "SplitNotFoundError",
     "UnexpectedError",
 ]
+
+# List of error codes that should trigger a retry.
+ERROR_CODES_TO_RETRY: list[str] = ["ClientConnectionError"]
 
 
 class WorkerError(CustomError):
@@ -218,52 +222,48 @@ class Worker(ABC):
             dataset=self.dataset, hf_endpoint=self.common_config.hf_endpoint, hf_token=self.common_config.hf_token
         )
 
-    def _should_process_job(self) -> bool:
-        """Return True if the job should be processed, False otherwise.
-
-        The job must be processed if:
-        - force is True
-        - or no cache entry exists for the dataset
-        - or the result was not successful
-        - or it has been created with the another major version of the worker
-        - or it has been created with the another git commit of the dataset repository
-        - or an exception occurred in this function (bad idea)
-
-        Returns:
-            :obj:`bool`: True if the job should be processed, False otherwise.
-        """
-        if self.force:
-            return True
-        try:
-            cached_response = get_response_without_content(
-                kind=self.processing_step.cache_kind, dataset=self.dataset, config=self.config, split=self.split
-            )
-            dataset_git_revision = self.get_dataset_git_revision()
-            return (
-                # TODO: use "error_code" to decide if the job should be skipped (ex: retry if temporary error)
-                cached_response["http_status"] != HTTPStatus.OK
-                or cached_response["worker_version"] is None
-                or self.compare_major_version(cached_response["worker_version"]) != 0
-                or cached_response["dataset_git_revision"] is None
-                or cached_response["dataset_git_revision"] != dataset_git_revision
-            )
-        except Exception:
-            return True
-
+    # TODO: set the git revision as part of the job_info -> no need to get info from the Hub
+    # if None: run the job
     def should_skip_job(self) -> bool:
         """Return True if the job should be skipped, False otherwise.
 
         The job must be skipped if:
         - force is False
         - and a cache entry exists for the dataset
-        - and the result was successful
-        - and it has been created with the same major version of the worker
-        - and it has been created with the exact same git commit of the dataset repository
+        - and we can get the git commit and it's not None
+        - and the cached entry has been created with the same git commit of the dataset repository
+        - and the cached entry has been created with the same major version of the worker
+        - and the cached entry, if an error, is not among the list of errors that should trigger a retry
 
         Returns:
             :obj:`bool`: True if the job should be skipped, False otherwise.
         """
-        return not self._should_process_job()
+        if self.force:
+            return False
+        try:
+            cached_response = get_response_without_content(
+                kind=self.processing_step.cache_kind, dataset=self.dataset, config=self.config, split=self.split
+            )
+        except DoesNotExist:
+            # no entry in the cache
+            return False
+        if cached_response["error_code"] in ERROR_CODES_TO_RETRY:
+            # the cache entry result was a temporary error - we process it
+            return False
+        if (
+            cached_response["worker_version"] is None
+            or self.compare_major_version(cached_response["worker_version"]) != 0
+        ):
+            # no worker version in the cache, or the worker has been updated - we process the job to update the cache
+            return False
+        try:
+            dataset_git_revision = self.get_dataset_git_revision()
+        except Exception:
+            # an exception occurred while getting the git revision from the Hub - the job will fail anyway, but we
+            # process it to store the error in the cache
+            return False
+        return dataset_git_revision is not None and cached_response["dataset_git_revision"] == dataset_git_revision
+        # skip if the git revision has not changed
 
     def process(
         self,

--- a/workers/datasets_based/tests/test_worker.py
+++ b/workers/datasets_based/tests/test_worker.py
@@ -1,13 +1,15 @@
+from dataclasses import dataclass
+from http import HTTPStatus
 from typing import Any, Mapping, Optional
 
 import pytest
 from libcommon.config import CommonConfig
 from libcommon.processing_graph import ProcessingGraph, ProcessingStep
 from libcommon.queue import Priority, Queue, Status
-from libcommon.simple_cache import SplitFullName
+from libcommon.simple_cache import SplitFullName, upsert_response
 
 from datasets_based.config import AppConfig
-from datasets_based.worker import Worker
+from datasets_based.worker import ERROR_CODES_TO_RETRY, Worker
 
 
 @pytest.fixture(autouse=True)
@@ -19,6 +21,10 @@ def prepare_and_clean_mongo(app_config: AppConfig) -> None:
 class DummyWorker(Worker):
     # override get_dataset_git_revision to avoid making a request to the Hub
     def get_dataset_git_revision(self) -> Optional[str]:
+        return DummyWorker._get_dataset_git_revision()
+
+    @staticmethod
+    def _get_dataset_git_revision() -> Optional[str]:
         return "0.1.2"
 
     @staticmethod
@@ -76,14 +82,103 @@ def test_compare_major_version(
         assert worker.compare_major_version(other_version) == expected
 
 
+@dataclass
+class CacheEntry:
+    error_code: Optional[str]
+    worker_version: Optional[str]
+    dataset_git_revision: Optional[str]
+
+
+# .get_version()
+@pytest.mark.parametrize(
+    "force,cache_entry,expected_skip",
+    [
+        (
+            False,
+            CacheEntry(
+                error_code="DoNotRetry",  # an error that we don't want to retry
+                worker_version=DummyWorker.get_version(),
+                dataset_git_revision=DummyWorker._get_dataset_git_revision(),
+            ),
+            True,  # skip
+        ),
+        (
+            False,
+            CacheEntry(
+                error_code=None,  # no error
+                worker_version=DummyWorker.get_version(),
+                dataset_git_revision=DummyWorker._get_dataset_git_revision(),
+            ),
+            True,  # skip
+        ),
+        (
+            True,  # force
+            CacheEntry(
+                error_code="DoNotRetry",
+                worker_version=DummyWorker.get_version(),
+                dataset_git_revision=DummyWorker._get_dataset_git_revision(),
+            ),
+            False,  # process
+        ),
+        (
+            False,
+            None,  # no cache entry
+            False,  # process
+        ),
+        (
+            False,
+            CacheEntry(
+                error_code=ERROR_CODES_TO_RETRY[0],  # an error that we want to retry
+                worker_version=DummyWorker.get_version(),
+                dataset_git_revision=DummyWorker._get_dataset_git_revision(),
+            ),
+            False,  # process
+        ),
+        (
+            False,
+            CacheEntry(
+                error_code="DoNotRetry",
+                worker_version=None,  # no worker version
+                dataset_git_revision=DummyWorker._get_dataset_git_revision(),
+            ),
+            False,  # process
+        ),
+        (
+            False,
+            CacheEntry(
+                error_code="DoNotRetry",
+                worker_version="0.0.1",  # a different worker version
+                dataset_git_revision=DummyWorker._get_dataset_git_revision(),
+            ),
+            False,  # process
+        ),
+        (
+            False,
+            CacheEntry(
+                error_code="DoNotRetry",
+                worker_version=DummyWorker.get_version(),
+                dataset_git_revision=None,  # no dataset git revision
+            ),
+            False,  # process
+        ),
+        (
+            False,
+            CacheEntry(
+                error_code="DoNotRetry",
+                worker_version=DummyWorker.get_version(),
+                dataset_git_revision="different",  # a different dataset git revision
+            ),
+            False,  # process
+        ),
+    ],
+)
 def test_should_skip_job(
-    test_processing_step: ProcessingStep,
+    test_processing_step: ProcessingStep, force: bool, cache_entry: Optional[CacheEntry], expected_skip: bool
 ) -> None:
     job_id = "job_id"
     dataset = "dataset"
     config = "config"
     split = "split"
-    force = False
     worker = DummyWorker(
         job_info={
             "job_id": job_id,
@@ -97,10 +192,20 @@ def test_should_skip_job(
         processing_step=test_processing_step,
         common_config=CommonConfig(),
     )
-    assert worker.should_skip_job() is False
-    # we add an entry to the cache
-    worker.process()
-    assert worker.should_skip_job() is True
+    if cache_entry:
+        upsert_response(
+            kind=test_processing_step.cache_kind,
+            dataset=dataset,
+            config=config,
+            split=split,
+            content={},
+            http_status=HTTPStatus.OK,  # <- not important
+            error_code=cache_entry.error_code,
+            details=None,
+            worker_version=cache_entry.worker_version,
+            dataset_git_revision=cache_entry.dataset_git_revision,
+        )
+    assert worker.should_skip_job() is expected_skip
 
 
 def test_check_type(


### PR DESCRIPTION
Instead of retrying for any non-successful response in the cache, we
only retry if the error is in the list of "retry-able" errors. Also:
refactor the logic and add complete tests