### PR TITLE
feat: 🎸 add a new admin endpoint: /dataset-status

### DIFF
--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -584,6 +584,18 @@ class Queue:
             )
         }
 
+    def get_dataset_pending_jobs_for_type(self, dataset: str, job_type: str) -> List[JobDict]:
+        """Get the pending jobs of a dataset for a given job type.
+
+        Returns: an array of the pending jobs for the dataset and the given job type
+        """
+        return [
+            d.to_dict()
+            for d in Job.objects(
+                type=job_type, dataset=dataset, status__in=[Status.WAITING.value, Status.STARTED.value]
+            )
+        ]
+
 
 # only for the tests
 def _clean_queue_database() -> None:

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -177,6 +177,21 @@ def get_response_without_content(
     }
 
 
+def get_dataset_responses_without_content_for_kind(kind: str, dataset: str) -> List[CacheEntryWithoutContent]:
+    responses = CachedResponse.objects(kind=kind, dataset=dataset).only(
+        "http_status", "error_code", "worker_version", "dataset_git_revision"
+    )
+    return [
+        {
+            "http_status": response.http_status,
+            "error_code": response.error_code,
+            "worker_version": response.worker_version,
+            "dataset_git_revision": response.dataset_git_revision,
+        }
+        for response in responses
+    ]
+
+
 class CacheEntry(CacheEntryWithoutContent):
     content: Mapping[str, Any]
 

--- a/services/admin/src/admin/app.py
+++ b/services/admin/src/admin/app.py
@@ -21,6 +21,7 @@ from admin.routes.cache_reports_with_content import (
     create_cache_reports_with_content_endpoint,
 )
 from admin.routes.cancel_jobs import create_cancel_jobs_endpoint
+from admin.routes.dataset_status import create_dataset_status_endpoint
 from admin.routes.force_refresh import create_force_refresh_endpoint
 from admin.routes.healthcheck import healthcheck_endpoint
 from admin.routes.jobs_duration import create_jobs_duration_per_dataset_endpoint
@@ -65,6 +66,15 @@ def create_app() -> Starlette:
             Route(
                 "/pending-jobs",
                 endpoint=create_pending_jobs_endpoint(
+                    processing_steps=processing_steps,
+                    max_age=app_config.admin.max_age,
+                    external_auth_url=app_config.admin.external_auth_url,
+                    organization=app_config.admin.hf_organization,
+                ),
+            ),
+            Route(
+                "/dataset-status",
+                endpoint=create_dataset_status_endpoint(
                     processing_steps=processing_steps,
                     max_age=app_config.admin.max_age,
                     external_auth_url=app_config.admin.external_auth_url,

--- a/services/admin/src/admin/routes/dataset_status.py
+++ b/services/admin/src/admin/routes/dataset_status.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+import logging
+from typing import List, Optional
+
+from libcommon.processing_graph import ProcessingStep
+from libcommon.queue import Queue
+from libcommon.simple_cache import get_dataset_responses_without_content_for_kind
+from starlette.requests import Request
+from starlette.responses import Response
+
+from admin.authentication import auth_check
+from admin.utils import (
+    AdminCustomError,
+    Endpoint,
+    MissingRequiredParameterError,
+    UnexpectedError,
+    are_valid_parameters,
+    get_json_admin_error_response,
+    get_json_ok_response,
+)
+
+
+def create_dataset_status_endpoint(
+    processing_steps: List[ProcessingStep],
+    max_age: int,
+    external_auth_url: Optional[str] = None,
+    organization: Optional[str] = None,
+) -> Endpoint:
+    async def dataset_status_endpoint(request: Request) -> Response:
+        try:
+            dataset = request.query_params.get("dataset")
+            if not are_valid_parameters([dataset]):
+                raise MissingRequiredParameterError("Parameter 'dataset' is required")
+            logging.info(f"/dataset-status, dataset={dataset}")
+
+            # if auth_check fails, it will raise an exception that will be caught below
+            auth_check(external_auth_url=external_auth_url, request=request, organization=organization)
+            queue = Queue()
+            return get_json_ok_response(
+                {
+                    processing_step.endpoint: {
+                        "cached_responses": get_dataset_responses_without_content_for_kind(
+                            kind=processing_step.cache_kind, dataset=dataset
+                        ),
+                        "jobs": queue.get_dataset_pending_jobs_for_type(
+                            dataset=dataset, job_type=processing_step.job_type
+                        ),
+                    }
+                    for processing_step in processing_steps
+                },
+                max_age=max_age,
+            )
+        except AdminCustomError as e:
+            return get_json_admin_error_response(e, max_age=max_age)
+        except Exception as e:
+            return get_json_admin_error_response(UnexpectedError("Unexpected error.", e), max_age=max_age)
+
+    return dataset_status_endpoint

--- a/services/admin/tests/test_app.py
+++ b/services/admin/tests/test_app.py
@@ -70,6 +70,17 @@ def test_pending_jobs(client: TestClient, processing_steps: List[ProcessingStep]
         assert json[processing_step.job_type] == {"waiting": [], "started": []}
 
 
+def test_dataset_status(client: TestClient, processing_steps: List[ProcessingStep]) -> None:
+    response = client.get("/dataset-status")
+    assert response.status_code == 422
+    response = client.get("/dataset-status", params={"dataset": "test-dataset"})
+    assert response.status_code == 200
+    json = response.json()
+    for processing_step in processing_steps:
+        assert not json[processing_step.job_type]["cached_responses"]
+        assert not json[processing_step.job_type]["jobs"]
+
+
 @pytest.mark.parametrize(
     "cursor,http_status,error_code",
     [


### PR DESCRIPTION
While looking at https://github.com/huggingface/datasets-server/issues/764 and https://github.com/huggingface/datasets-server/issues/736#issuecomment-1412242342, I added a new admin endpoint that gives the current status of a dataset. I think it can help to get insights about a dataset when doing support manually.

It takes a `?dataset=` parameter, ie https://dataset-server.huggingface.co/admin/dataset-status?dataset=glue

As with all the admin endpoints, it requires being authenticated as part of the huggingface org.
