### PR TITLE
Kill zombies

### DIFF
--- a/services/worker/src/worker/config.py
+++ b/services/worker/src/worker/config.py
@@ -20,6 +20,8 @@ WORKER_MAX_LOAD_PCT = 70
 WORKER_MAX_MEMORY_PCT = 80
 WORKER_SLEEP_SECONDS = 15
 WORKER_HEARTBEAT_TIME_INTERVAL_SECONDS = 60
+WORKER_MAX_MISSING_HEARTBEATS = 5
+WORKER_KILL_ZOMBIES_TIME_INTERVAL_SECONDS = 10 * 60
 
 
 def get_empty_str_list() -> List[str]:
@@ -37,6 +39,8 @@ class WorkerConfig:
     storage_paths: List[str] = field(default_factory=get_empty_str_list)
     state_path: Optional[str] = None
     heartbeat_time_interval_seconds: int = WORKER_HEARTBEAT_TIME_INTERVAL_SECONDS
+    max_missing_heartbeats: int = WORKER_MAX_MISSING_HEARTBEATS
+    kill_zombies_time_interval_seconds: int = WORKER_KILL_ZOMBIES_TIME_INTERVAL_SECONDS
 
     @classmethod
     def from_env(cls) -> "WorkerConfig":
@@ -53,6 +57,10 @@ class WorkerConfig:
                 state_path=env.str(name="STATE_PATH", default=None),
                 heartbeat_time_interval_seconds=env.int(
                     name="HEARTBEAT_TIME_INTERVAL_SECONDS", default=WORKER_HEARTBEAT_TIME_INTERVAL_SECONDS
+                ),
+                max_missing_heartbeats=env.int(name="MAX_MISSING_HEARTBEATS", default=WORKER_MAX_MISSING_HEARTBEATS),
+                kill_zombies_time_interval_seconds=env.int(
+                    name="KILL_ZOMBIES_TIME_INTERVAL_SECONDS", default=WORKER_KILL_ZOMBIES_TIME_INTERVAL_SECONDS
                 ),
             )
 

--- a/services/worker/src/worker/main.py
+++ b/services/worker/src/worker/main.py
@@ -1,11 +1,13 @@
+import asyncio
 import json
 import logging
 import os
 import sys
 import tempfile
-import time
-from typing import Optional
+from datetime import timedelta
+from typing import Any, Callable, List, Optional
 
+import pytz
 from filelock import FileLock
 from libcommon.log import init_logging
 from libcommon.queue import Job, Status, get_datetime
@@ -18,6 +20,16 @@ from worker.loop import WorkerState
 
 WORKER_STATE_FILE_NAME = "worker_state.json"
 START_WORKER_LOOP_PATH = start_worker_loop.__file__
+
+
+async def every(
+    func: Callable[..., Optional[Any]], *args: Any, seconds: int, stop_on: Optional[Any] = None, **kwargs: Any
+) -> None:
+    while True:
+        out = func(*args, **kwargs)
+        if stop_on is not None and out == stop_on:
+            break
+        await asyncio.sleep(seconds)
 
 
 class WorkerExecutor:
@@ -38,11 +50,14 @@ class WorkerExecutor:
     def start(self) -> None:
         worker_loop_executor = self._create_worker_loop_executor()
         worker_loop_executor.start()  # blocking until the banner is printed
+
+        loop = asyncio.get_event_loop()
         logging.info("Starting heartbeat.")
-        while worker_loop_executor.running():
-            self.heartbeat()
-            time.sleep(self.app_config.worker.heartbeat_time_interval_seconds)
-        worker_loop_executor.stop()
+        loop.create_task(every(self.heartbeat, seconds=self.app_config.worker.heartbeat_time_interval_seconds))
+        loop.create_task(every(self.kill_zombies, seconds=self.app_config.worker.kill_zombies_time_interval_seconds))
+        loop.run_until_complete(
+            every(self.is_worker_alive, worker_loop_executor=worker_loop_executor, seconds=1, stop_on=False)
+        )
 
     def get_state(self) -> WorkerState:
         worker_state_path = self.app_config.worker.state_path
@@ -71,6 +86,33 @@ class WorkerExecutor:
         current_job = self.get_current_job()
         if current_job:
             current_job.update(last_heartbeat=get_datetime())
+
+    def get_zombies(self) -> List[Job]:
+        started_jobs = Job.objects(status=Status.STARTED)
+        max_missing_heartbeats = self.app_config.worker.max_missing_heartbeats
+        heartbeat_time_interval_seconds = self.app_config.worker.heartbeat_time_interval_seconds
+        if max_missing_heartbeats >= 1:
+            return [
+                job
+                for job in started_jobs
+                if job.last_heartbeat is not None
+                and get_datetime()
+                >= pytz.UTC.localize(job.last_heartbeat)
+                + timedelta(seconds=max_missing_heartbeats * heartbeat_time_interval_seconds)
+            ]
+        else:
+            return []
+
+    def kill_zombies(self) -> None:
+        zombies = self.get_zombies()
+        Job.objects(pk__in=[zombie.pk for zombie in zombies]).update(status=Status.ERROR)
+
+    def is_worker_alive(self, worker_loop_executor: OutputExecutor) -> bool:
+        if not worker_loop_executor.running():
+            worker_loop_executor.stop()  # raises an error if the worker returned exit code 1
+            return False
+        else:
+            return True
 
 
 if __name__ == "__main__":

--- a/services/worker/tests/conftest.py
+++ b/services/worker/tests/conftest.py
@@ -65,6 +65,7 @@ def set_env_vars(
     mp.setenv("WORKER_CONTENT_MAX_BYTES", "10_000_000")
     mp.setenv("WORKER_STATE_PATH", str(worker_state_path))
     mp.setenv("WORKER_HEARTBEAT_TIME_INTERVAL_SECONDS", "1")
+    mp.setenv("WORKER_KILL_ZOMBIES_TIME_INTERVAL_SECONDS", "1")
     yield mp
     mp.undo()
 


### PR DESCRIPTION
I defined zombies as started jobs with a `last_heartbeat` that is older than `max_missing_heartbeats * heartbeat_time_interval_seconds`

Then I added `kill_zombies` to the worker executor. It runs every `kill_zombies_time_interval_seconds` seconds and set the zombie jobs status to ERROR.

Given that heartbeats happen every 60s, I defined:
- max_missing_heartbeats = 5
- kill_zombies_time_interval_seconds = 10min

## Implementations details

To keep full control on the time interval for every action the executor runs, I switched to `asyncio`