### PR TITLE
fix: 🐛 set the list of supported job types as a csv string

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -161,7 +161,7 @@ workers:
   -
     deployName: "generic"
     maxJobsPerNamespace: 1
-    workerOnlyJobTypes: []
+    workerOnlyJobTypes: ""
     nodeSelector: {}
     replicas: 1
     resources:
@@ -175,7 +175,7 @@ workers:
   -
     deployName: "first-rows"
     maxJobsPerNamespace: 1
-    workerOnlyJobTypes: ["/first-rows"]
+    workerOnlyJobTypes: "/first-rows"
     nodeSelector: {}
     replicas: 1
     resources:
@@ -189,7 +189,7 @@ workers:
   -
     deployName: "parquet-and-dataset-info"
     maxJobsPerNamespace: 1
-    workerOnlyJobTypes: []
+    workerOnlyJobTypes: "/parquet-and-dataset-info"
     nodeSelector: {}
     replicas: 1
     resources:

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -176,7 +176,7 @@ workers:
   -
     deployName: "generic"
     maxJobsPerNamespace: 4
-    workerOnlyJobTypes: []
+    workerOnlyJobTypes: ""
     nodeSelector:
       role-datasets-server: "true"
     replicas: 20
@@ -191,7 +191,7 @@ workers:
   -
     deployName: "config-names"
     maxJobsPerNamespace: 4
-    workerOnlyJobTypes: ["/config-names"]
+    workerOnlyJobTypes: "/config-names"
     nodeSelector:
       role-datasets-server: "true"
     replicas: 8
@@ -206,7 +206,7 @@ workers:
   -
     deployName: "split-names"
     maxJobsPerNamespace: 5
-    workerOnlyJobTypes: ["/split-names"]
+    workerOnlyJobTypes: "/split-names"
     nodeSelector:
       role-datasets-server: "true"
     replicas: 12
@@ -221,7 +221,7 @@ workers:
   -
     deployName: "splits"
     maxJobsPerNamespace: 5
-    workerOnlyJobTypes: ["/splits"]
+    workerOnlyJobTypes: "/splits"
     nodeSelector:
       role-datasets-server: "true"
     replicas: 8
@@ -236,7 +236,7 @@ workers:
   -
     deployName: "first-rows"
     maxJobsPerNamespace: 4
-    workerOnlyJobTypes: ["/first-rows"]
+    workerOnlyJobTypes: "/first-rows"
     nodeSelector:
       role-datasets-server: "true"
     replicas: 80
@@ -251,7 +251,7 @@ workers:
   -
     deployName: "parquet-and-dataset-info"
     maxJobsPerNamespace: 4
-    workerOnlyJobTypes: ["/parquet-and-dataset-info"]
+    workerOnlyJobTypes: "/parquet-and-dataset-info"
     nodeSelector:
       role-datasets-server: "true"
     replicas: 20
@@ -266,7 +266,7 @@ workers:
   -
     deployName: "parquet"
     maxJobsPerNamespace: 2
-    workerOnlyJobTypes: ["/parquet"]
+    workerOnlyJobTypes: "/parquet"
     nodeSelector:
       role-datasets-server: "true"
     replicas: 2
@@ -281,7 +281,7 @@ workers:
   -
     deployName: "dataset-info"
     maxJobsPerNamespace: 2
-    workerOnlyJobTypes: ["/dataset-info"]
+    workerOnlyJobTypes: "/dataset-info"
     nodeSelector:
       role-datasets-server: "true"
     replicas: 2
@@ -296,7 +296,7 @@ workers:
   -
     deployName: "sizes"
     maxJobsPerNamespace: 2
-    workerOnlyJobTypes: ["/sizes"]
+    workerOnlyJobTypes: "/sizes"
     nodeSelector:
       role-datasets-server: "true"
     replicas: 2

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -277,7 +277,7 @@ workers:
     # Maximum number of jobs running at the same time for the same namespace
     maxJobsPerNamespace: 1
     # job types that this worker can process
-    workerOnlyJobTypes: []
+    workerOnlyJobTypes: ""
     nodeSelector: {}
     replicas: 1
     resources:
@@ -292,7 +292,7 @@ workers:
     # Maximum number of jobs running at the same time for the same namespace
     maxJobsPerNamespace: 1
     # job types that this worker can process
-    workerOnlyJobTypes: ["/config-names"]
+    workerOnlyJobTypes: "/config-names"
     nodeSelector: {}
     replicas: 1
     resources:
@@ -307,7 +307,7 @@ workers:
     # Maximum number of jobs running at the same time for the same namespace
     maxJobsPerNamespace: 1
     # job types that this worker can process
-    workerOnlyJobTypes: ["/split-names"]
+    workerOnlyJobTypes: "/split-names"
     nodeSelector: {}
     replicas: 1
     resources:
@@ -322,7 +322,7 @@ workers:
     # Maximum number of jobs running at the same time for the same namespace
     maxJobsPerNamespace: 1
     # job types that this worker can process
-    workerOnlyJobTypes: ["/splits"]
+    workerOnlyJobTypes: "/splits"
     nodeSelector: {}
     replicas: 1
     resources:
@@ -337,7 +337,7 @@ workers:
     # Maximum number of jobs running at the same time for the same namespace
     maxJobsPerNamespace: 1
     # job types that this worker can process
-    workerOnlyJobTypes: ["/first-rows"]
+    workerOnlyJobTypes: "/first-rows"
     nodeSelector: {}
     replicas: 1
     resources:
@@ -352,7 +352,7 @@ workers:
     # Maximum number of jobs running at the same time for the same namespace
     maxJobsPerNamespace: 1
     # job types that this worker can process
-    workerOnlyJobTypes: ["/parquet-and-dataset-info"]
+    workerOnlyJobTypes: "/parquet-and-dataset-info"
     nodeSelector: {}
     replicas: 1
     resources:
@@ -367,7 +367,7 @@ workers:
     # Maximum number of jobs running at the same time for the same namespace
     maxJobsPerNamespace: 1
     # job types that this worker can process
-    workerOnlyJobTypes: ["/parquet"]
+    workerOnlyJobTypes: "/parquet"
     nodeSelector: {}
     replicas: 1
     resources:
@@ -382,7 +382,7 @@ workers:
     # Maximum number of jobs running at the same time for the same namespace
     maxJobsPerNamespace: 1
     # job types that this worker can process
-    workerOnlyJobTypes: ["/dataset-info"]
+    workerOnlyJobTypes: "/dataset-info"
     nodeSelector: {}
     replicas: 1
     resources:
@@ -397,7 +397,7 @@ workers:
     # Maximum number of jobs running at the same time for the same namespace
     maxJobsPerNamespace: 1
     # job types that this worker can process
-    workerOnlyJobTypes: ["/sizes"]
+    workerOnlyJobTypes: "/sizes"
     nodeSelector: {}
     replicas: 1
     resources:


### PR DESCRIPTION
not a python list! fixes #870