### PR TITLE
Renaming split-names response to splits

### DIFF
--- a/e2e/tests/test_12_splits.py
+++ b/e2e/tests/test_12_splits.py
@@ -75,7 +75,7 @@ def test_splits_with_config_using_openapi(status: int, dataset: str, config: str
     assert r_splits.status_code == status, f"{r_splits.status_code} - {r_splits.text}"
 
     if error_code is None:
-        assert all(split["config"] == config for split in r_splits.json()["split_names"])
+        assert all(split["config"] == config for split in r_splits.json()["splits"])
         # all splits must belong to the provided config
 
         assert "X-Error-Code" not in r_splits.headers, r_splits.headers["X-Error-Code"]

--- a/services/worker/src/worker/job_runners/split_names_from_dataset_info.py
+++ b/services/worker/src/worker/job_runners/split_names_from_dataset_info.py
@@ -54,7 +54,7 @@ class SplitNameItem(TypedDict):
 
 
 class SplitNamesFromDatasetInfoResponseContent(TypedDict):
-    split_names: List[SplitNameItem]
+    splits: List[SplitNameItem]
 
 
 def compute_split_names_from_dataset_info_response(
@@ -105,7 +105,7 @@ def compute_split_names_from_dataset_info_response(
         {"dataset": dataset, "config": config, "split": str(split)} for split in splits_content
     ]
 
-    return {"split_names": split_name_items}
+    return {"splits": split_name_items}
 
 
 class SplitNamesFromDatasetInfoJobRunner(DatasetsBasedJobRunner):
@@ -126,6 +126,4 @@ class SplitNamesFromDatasetInfoJobRunner(DatasetsBasedJobRunner):
 
     def get_new_splits(self, content: Mapping[str, Any]) -> set[SplitFullName]:
         """Get the set of new splits, from the content created by the compute."""
-        return {
-            SplitFullName(dataset=s["dataset"], config=s["config"], split=s["split"]) for s in content["split_names"]
-        }
+        return {SplitFullName(dataset=s["dataset"], config=s["config"], split=s["split"]) for s in content["splits"]}

--- a/services/worker/src/worker/job_runners/split_names_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split_names_from_streaming.py
@@ -55,7 +55,7 @@ class SplitNameItem(TypedDict):
 
 
 class SplitNamesFromStreamingResponseContent(TypedDict):
-    split_names: List[SplitNameItem]
+    splits: List[SplitNameItem]
 
 
 def compute_split_names_from_streaming_response(
@@ -109,7 +109,7 @@ def compute_split_names_from_streaming_response(
             f"Cannot get the split names for the config '{config}' of the dataset.",
             cause=err,
         ) from err
-    return {"split_names": split_name_items}
+    return {"splits": split_name_items}
 
 
 class SplitNamesFromStreamingJobRunner(DatasetsBasedJobRunner):
@@ -130,6 +130,4 @@ class SplitNamesFromStreamingJobRunner(DatasetsBasedJobRunner):
 
     def get_new_splits(self, content: Mapping[str, Any]) -> set[SplitFullName]:
         """Get the set of new splits, from the content created by the compute."""
-        return {
-            SplitFullName(dataset=s["dataset"], config=s["config"], split=s["split"]) for s in content["split_names"]
-        }
+        return {SplitFullName(dataset=s["dataset"], config=s["config"], split=s["split"]) for s in content["splits"]}

--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -244,7 +244,6 @@ def external_files_dataset_builder(hub_public_external_files: str) -> DatasetBui
 class HubDatasetTest(TypedDict):
     name: str
     config_names_response: Any
-    split_names_response: Any
     splits_response: Any
     first_rows_response: Any
     parquet_and_dataset_info_response: Any
@@ -260,19 +259,6 @@ def create_config_names_response(dataset: str) -> Any:
             {
                 "dataset": dataset,
                 "config": config,
-            }
-        ]
-    }
-
-
-def create_split_names_response(dataset: str) -> Any:
-    dataset, config, split = get_default_config_split(dataset)
-    return {
-        "split_names": [
-            {
-                "dataset": dataset,
-                "config": config,
-                "split": split,
             }
         ]
     }
@@ -523,7 +509,6 @@ def hub_datasets(
         "does_not_exist": {
             "name": "does_not_exist",
             "config_names_response": None,
-            "split_names_response": None,
             "splits_response": None,
             "first_rows_response": None,
             "parquet_and_dataset_info_response": None,
@@ -531,7 +516,6 @@ def hub_datasets(
         "empty": {
             "name": hub_public_empty,
             "config_names_response": None,
-            "split_names_response": None,
             "splits_response": None,
             "first_rows_response": None,
             "parquet_and_dataset_info_response": None,
@@ -539,7 +523,6 @@ def hub_datasets(
         "public": {
             "name": hub_public_csv,
             "config_names_response": create_config_names_response(hub_public_csv),
-            "split_names_response": create_split_names_response(hub_public_csv),
             "splits_response": create_splits_response(hub_public_csv),
             "first_rows_response": create_first_rows_response(hub_public_csv, DATA_cols, DATA_rows),
             "parquet_and_dataset_info_response": create_parquet_and_dataset_info_response(
@@ -549,7 +532,6 @@ def hub_datasets(
         "private": {
             "name": hub_private_csv,
             "config_names_response": create_config_names_response(hub_private_csv),
-            "split_names_response": create_split_names_response(hub_private_csv),
             "splits_response": create_splits_response(hub_private_csv),
             "first_rows_response": create_first_rows_response(hub_private_csv, DATA_cols, DATA_rows),
             "parquet_and_dataset_info_response": create_parquet_and_dataset_info_response(
@@ -559,7 +541,6 @@ def hub_datasets(
         "gated": {
             "name": hub_gated_csv,
             "config_names_response": create_config_names_response(hub_gated_csv),
-            "split_names_response": create_split_names_response(hub_gated_csv),
             "splits_response": create_splits_response(hub_gated_csv),
             "first_rows_response": create_first_rows_response(hub_gated_csv, DATA_cols, DATA_rows),
             "parquet_and_dataset_info_response": create_parquet_and_dataset_info_response(
@@ -569,7 +550,6 @@ def hub_datasets(
         "jsonl": {
             "name": hub_public_jsonl,
             "config_names_response": create_config_names_response(hub_public_jsonl),
-            "split_names_response": create_split_names_response(hub_public_jsonl),
             "splits_response": create_splits_response(hub_public_jsonl),
             "first_rows_response": create_first_rows_response(hub_public_jsonl, JSONL_cols, JSONL_rows),
             "parquet_and_dataset_info_response": None,
@@ -577,7 +557,6 @@ def hub_datasets(
         "gated_extra_fields": {
             "name": hub_gated_extra_fields_csv,
             "config_names_response": create_config_names_response(hub_gated_extra_fields_csv),
-            "split_names_response": create_split_names_response(hub_gated_extra_fields_csv),
             "splits_response": create_splits_response(hub_gated_extra_fields_csv),
             "first_rows_response": create_first_rows_response(hub_gated_extra_fields_csv, DATA_cols, DATA_rows),
             "parquet_and_dataset_info_response": create_parquet_and_dataset_info_response(
@@ -587,7 +566,6 @@ def hub_datasets(
         "audio": {
             "name": hub_public_audio,
             "config_names_response": create_config_names_response(hub_public_audio),
-            "split_names_response": create_split_names_response(hub_public_audio),
             "splits_response": create_splits_response(hub_public_audio),
             "first_rows_response": create_first_rows_response(
                 hub_public_audio, AUDIO_cols, get_AUDIO_rows(hub_public_audio)
@@ -599,7 +577,6 @@ def hub_datasets(
         "image": {
             "name": hub_public_image,
             "config_names_response": create_config_names_response(hub_public_image),
-            "split_names_response": create_split_names_response(hub_public_image),
             "splits_response": create_splits_response(hub_public_image),
             "first_rows_response": create_first_rows_response(
                 hub_public_image, IMAGE_cols, get_IMAGE_rows(hub_public_image)
@@ -609,7 +586,6 @@ def hub_datasets(
         "images_list": {
             "name": hub_public_images_list,
             "config_names_response": create_config_names_response(hub_public_images_list),
-            "split_names_response": create_split_names_response(hub_public_images_list),
             "splits_response": create_splits_response(hub_public_images_list),
             "first_rows_response": create_first_rows_response(
                 hub_public_images_list, IMAGES_LIST_cols, get_IMAGES_LIST_rows(hub_public_images_list)
@@ -619,7 +595,6 @@ def hub_datasets(
         "big": {
             "name": hub_public_big,
             "config_names_response": create_config_names_response(hub_public_big),
-            "split_names_response": create_split_names_response(hub_public_big),
             "splits_response": create_splits_response(hub_public_big),
             "first_rows_response": create_first_rows_response(hub_public_big, BIG_cols, BIG_rows),
             "parquet_and_dataset_info_response": None,
@@ -627,7 +602,6 @@ def hub_datasets(
         "external_files": {
             "name": hub_public_external_files,
             "config_names_response": create_config_names_response(hub_public_external_files),
-            "split_names_response": create_split_names_response(hub_public_external_files),
             "splits_response": create_splits_response(hub_public_external_files),
             "first_rows_response": create_first_rows_response(hub_public_external_files, TEXT_cols, TEXT_rows),
             "parquet_and_dataset_info_response": None,

--- a/services/worker/tests/job_runners/test_split_names_from_dataset_info.py
+++ b/services/worker/tests/job_runners/test_split_names_from_dataset_info.py
@@ -80,7 +80,7 @@ def get_job_runner(
             },
             None,
             {
-                "split_names": [
+                "splits": [
                     {"dataset": "ok", "config": "config_name", "split": "train"},
                     {"dataset": "ok", "config": "config_name", "split": "validation"},
                     {"dataset": "ok", "config": "config_name", "split": "test"},

--- a/services/worker/tests/job_runners/test_split_names_from_streaming.py
+++ b/services/worker/tests/job_runners/test_split_names_from_streaming.py
@@ -72,7 +72,7 @@ def test_process(app_config: AppConfig, get_job_runner: GetJobRunner, hub_public
     assert cached_response["dataset_git_revision"] is not None
     assert cached_response["error_code"] is None
     content = cached_response["content"]
-    assert len(content["split_names"]) == 1
+    assert len(content["splits"]) == 1
 
 
 def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> None:
@@ -99,7 +99,7 @@ def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> No
         ("private", False, "SplitNamesFromStreamingError", "FileNotFoundError"),
     ],
 )
-def test_compute_split_names_response(
+def test_compute_split_names_from_streaming_response(
     hub_datasets: HubDatasets,
     get_job_runner: GetJobRunner,
     name: str,
@@ -109,7 +109,7 @@ def test_compute_split_names_response(
     app_config: AppConfig,
 ) -> None:
     dataset, config, _ = get_default_config_split(hub_datasets[name]["name"])
-    expected_configs_response = hub_datasets[name]["split_names_response"]
+    expected_configs_response = hub_datasets[name]["splits_response"]
     job_runner = get_job_runner(
         dataset,
         config,


### PR DESCRIPTION
Fix content response name in split_names_from_streaming and split_names_from_dataset_info from "split_names" to "splits" so that it is consistent with the response of splits worker 