### PR TITLE
Adding missing function on split-names-from-dataset-info worker

### DIFF
--- a/services/worker/src/worker/job_runners/split_names_from_dataset_info.py
+++ b/services/worker/src/worker/job_runners/split_names_from_dataset_info.py
@@ -7,6 +7,7 @@ from typing import Any, List, Literal, Mapping, Optional, TypedDict
 
 from libcommon.dataset import DatasetNotFoundError
 from libcommon.simple_cache import DoesNotExist, get_response
+from libcommon.simple_cache import SplitFullName
 
 from worker.job_runner import JobRunnerError
 from worker.job_runners._datasets_based_job_runner import DatasetsBasedJobRunner
@@ -123,3 +124,9 @@ class SplitNamesFromDatasetInfoJobRunner(DatasetsBasedJobRunner):
         if self.config is None:
             raise ValueError("config is required")
         return compute_split_names_from_dataset_info_response(dataset=self.dataset, config=self.config)
+
+    def get_new_splits(self, content: Mapping[str, Any]) -> set[SplitFullName]:
+        """Get the set of new splits, from the content created by the compute."""
+        return {
+            SplitFullName(dataset=s["dataset"], config=s["config"], split=s["split"]) for s in content["split_names"]
+        }

--- a/services/worker/src/worker/job_runners/split_names_from_dataset_info.py
+++ b/services/worker/src/worker/job_runners/split_names_from_dataset_info.py
@@ -6,8 +6,7 @@ from http import HTTPStatus
 from typing import Any, List, Literal, Mapping, Optional, TypedDict
 
 from libcommon.dataset import DatasetNotFoundError
-from libcommon.simple_cache import DoesNotExist, get_response
-from libcommon.simple_cache import SplitFullName
+from libcommon.simple_cache import DoesNotExist, SplitFullName, get_response
 
 from worker.job_runner import JobRunnerError
 from worker.job_runners._datasets_based_job_runner import DatasetsBasedJobRunner


### PR DESCRIPTION
`get_new_splits` function is used when creating children jobs, this function was missing in the new worker `split-names-from-dataset-info`