### PR TITLE
feat: 🎸 reduce the requests (and limits) in k8s resources

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -89,8 +89,8 @@ storageAdmin:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
-      memory: "256Mi"
+      cpu: 50m
+      memory: "64Mi"
     limits:
       cpu: 1
       memory: "256Mi"
@@ -102,7 +102,7 @@ reverseProxy:
   resources:
     requests:
       cpu: 100m
-      memory: "256Mi"
+      memory: "64Mi"
     limits:
       cpu: 1
       memory: "256Mi"

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -102,7 +102,7 @@ reverseProxy:
   replicas: 2
   resources:
     requests:
-      cpu: 200m
+      cpu: 1
       memory: "64Mi"
     limits:
       cpu: 1
@@ -147,7 +147,7 @@ admin:
     type: NodePort
   resources:
     requests:
-      cpu: 200m
+      cpu: 1
       memory: "512Mi"
     limits:
       cpu: 4
@@ -166,7 +166,7 @@ api:
     type: NodePort
   resources:
     requests:
-      cpu: 200m
+      cpu: 1
       memory: "512Mi"
     limits:
       cpu: 4
@@ -182,7 +182,7 @@ workers:
     replicas: 12
     resources:
       requests:
-        cpu: 200m
+        cpu: 1
         memory: "2Gi"
       limits:
         cpu: 2
@@ -197,7 +197,7 @@ workers:
     replicas: 2
     resources:
       requests:
-        cpu: 200m
+        cpu: 1
         memory: "2Gi"
       limits:
         cpu: 2
@@ -212,7 +212,7 @@ workers:
     replicas: 2
     resources:
       requests:
-        cpu: 200m
+        cpu: 1
         memory: "2Gi"
       limits:
         cpu: 2
@@ -227,7 +227,7 @@ workers:
     replicas: 2
     resources:
       requests:
-        cpu: 200m
+        cpu: 1
         memory: "2Gi"
       limits:
         cpu: 2
@@ -242,7 +242,7 @@ workers:
     replicas: 2
     resources:
       requests:
-        cpu: 200m
+        cpu: 1
         memory: "2Gi"
       limits:
         cpu: 2
@@ -257,7 +257,7 @@ workers:
     replicas: 2
     resources:
       requests:
-        cpu: 200m
+        cpu: 1
         memory: "2Gi"
       limits:
         cpu: 2

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -88,8 +88,8 @@ storageAdmin:
   replicas: 1
   resources:
     requests:
-      cpu: 1
-      memory: "256Mi"
+      cpu: 50m
+      memory: "64Mi"
     limits:
       cpu: 1
       memory: "256Mi"
@@ -102,8 +102,8 @@ reverseProxy:
   replicas: 2
   resources:
     requests:
-      cpu: 1
-      memory: "256Mi"
+      cpu: 200m
+      memory: "64Mi"
     limits:
       cpu: 1
       memory: "256Mi"
@@ -147,7 +147,7 @@ admin:
     type: NodePort
   resources:
     requests:
-      cpu: 4
+      cpu: 200m
       memory: "512Mi"
     limits:
       cpu: 4
@@ -166,7 +166,7 @@ api:
     type: NodePort
   resources:
     requests:
-      cpu: 4
+      cpu: 200m
       memory: "512Mi"
     limits:
       cpu: 4
@@ -182,11 +182,11 @@ workers:
     replicas: 12
     resources:
       requests:
-        cpu: 1
-        memory: "1Gi"
+        cpu: 200m
+        memory: "2Gi"
       limits:
         cpu: 2
-        memory: "30Gi"
+        memory: "8Gi"
     tolerations: []
   -
     deployName: "config-names"
@@ -197,11 +197,11 @@ workers:
     replicas: 2
     resources:
       requests:
-        cpu: 1
-        memory: "1Gi"
+        cpu: 200m
+        memory: "2Gi"
       limits:
         cpu: 2
-        memory: "30Gi"
+        memory: "8Gi"
     tolerations: []
   -
     deployName: "split-names"
@@ -212,11 +212,11 @@ workers:
     replicas: 2
     resources:
       requests:
-        cpu: 1
-        memory: "8Gi"
+        cpu: 200m
+        memory: "2Gi"
       limits:
         cpu: 2
-        memory: "30Gi"
+        memory: "8Gi"
     tolerations: []
   -
     deployName: "splits"
@@ -227,11 +227,11 @@ workers:
     replicas: 2
     resources:
       requests:
-        cpu: 1
-        memory: "8Gi"
+        cpu: 200m
+        memory: "2Gi"
       limits:
         cpu: 2
-        memory: "30Gi"
+        memory: "8Gi"
     tolerations: []
   -
     deployName: "first-rows"
@@ -242,11 +242,11 @@ workers:
     replicas: 2
     resources:
       requests:
-        cpu: 1
-        memory: "8Gi"
+        cpu: 200m
+        memory: "2Gi"
       limits:
         cpu: 2
-        memory: "30Gi"
+        memory: "8Gi"
     tolerations: []
   -
     deployName: "parquet-and-dataset-info"
@@ -257,11 +257,11 @@ workers:
     replicas: 2
     resources:
       requests:
-        cpu: 1
-        memory: "8Gi"
+        cpu: 200m
+        memory: "2Gi"
       limits:
         cpu: 2
-        memory: "30Gi"
+        memory: "8Gi"
     tolerations: []
   -
     deployName: "parquet"
@@ -272,7 +272,7 @@ workers:
     replicas: 2
     resources:
       requests:
-        cpu: 1
+        cpu: 200m
         memory: "100Mi"
       limits:
         cpu: 2
@@ -287,7 +287,7 @@ workers:
     replicas: 2
     resources:
       requests:
-        cpu: 1
+        cpu: 200m
         memory: "100Mi"
       limits:
         cpu: 2
@@ -302,7 +302,7 @@ workers:
     replicas: 2
     resources:
       requests:
-        cpu: 1
+        cpu: 200m
         memory: "100Mi"
       limits:
         cpu: 2


### PR DESCRIPTION
It's required for the api/admin services which were absolutely over-provisioned. And for the workers: we reduce a lot for now, since most of the datasets don't require that quantity of RAM, and we now manage the failed jobs due to OOm. We will work on a strategy to relaunch these jobs on "big" workers (to be done)