### PR TITLE
fix: 🐛 ensure the dataset parameter is provided in endpoints

### DIFF
--- a/services/api/src/api/routes/endpoint.py
+++ b/services/api/src/api/routes/endpoint.py
@@ -226,12 +226,16 @@ def create_endpoint(
                 dataset_parameter, config_parameter, split_parameter
             )
 
+            # for now, dataset is always required in the endpoints.
+            if not dataset:
+                raise MissingRequiredParameterError("Parameter 'dataset' is required")
+
             # if auth_check fails, it will raise an exception that will be caught below
-            auth_check(dataset, external_auth_url=external_auth_url, request=request)  # type: ignore
+            auth_check(dataset, external_auth_url=external_auth_url, request=request)
 
             # getting result based on processing steps
             result = get_cache_entry_from_steps(
-                processing_steps, dataset, config, split, init_processing_steps, hf_endpoint, hf_token  # type: ignore
+                processing_steps, dataset, config, split, init_processing_steps, hf_endpoint, hf_token
             )
 
             content = result["content"]


### PR DESCRIPTION
All the endpoints require the dataset parameter, at least, for the moment. The auth_check and the get_cache_entry_from_steps methods require dataset to be a string (None is not supported) and we have to check before that it's the case.