### PR TITLE
Fix CI mypy error: "WorkerFactory" has no attribute "app_config"

### DIFF
--- a/workers/datasets_based/src/datasets_based/worker_loop.py
+++ b/workers/datasets_based/src/datasets_based/worker_loop.py
@@ -10,7 +10,7 @@ from libcommon.config import WorkerLoopConfig
 from libcommon.queue import EmptyQueueError, Queue
 from psutil import cpu_count, disk_usage, getloadavg, swap_memory, virtual_memory
 
-from datasets_based.worker_factory import DatasetBasedWorkerFactory
+from datasets_based.worker import WorkerFactory
 
 
 @dataclass
@@ -31,7 +31,7 @@ class WorkerLoop:
     """
 
     queue: Queue
-    worker_factory: DatasetBasedWorkerFactory
+    worker_factory: WorkerFactory
     worker_loop_config: WorkerLoopConfig
 
     def log(self, level: int, msg: str) -> None:

--- a/workers/datasets_based/src/datasets_based/worker_loop.py
+++ b/workers/datasets_based/src/datasets_based/worker_loop.py
@@ -10,7 +10,7 @@ from libcommon.config import WorkerLoopConfig
 from libcommon.queue import EmptyQueueError, Queue
 from psutil import cpu_count, disk_usage, getloadavg, swap_memory, virtual_memory
 
-from datasets_based.worker import WorkerFactory
+from datasets_based.worker_factory import DatasetBasedWorkerFactory
 
 
 @dataclass
@@ -31,7 +31,7 @@ class WorkerLoop:
     """
 
     queue: Queue
-    worker_factory: WorkerFactory
+    worker_factory: DatasetBasedWorkerFactory
     worker_loop_config: WorkerLoopConfig
 
     def log(self, level: int, msg: str) -> None:

--- a/workers/datasets_based/src/datasets_based/worker_loop.py
+++ b/workers/datasets_based/src/datasets_based/worker_loop.py
@@ -97,7 +97,6 @@ class WorkerLoop:
         time.sleep(duration)
 
     def loop(self) -> None:
-        self.info(f"Using endpoint {self.worker_factory.app_config.common.hf_endpoint}")
         self.info("Worker started")
         try:
             while True:

--- a/workers/datasets_based/tests/test_worker_loop.py
+++ b/workers/datasets_based/tests/test_worker_loop.py
@@ -6,7 +6,8 @@ from libcommon.processing_graph import ProcessingStep
 from libcommon.queue import Queue
 
 from datasets_based.config import AppConfig
-from datasets_based.worker import JobInfo, Worker, WorkerFactory
+from datasets_based.worker import JobInfo, Worker
+from datasets_based.worker_factory import DatasetBasedWorkerFactory
 from datasets_based.worker_loop import WorkerLoop
 
 
@@ -33,8 +34,9 @@ class DummyWorker(Worker):
         return {"key": "value"}
 
 
-class DummyWorkerFactory(WorkerFactory):
-    def __init__(self, processing_step: ProcessingStep) -> None:
+class DummyWorkerFactory(DatasetBasedWorkerFactory):
+    def __init__(self, app_config: AppConfig, processing_step: ProcessingStep) -> None:
+        self.app_config = app_config
         self.common_config = CommonConfig()
         self.processing_step = processing_step
 
@@ -43,10 +45,11 @@ class DummyWorkerFactory(WorkerFactory):
 
 
 def test_process_next_job(
+    app_config: AppConfig,
     test_processing_step: ProcessingStep,
     queue_config: QueueConfig,
 ) -> None:
-    worker_factory = DummyWorkerFactory(processing_step=test_processing_step)
+    worker_factory = DummyWorkerFactory(app_config=app_config, processing_step=test_processing_step)
     queue = Queue(type=test_processing_step.endpoint, max_jobs_per_namespace=queue_config.max_jobs_per_namespace)
     worker_loop = WorkerLoop(
         worker_factory=worker_factory,

--- a/workers/datasets_based/tests/test_worker_loop.py
+++ b/workers/datasets_based/tests/test_worker_loop.py
@@ -6,8 +6,7 @@ from libcommon.processing_graph import ProcessingStep
 from libcommon.queue import Queue
 
 from datasets_based.config import AppConfig
-from datasets_based.worker import JobInfo, Worker
-from datasets_based.worker_factory import DatasetBasedWorkerFactory
+from datasets_based.worker import JobInfo, Worker, WorkerFactory
 from datasets_based.worker_loop import WorkerLoop
 
 
@@ -34,9 +33,8 @@ class DummyWorker(Worker):
         return {"key": "value"}
 
 
-class DummyWorkerFactory(DatasetBasedWorkerFactory):
-    def __init__(self, app_config: AppConfig, processing_step: ProcessingStep) -> None:
-        self.app_config = app_config
+class DummyWorkerFactory(WorkerFactory):
+    def __init__(self, processing_step: ProcessingStep) -> None:
         self.common_config = CommonConfig()
         self.processing_step = processing_step
 
@@ -45,11 +43,10 @@ class DummyWorkerFactory(DatasetBasedWorkerFactory):
 
 
 def test_process_next_job(
-    app_config: AppConfig,
     test_processing_step: ProcessingStep,
     queue_config: QueueConfig,
 ) -> None:
-    worker_factory = DummyWorkerFactory(app_config=app_config, processing_step=test_processing_step)
+    worker_factory = DummyWorkerFactory(processing_step=test_processing_step)
     queue = Queue(type=test_processing_step.endpoint, max_jobs_per_namespace=queue_config.max_jobs_per_namespace)
     worker_loop = WorkerLoop(
         worker_factory=worker_factory,


### PR DESCRIPTION
Fix type checking on WorkerLoop.loop method, when tryin to access the worker_factory's attribute app_config.

This PR fixes an issue introduced by:
- #774

```
src/datasets_based/worker_loop.py:100: error: "WorkerFactory" has no attribute "app_config"
```