### PR TITLE
Adding deploy for missing JobRunners in chart

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -213,9 +213,9 @@ workers:
         memory: "8Gi"
     tolerations: []
   -
-    deployName: "split-names"
+    deployName: "split-names-from-streaming"
     maxJobsPerNamespace: 20
-    workerOnlyJobTypes: "/split-names"
+    workerOnlyJobTypes: "/split-names-from-streaming"
     nodeSelector:
       role-datasets-server-worker: "true"
     replicas: 2
@@ -291,6 +291,21 @@ workers:
     deployName: "dataset-info"
     maxJobsPerNamespace: 20
     workerOnlyJobTypes: "/dataset-info"
+    nodeSelector:
+      role-datasets-server-worker: "true"
+    replicas: 2
+    resources:
+      requests:
+        cpu: 200m
+        memory: "100Mi"
+      limits:
+        cpu: 2
+        memory: "1Gi"
+    tolerations: []
+  -
+    deployName: "split-names-from-streaming"
+    maxJobsPerNamespace: 20
+    workerOnlyJobTypes: "/split-names-from-streaming"
     nodeSelector:
       role-datasets-server-worker: "true"
     replicas: 2

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -312,11 +312,11 @@ workers:
     tolerations: []
   -
     # name of the deployment
-    deployName: "split-names"
+    deployName: "split-names-from-streaming"
     # Maximum number of jobs running at the same time for the same namespace
     maxJobsPerNamespace: 1
     # job types that this worker can process
-    workerOnlyJobTypes: "/split-names"
+    workerOnlyJobTypes: "/split-names-from-streaming"
     nodeSelector: {}
     replicas: 1
     resources:
@@ -392,6 +392,21 @@ workers:
     maxJobsPerNamespace: 1
     # job types that this worker can process
     workerOnlyJobTypes: "/dataset-info"
+    nodeSelector: {}
+    replicas: 1
+    resources:
+      requests:
+        cpu: 0
+      limits:
+        cpu: 0
+    tolerations: []
+  -
+    # name of the deployment
+    deployName: "split-names-from-dataset-info"
+    # Maximum number of jobs running at the same time for the same namespace
+    maxJobsPerNamespace: 1
+    # job types that this worker can process
+    workerOnlyJobTypes: "/split-names-from-dataset-info"
     nodeSelector: {}
     replicas: 1
     resources:


### PR DESCRIPTION
We have two new JobRunners name:
- /split-names-from-streaming -> It was previously /split-names, but it was renamed 
- /split-names-from-dataset-info -> It is a new JobRunner which is supposed to have a similar workload as /dataset-info or /parquet