### PR TITLE
feat: 🎸 add timeout when requesting Hub authentication check

### DIFF
--- a/chart/templates/services/api/_container.tpl
+++ b/chart/templates/services/api/_container.tpl
@@ -12,6 +12,8 @@
   # service
   - name: API_HF_AUTH_PATH
     value: {{ .Values.api.hfAuthPath | quote }}
+  - name: API_HF_AUTH_TIMEOUT_SECONDS
+    value: {{ .Values.api.hfAuthTimeoutSeconds | quote }}
   - name: API_MAX_AGE_LONG
     value: {{ .Values.api.maxAgeLong | quote }}
   - name: API_MAX_AGE_SHORT

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -253,6 +253,8 @@ api:
   # the path of the external authentication service on the hub.
   # The string must contain `%s` which will be replaced with the dataset name.
   hfAuthPath: "/api/datasets/%s/auth-check"
+  # the timeout in seconds for the external authentication service.
+  hfAuthTimeoutSeconds: "0.2"
   # Number of seconds to set in the `max-age` header on data endpoints
   maxAgeLong: "120"
   # Number of seconds to set in the `max-age` header on technical endpoints

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -13,6 +13,8 @@ export PROMETHEUS_MULTIPROC_DIR := /tmp
 export ADMIN_UVICORN_NUM_WORKERS := 2
 export API_UVICORN_NUM_WORKERS := 2
 export COMMON_LOG_LEVEL := DEBUG
+export API_HF_AUTH_TIMEOUT_SECONDS := 10
+# ^ allow hub-ci to be slow to answer
 
 # makefile variables
 DOCKER_COMPOSE := ../tools/docker-compose-datasets-server.yml

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -11,6 +11,7 @@ The worker can be configured using environment variables. They are grouped by sc
 Set environment variables to configure the application (`API_` prefix):
 
 - `API_HF_AUTH_PATH`: the path of the external authentication service, on the hub (see `HF_ENDPOINT`). The string must contain `%s` which will be replaced with the dataset name. The external authentication service must return 200, 401, 403 or 404. Defaults to "/api/datasets/%s/auth-check".
+- `API_HF_AUTH_TIMEOUT_SECONDS`: the timeout in seconds for the external authentication service. Defaults to `0.2` (200 ms).
 - `API_MAX_AGE_LONG`: number of seconds to set in the `max-age` header on data endpoints. Defaults to `120` (2 minutes).
 - `API_MAX_AGE_SHORT`: number of seconds to set in the `max-age` header on technical endpoints. Defaults to `10` (10 seconds).
 

--- a/services/api/src/api/app.py
+++ b/services/api/src/api/app.py
@@ -63,6 +63,7 @@ def create_app_with_config(app_config: AppConfig, endpoint_config: EndpointConfi
                 hf_endpoint=app_config.common.hf_endpoint,
                 hf_token=app_config.common.hf_token,
                 external_auth_url=app_config.api.external_auth_url,
+                external_auth_timeout_seconds=app_config.api.hf_auth_timeout_seconds,
                 max_age_long=app_config.api.max_age_long,
                 max_age_short=app_config.api.max_age_short,
             ),
@@ -81,6 +82,7 @@ def create_app_with_config(app_config: AppConfig, endpoint_config: EndpointConfi
             "/is-valid",
             endpoint=create_is_valid_endpoint(
                 external_auth_url=app_config.api.external_auth_url,
+                external_auth_timeout_seconds=app_config.api.hf_auth_timeout_seconds,
                 processing_steps_for_valid=processing_steps_required_by_dataset_viewer,
                 max_age_long=app_config.api.max_age_long,
                 max_age_short=app_config.api.max_age_short,

--- a/services/api/src/api/config.py
+++ b/services/api/src/api/config.py
@@ -37,6 +37,7 @@ class UvicornConfig:
 
 API_EXTERNAL_AUTH_URL = None
 API_HF_AUTH_PATH = "/api/datasets/%s/auth-check"
+API_HF_AUTH_TIMEOUT_SECONDS = 0.2
 API_MAX_AGE_LONG = 120  # 2 minutes
 API_MAX_AGE_SHORT = 10  # 10 seconds
 
@@ -45,6 +46,7 @@ API_MAX_AGE_SHORT = 10  # 10 seconds
 class ApiConfig:
     external_auth_url: Optional[str] = API_EXTERNAL_AUTH_URL  # not documented
     hf_auth_path: str = API_HF_AUTH_PATH
+    hf_auth_timeout_seconds: Optional[float] = API_HF_AUTH_TIMEOUT_SECONDS
     max_age_long: int = API_MAX_AGE_LONG
     max_age_short: int = API_MAX_AGE_SHORT
 
@@ -57,6 +59,7 @@ class ApiConfig:
             return cls(
                 external_auth_url=external_auth_url,
                 hf_auth_path=hf_auth_path,
+                hf_auth_timeout_seconds=env.float(name="HF_AUTH_TIMEOUT_SECONDS", default=API_HF_AUTH_TIMEOUT_SECONDS),
                 max_age_long=env.int(name="MAX_AGE_LONG", default=API_MAX_AGE_LONG),
                 max_age_short=env.int(name="MAX_AGE_SHORT", default=API_MAX_AGE_SHORT),
             )

--- a/services/api/src/api/routes/endpoint.py
+++ b/services/api/src/api/routes/endpoint.py
@@ -202,6 +202,7 @@ def create_endpoint(
     hf_endpoint: str,
     hf_token: Optional[str] = None,
     external_auth_url: Optional[str] = None,
+    external_auth_timeout_seconds: Optional[float] = None,
     max_age_long: int = 0,
     max_age_short: int = 0,
 ) -> Endpoint:
@@ -231,7 +232,12 @@ def create_endpoint(
                 raise MissingRequiredParameterError("Parameter 'dataset' is required")
 
             # if auth_check fails, it will raise an exception that will be caught below
-            auth_check(dataset, external_auth_url=external_auth_url, request=request)
+            auth_check(
+                dataset,
+                external_auth_url=external_auth_url,
+                request=request,
+                external_auth_timeout_seconds=external_auth_timeout_seconds,
+            )
 
             # getting result based on processing steps
             result = get_cache_entry_from_steps(

--- a/services/api/src/api/routes/valid.py
+++ b/services/api/src/api/routes/valid.py
@@ -65,6 +65,7 @@ def create_valid_endpoint(
 def create_is_valid_endpoint(
     processing_steps_for_valid: List[ProcessingStep],
     external_auth_url: Optional[str] = None,
+    external_auth_timeout_seconds: Optional[float] = None,
     max_age_long: int = 0,
     max_age_short: int = 0,
 ) -> Endpoint:
@@ -76,7 +77,12 @@ def create_is_valid_endpoint(
             if not are_valid_parameters([dataset]) or not dataset:
                 raise MissingRequiredParameterError("Parameter 'dataset' is required")
             # if auth_check fails, it will raise an exception that will be caught below
-            auth_check(dataset, external_auth_url=external_auth_url, request=request)
+            auth_check(
+                dataset,
+                external_auth_url=external_auth_url,
+                request=request,
+                external_auth_timeout_seconds=external_auth_timeout_seconds,
+            )
             content = {
                 "valid": is_valid(dataset=dataset, processing_steps_for_valid=processing_steps_for_valid),
             }

--- a/services/api/src/api/utils.py
+++ b/services/api/src/api/utils.py
@@ -17,6 +17,7 @@ ApiErrorCode = Literal[
     "UnexpectedError",
     "ExternalUnauthenticatedError",
     "ExternalAuthenticatedError",
+    "ExternalTimeoutError",
     "MissingProcessingStepsError",
 ]
 
@@ -79,6 +80,15 @@ class ExternalAuthenticatedError(ApiCustomError):
 
     def __init__(self, message: str):
         super().__init__(message, HTTPStatus.NOT_FOUND, "ExternalAuthenticatedError")
+
+
+class ExternalTimeoutError(ApiCustomError):
+    """Raised when the external authentication check failed due to timeout."""
+
+    def __init__(self, message: str, cause: Optional[BaseException] = None):
+        super().__init__(
+            message, HTTPStatus.INTERNAL_SERVER_ERROR, "ExternalTimeoutError", cause=cause, disclose_cause=False
+        )
 
 
 class OrjsonResponse(JSONResponse):

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -21,6 +21,7 @@ def monkeypatch_session() -> Iterator[MonkeyPatch]:
     monkeypatch_session.setenv("QUEUE_MONGO_DATABASE", "datasets_server_queue_test")
     hostname = "localhost"
     port = "8888"
+    monkeypatch_session.setenv("API_HF_AUTH_TIMEOUT_SECONDS", "10")
     monkeypatch_session.setenv("API_UVICORN_HOSTNAME", hostname)
     monkeypatch_session.setenv("API_UVICORN_PORT", port)
     monkeypatch_session.setenv("COMMON_HF_ENDPOINT", f"http://{hostname}:{port}")

--- a/tools/docker-compose-datasets-server.yml
+++ b/tools/docker-compose-datasets-server.yml
@@ -54,6 +54,7 @@ services:
     environment:
       # service
       API_HF_AUTH_PATH: ${API_HF_AUTH_PATH-/api/datasets/%s/auth-check}
+      API_HF_AUTH_TIMEOUT_SECONDS: ${API_HF_AUTH_TIMEOUT_SECONDS-0.2}
       API_MAX_AGE_LONG: ${API_MAX_AGE_LONG-120}
       API_MAX_AGE_SHORT: ${API_MAX_AGE_SHORT-10}
       # prometheus

--- a/tools/docker-compose-dev-datasets-server.yml
+++ b/tools/docker-compose-dev-datasets-server.yml
@@ -54,6 +54,7 @@ services:
     environment:
       # service
       API_HF_AUTH_PATH: ${API_HF_AUTH_PATH-/api/datasets/%s/auth-check}
+      API_HF_AUTH_TIMEOUT_SECONDS: ${API_HF_AUTH_TIMEOUT_SECONDS-0.2}
       API_MAX_AGE_LONG: ${API_MAX_AGE_LONG-120}
       API_MAX_AGE_SHORT: ${API_MAX_AGE_SHORT-10}
       # prometheus


### PR DESCRIPTION
Set to 200ms by default and in production. See #877