### PR TITLE
Create doc for every PR

### DIFF
--- a/.github/workflows/doc-pr-build.yml
+++ b/.github/workflows/doc-pr-build.yml
@@ -5,9 +5,6 @@ name: Build PR Documentation
 
 on:
   pull_request:
-    paths:
-      - 'docs/**'
-      - '.github/workflows/doc-pr-build.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
This is what is done in the other HF repos on github.

This way the Delete doc github action has something to delete.
If the doc doesn't exists, the job fails