### PR TITLE
Change worker_version to int job_runner_version

### DIFF
--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -26,6 +26,9 @@ from mongodb_migration.migrations._20230309123100_cache_add_progress import (
 from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version import (
     MigrationAddJobRunnerVersionToCacheResponse,
 )
+from mongodb_migration.migrations._20230309123100_cache_add_progress import (
+    MigrationAddProgressToCacheResponse,
+)
 
 
 # TODO: add a way to automatically collect migrations from the migrations/ folder
@@ -58,7 +61,7 @@ class MigrationsCollector:
                 version="20230309123100",
                 description="add the 'progress' field with the default value (1.0) to the cached results",
             ),
-            MigrationAddJobRunnerVerionToCacheResponse(
+            MigrationAddJobRunnerVersionToCacheResponse(
                 version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
-            ),
+            )
         ]

--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -23,6 +23,9 @@ from mongodb_migration.migrations._20230216141000_queue_split_names_from_streami
 from mongodb_migration.migrations._20230309123100_cache_add_progress import (
     MigrationAddProgressToCacheResponse,
 )
+from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version import (
+    MigrationAddJobRunnerVerionToCacheResponse,
+)
 
 
 # TODO: add a way to automatically collect migrations from the migrations/ folder
@@ -54,5 +57,8 @@ class MigrationsCollector:
             MigrationAddProgressToCacheResponse(
                 version="20230309123100",
                 description="add the 'progress' field with the default value (1.0) to the cached results",
+            ),
+            MigrationAddJobRunnerVerionToCacheResponse(
+                version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
             ),
         ]

--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -29,6 +29,9 @@ from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version i
 from mongodb_migration.migrations._20230309123100_cache_add_progress import (
     MigrationAddProgressToCacheResponse,
 )
+from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version import (
+    MigrationAddJobRunnerVerionToCacheResponse,
+)
 
 
 # TODO: add a way to automatically collect migrations from the migrations/ folder

--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -30,7 +30,7 @@ from mongodb_migration.migrations._20230309123100_cache_add_progress import (
     MigrationAddProgressToCacheResponse,
 )
 from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version import (
-    MigrationAddJobRunnerVerionToCacheResponse,
+    MigrationAddJobRunnerVersionToCacheResponse,
 )
 
 

--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -24,7 +24,7 @@ from mongodb_migration.migrations._20230309123100_cache_add_progress import (
     MigrationAddProgressToCacheResponse,
 )
 from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version import (
-    MigrationAddJobRunnerVerionToCacheResponse,
+    MigrationAddJobRunnerVersionToCacheResponse,
 )
 
 

--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -26,12 +26,6 @@ from mongodb_migration.migrations._20230309123100_cache_add_progress import (
 from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version import (
     MigrationAddJobRunnerVersionToCacheResponse,
 )
-from mongodb_migration.migrations._20230309123100_cache_add_progress import (
-    MigrationAddProgressToCacheResponse,
-)
-from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version import (
-    MigrationAddJobRunnerVersionToCacheResponse,
-)
 
 
 # TODO: add a way to automatically collect migrations from the migrations/ folder
@@ -66,5 +60,5 @@ class MigrationsCollector:
             ),
             MigrationAddJobRunnerVersionToCacheResponse(
                 version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
-            )
+            ),
         ]

--- a/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230309141600_cache_add_job_runner_version.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230309141600_cache_add_job_runner_version.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+import logging
+
+from libcommon.simple_cache import CachedResponse
+from mongoengine.connection import get_db
+
+from mongodb_migration.check import check_documents
+from mongodb_migration.migration import Migration
+
+
+# connection already occurred in the main.py (caveat: we use globals)
+class MigrationAddJobRunnerVerionToCacheResponse(Migration):
+    def up(self) -> None:
+        # See https://docs.mongoengine.org/guide/migration.html#example-1-addition-of-a-field
+        logging.info("If missing, add 'job_runner_version' field based on 'worker_version' value")
+        db = get_db("cache")
+        db["cachedResponsesBlue"].update_many(
+            {"job_runner_version": {"$exists": False}},
+            [
+                {"$set": {"job_runner_version": {"$toInt": {"$first": {"$split": ["$worker_version", "."]}}}}},
+                {"$unset": "worker_version"},
+            ],  # type: ignore
+        )
+
+    def down(self) -> None:
+        logging.info("Remove 'job_runner_version' field from all the cached results")
+        db = get_db("cache")
+        db["cachedResponsesBlue"].update_many({}, {"$unset": {"job_runner_version": ""}})
+
+    def validate(self) -> None:
+        logging.info("Ensure that a random selection of cached results have the 'job_runner_version' field")
+
+        check_documents(DocCls=CachedResponse, sample_size=10)

--- a/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230309141600_cache_add_job_runner_version.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230309141600_cache_add_job_runner_version.py
@@ -11,7 +11,7 @@ from mongodb_migration.migration import Migration
 
 
 # connection already occurred in the main.py (caveat: we use globals)
-class MigrationAddJobRunnerVerionToCacheResponse(Migration):
+class MigrationAddJobRunnerVersionToCacheResponse(Migration):
     def up(self) -> None:
         # See https://docs.mongoengine.org/guide/migration.html#example-1-addition-of-a-field
         logging.info("If missing, add 'job_runner_version' field based on 'worker_version' value")

--- a/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230309141600_cache_add_job_runner_version.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230309141600_cache_add_job_runner_version.py
@@ -19,8 +19,18 @@ class MigrationAddJobRunnerVerionToCacheResponse(Migration):
         db["cachedResponsesBlue"].update_many(
             {"job_runner_version": {"$exists": False}},
             [
-                {"$set": {"job_runner_version": {"$toInt": {"$first": {"$split": ["$worker_version", "."]}}}}},
-                {"$unset": "worker_version"},
+                {
+                    "$set": {
+                        "job_runner_version": {
+                            "$convert": {
+                                "input": {"$first": {"$split": ["$worker_version", "."]}},
+                                "to": "int",
+                                "onError": None,
+                                "onNull": None,
+                            }
+                        }
+                    }
+                }
             ],  # type: ignore
         )
 

--- a/jobs/mongodb_migration/tests/migrations/test_20230309141600_cache_add_job_runner_version.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230309141600_cache_add_job_runner_version.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
+from typing import Optional
+
 import pytest
 from libcommon.resources import MongoResource
 from mongoengine.connection import get_db

--- a/jobs/mongodb_migration/tests/migrations/test_20230309141600_cache_add_job_runner_version.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230309141600_cache_add_job_runner_version.py
@@ -5,7 +5,7 @@ from libcommon.resources import MongoResource
 from mongoengine.connection import get_db
 
 from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version import (
-    MigrationAddJobRunnerVerionToCacheResponse,
+    MigrationAddJobRunnerVersionToCacheResponse,
 )
 
 
@@ -16,7 +16,7 @@ def test_cache_add_job_runner_version_without_worker_version(mongo_host: str) ->
         db["cachedResponsesBlue"].insert_many(
             [{"kind": "/splits", "dataset": "dataset_without_worker_version", "http_status": 200}]
         )
-        migration = MigrationAddJobRunnerVerionToCacheResponse(
+        migration = MigrationAddJobRunnerVersionToCacheResponse(
             version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
         )
         migration.up()
@@ -41,7 +41,7 @@ def test_cache_add_job_runner_version(mongo_host: str, worker_version: str, expe
         db["cachedResponsesBlue"].insert_many(
             [{"kind": "/splits", "dataset": "dataset", "http_status": 200, "worker_version": worker_version}]
         )
-        migration = MigrationAddJobRunnerVerionToCacheResponse(
+        migration = MigrationAddJobRunnerVersionToCacheResponse(
             version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
         )
         migration.up()

--- a/jobs/mongodb_migration/tests/migrations/test_20230309141600_cache_add_job_runner_version.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230309141600_cache_add_job_runner_version.py
@@ -34,7 +34,7 @@ def test_cache_add_job_runner_version_without_worker_version(mongo_host: str) ->
         (None, None),
     ],
 )
-def test_cache_add_job_runner_version(mongo_host: str, worker_version: str, expected: int) -> None:
+def test_cache_add_job_runner_version(mongo_host: str, worker_version: str, expected: Optional[int]) -> None:
     with MongoResource(database="test_cache_add_job_runner_version", host=mongo_host, mongoengine_alias="cache"):
         db = get_db("cache")
         db["cachedResponsesBlue"].delete_many({})
@@ -47,6 +47,4 @@ def test_cache_add_job_runner_version(mongo_host: str, worker_version: str, expe
         migration.up()
         result = db["cachedResponsesBlue"].find_one({"dataset": "dataset"})
         assert result
-        if expected:
-            assert result["job_runner_version"]
-            assert result["job_runner_version"] == expected
+        assert result["job_runner_version"] == expected

--- a/jobs/mongodb_migration/tests/migrations/test_20230309141600_cache_add_job_runner_version.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230309141600_cache_add_job_runner_version.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+import pytest
+from libcommon.resources import MongoResource
+from mongoengine.connection import get_db
+
+from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version import (
+    MigrationAddJobRunnerVerionToCacheResponse,
+)
+
+
+def test_cache_add_job_runner_version_without_worker_version(mongo_host: str) -> None:
+    with MongoResource(database="test_cache_add_job_runner_version", host=mongo_host, mongoengine_alias="cache"):
+        db = get_db("cache")
+        db["cachedResponsesBlue"].delete_many({})
+        db["cachedResponsesBlue"].insert_many(
+            [{"kind": "/splits", "dataset": "dataset_without_worker_version", "http_status": 200}]
+        )
+        migration = MigrationAddJobRunnerVerionToCacheResponse(
+            version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
+        )
+        migration.up()
+        result = db["cachedResponsesBlue"].find_one({"dataset": "dataset_without_worker_version"})
+        assert result
+        assert not result["job_runner_version"]
+
+
+@pytest.mark.parametrize(
+    "worker_version,expected",
+    [
+        ("2.0.0", 2),
+        ("1.5.0", 1),
+        ("WrongFormat", None),
+        (None, None),
+    ],
+)
+def test_cache_add_job_runner_version(mongo_host: str, worker_version: str, expected: int) -> None:
+    with MongoResource(database="test_cache_add_job_runner_version", host=mongo_host, mongoengine_alias="cache"):
+        db = get_db("cache")
+        db["cachedResponsesBlue"].delete_many({})
+        db["cachedResponsesBlue"].insert_many(
+            [{"kind": "/splits", "dataset": "dataset", "http_status": 200, "worker_version": worker_version}]
+        )
+        migration = MigrationAddJobRunnerVerionToCacheResponse(
+            version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
+        )
+        migration.up()
+        result = db["cachedResponsesBlue"].find_one({"dataset": "dataset"})
+        assert result
+        if expected:
+            assert result["job_runner_version"]
+            assert result["job_runner_version"] == expected

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -99,8 +99,6 @@ class CachedResponse(Document):
     dataset_git_revision = StringField()
     progress = FloatField(min_value=0.0, max_value=1.0)
     job_runner_version = IntField()
-    progress = FloatField(min_value=0.0, max_value=1.0)
-    job_runner_version = IntField()
 
     details = DictField()
     updated_at = DateTimeField(default=get_datetime)

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -185,7 +185,6 @@ def get_response_without_content(
         "error_code": response.error_code,
         "dataset_git_revision": response.dataset_git_revision,
         "progress": response.progress,
-        "job_runner_version": response.job_runner_version,
     }
 
 

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -25,6 +25,7 @@ from mongoengine.fields import (
     DictField,
     EnumField,
     FloatField,
+    IntField,
     ObjectIdField,
     StringField,
 )
@@ -78,7 +79,7 @@ class CachedResponse(Document):
         content (`dict`): The content of the cached response. Can be an error or a valid content.
         details (`dict`, optional): Additional details, eg. a detailed error that we don't want to send as a response.
         updated_at (`datetime`): When the cache entry has been last updated.
-        worker_version (`str`): The semver version of the worker that cached the response.
+        job_runner_version (`int`): The version of the job runner that cached the response.
         dataset_git_revision (`str`): The commit (of the git dataset repo) used to generate the response.
         progress (`float`): Progress percentage (between 0. and 1.) if the result is not complete yet.
     """
@@ -93,9 +94,9 @@ class CachedResponse(Document):
     http_status = EnumField(HTTPStatus, required=True)
     error_code = StringField()
     content = DictField(required=True)
-    worker_version = StringField()
     dataset_git_revision = StringField()
     progress = FloatField(min_value=0.0, max_value=1.0)
+    job_runner_version = IntField()
 
     details = DictField()
     updated_at = DateTimeField(default=get_datetime)
@@ -132,7 +133,7 @@ def upsert_response(
     split: Optional[str] = None,
     error_code: Optional[str] = None,
     details: Optional[Mapping[str, Any]] = None,
-    worker_version: Optional[str] = None,
+    job_runner_version: Optional[int] = None,
     dataset_git_revision: Optional[str] = None,
     progress: Optional[float] = None,
 ) -> None:
@@ -141,10 +142,10 @@ def upsert_response(
         http_status=http_status,
         error_code=error_code,
         details=details,
-        worker_version=worker_version,
         dataset_git_revision=dataset_git_revision,
         progress=progress,
         updated_at=get_datetime(),
+        job_runner_version=job_runner_version,
     )
 
 
@@ -161,9 +162,9 @@ def delete_dataset_responses(dataset: str) -> Optional[int]:
 class CacheEntryWithoutContent(TypedDict):
     http_status: HTTPStatus
     error_code: Optional[str]
-    worker_version: Optional[str]
     dataset_git_revision: Optional[str]
     progress: Optional[float]
+    job_runner_version: Optional[int]
 
 
 # Note: we let the exceptions throw (ie DoesNotExist): it's the responsibility of the caller to manage them
@@ -172,27 +173,27 @@ def get_response_without_content(
 ) -> CacheEntryWithoutContent:
     response = (
         CachedResponse.objects(kind=kind, dataset=dataset, config=config, split=split)
-        .only("http_status", "error_code", "worker_version", "dataset_git_revision", "progress")
+        .only("http_status", "error_code", "job_runner_version", "dataset_git_revision", "progress")
         .get()
     )
     return {
         "http_status": response.http_status,
         "error_code": response.error_code,
-        "worker_version": response.worker_version,
         "dataset_git_revision": response.dataset_git_revision,
         "progress": response.progress,
+        "job_runner_version": response.job_runner_version,
     }
 
 
 def get_dataset_responses_without_content_for_kind(kind: str, dataset: str) -> List[CacheEntryWithoutContent]:
     responses = CachedResponse.objects(kind=kind, dataset=dataset).only(
-        "http_status", "error_code", "worker_version", "dataset_git_revision", "progress"
+        "http_status", "error_code", "job_runner_version", "dataset_git_revision", "progress"
     )
     return [
         {
             "http_status": response.http_status,
             "error_code": response.error_code,
-            "worker_version": response.worker_version,
+            "job_runner_version": response.job_runner_version,
             "dataset_git_revision": response.dataset_git_revision,
             "progress": response.progress,
         }
@@ -208,14 +209,14 @@ class CacheEntry(CacheEntryWithoutContent):
 def get_response(kind: str, dataset: str, config: Optional[str] = None, split: Optional[str] = None) -> CacheEntry:
     response = (
         CachedResponse.objects(kind=kind, dataset=dataset, config=config, split=split)
-        .only("content", "http_status", "error_code", "worker_version", "dataset_git_revision", "progress")
+        .only("content", "http_status", "error_code", "job_runner_version", "dataset_git_revision", "progress")
         .get()
     )
     return {
         "content": response.content,
         "http_status": response.http_status,
         "error_code": response.error_code,
-        "worker_version": response.worker_version,
+        "job_runner_version": response.job_runner_version,
         "dataset_git_revision": response.dataset_git_revision,
         "progress": response.progress,
     }
@@ -280,7 +281,7 @@ class CacheReport(TypedDict):
     split: Optional[str]
     http_status: int
     error_code: Optional[str]
-    worker_version: Optional[str]
+    job_runner_version: Optional[int]
     dataset_git_revision: Optional[str]
 
 
@@ -342,7 +343,7 @@ def get_cache_reports(kind: str, cursor: Optional[str], limit: int) -> CacheRepo
             "split",
             "http_status",
             "error_code",
-            "worker_version",
+            "job_runner_version",
             "dataset_git_revision",
         )
         .limit(limit)
@@ -356,7 +357,7 @@ def get_cache_reports(kind: str, cursor: Optional[str], limit: int) -> CacheRepo
                 "split": object.split,
                 "http_status": object.http_status.value,
                 "error_code": object.error_code,
-                "worker_version": object.worker_version,
+                "job_runner_version": object.job_runner_version,
                 "dataset_git_revision": object.dataset_git_revision,
             }
             for object in objects
@@ -422,7 +423,7 @@ def get_cache_reports_with_content(kind: str, cursor: Optional[str], limit: int)
             "http_status",
             "error_code",
             "content",
-            "worker_version",
+            "job_runner_version",
             "dataset_git_revision",
             "details",
             "updated_at",
@@ -439,7 +440,7 @@ def get_cache_reports_with_content(kind: str, cursor: Optional[str], limit: int)
                 "http_status": object.http_status.value,
                 "error_code": object.error_code,
                 "content": object.content,
-                "worker_version": object.worker_version,
+                "job_runner_version": object.job_runner_version,
                 "dataset_git_revision": object.dataset_git_revision,
                 "details": object.details,
                 "updated_at": object.updated_at,

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -99,6 +99,7 @@ class CachedResponse(Document):
     dataset_git_revision = StringField()
     progress = FloatField(min_value=0.0, max_value=1.0)
     job_runner_version = IntField()
+    progress = FloatField(min_value=0.0, max_value=1.0)
 
     details = DictField()
     updated_at = DateTimeField(default=get_datetime)
@@ -167,6 +168,7 @@ class CacheEntryWithoutContent(TypedDict):
     dataset_git_revision: Optional[str]
     progress: Optional[float]
     job_runner_version: Optional[int]
+    progress: Optional[float]
 
 
 # Note: we let the exceptions throw (ie DoesNotExist): it's the responsibility of the caller to manage them
@@ -184,6 +186,7 @@ def get_response_without_content(
         "dataset_git_revision": response.dataset_git_revision,
         "progress": response.progress,
         "job_runner_version": response.job_runner_version,
+        "progress": response.progress,
     }
 
 

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -184,6 +184,7 @@ def get_response_without_content(
         "http_status": response.http_status,
         "error_code": response.error_code,
         "dataset_git_revision": response.dataset_git_revision,
+        "job_runner_version": response.job_runner_version,
         "progress": response.progress,
     }
 

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -79,6 +79,7 @@ class CachedResponse(Document):
         content (`dict`): The content of the cached response. Can be an error or a valid content.
         details (`dict`, optional): Additional details, eg. a detailed error that we don't want to send as a response.
         updated_at (`datetime`): When the cache entry has been last updated.
+        worker_version (`str`): The semver version of the worker that cached the response.
         job_runner_version (`int`): The version of the job runner that cached the response.
         dataset_git_revision (`str`): The commit (of the git dataset repo) used to generate the response.
         progress (`float`): Progress percentage (between 0. and 1.) if the result is not complete yet.
@@ -94,6 +95,7 @@ class CachedResponse(Document):
     http_status = EnumField(HTTPStatus, required=True)
     error_code = StringField()
     content = DictField(required=True)
+    worker_version = StringField()
     dataset_git_revision = StringField()
     progress = FloatField(min_value=0.0, max_value=1.0)
     job_runner_version = IntField()

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -95,6 +95,7 @@ class CachedResponse(Document):
     http_status = EnumField(HTTPStatus, required=True)
     error_code = StringField()
     content = DictField(required=True)
+    worker_version = StringField()
     dataset_git_revision = StringField()
     progress = FloatField(min_value=0.0, max_value=1.0)
     job_runner_version = IntField()

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -95,11 +95,11 @@ class CachedResponse(Document):
     http_status = EnumField(HTTPStatus, required=True)
     error_code = StringField()
     content = DictField(required=True)
-    worker_version = StringField()
     dataset_git_revision = StringField()
     progress = FloatField(min_value=0.0, max_value=1.0)
     job_runner_version = IntField()
     progress = FloatField(min_value=0.0, max_value=1.0)
+    job_runner_version = IntField()
 
     details = DictField()
     updated_at = DateTimeField(default=get_datetime)
@@ -168,7 +168,6 @@ class CacheEntryWithoutContent(TypedDict):
     dataset_git_revision: Optional[str]
     progress: Optional[float]
     job_runner_version: Optional[int]
-    progress: Optional[float]
 
 
 # Note: we let the exceptions throw (ie DoesNotExist): it's the responsibility of the caller to manage them
@@ -186,7 +185,6 @@ def get_response_without_content(
         "dataset_git_revision": response.dataset_git_revision,
         "progress": response.progress,
         "job_runner_version": response.job_runner_version,
-        "progress": response.progress,
     }
 
 

--- a/libs/libcommon/tests/test_simple_cache.py
+++ b/libs/libcommon/tests/test_simple_cache.py
@@ -113,7 +113,7 @@ def test_upsert_response(config: Optional[str], split: Optional[str]) -> None:
         "http_status": HTTPStatus.OK,
         "content": content,
         "error_code": None,
-        "worker_version": None,
+        "job_runner_version": None,
         "dataset_git_revision": None,
         "progress": None,
     }
@@ -123,7 +123,7 @@ def test_upsert_response(config: Optional[str], split: Optional[str]) -> None:
     assert cached_response_without_content == {
         "http_status": HTTPStatus.OK,
         "error_code": None,
-        "worker_version": None,
+        "job_runner_version": None,
         "dataset_git_revision": None,
         "progress": None,
     }
@@ -144,7 +144,7 @@ def test_upsert_response(config: Optional[str], split: Optional[str]) -> None:
         get_response(kind=kind, dataset=dataset, config=config, split=split)
 
     error_code = "error_code"
-    worker_version = "0.1.2"
+    job_runner_version = 0
     dataset_git_revision = "123456"
     upsert_response(
         kind=kind,
@@ -154,7 +154,7 @@ def test_upsert_response(config: Optional[str], split: Optional[str]) -> None:
         content=content,
         http_status=HTTPStatus.BAD_REQUEST,
         error_code=error_code,
-        worker_version=worker_version,
+        job_runner_version=job_runner_version,
         dataset_git_revision=dataset_git_revision,
     )
 
@@ -163,7 +163,7 @@ def test_upsert_response(config: Optional[str], split: Optional[str]) -> None:
         "http_status": HTTPStatus.BAD_REQUEST,
         "content": content,
         "error_code": error_code,
-        "worker_version": worker_version,
+        "job_runner_version": job_runner_version,
         "dataset_git_revision": dataset_git_revision,
         "progress": None,
     }
@@ -418,7 +418,7 @@ def test_get_cache_reports() -> None:
     details_b = {
         "error": "error b",
     }
-    worker_version_b = "0.1.2"
+    job_runner_version_b = 0
     dataset_git_revision_b = "123456"
     upsert_response(
         kind=kind,
@@ -428,7 +428,7 @@ def test_get_cache_reports() -> None:
         details=details_b,
         http_status=http_status_b,
         error_code=error_code_b,
-        worker_version=worker_version_b,
+        job_runner_version=job_runner_version_b,
         dataset_git_revision=dataset_git_revision_b,
     )
 
@@ -480,7 +480,7 @@ def test_get_cache_reports() -> None:
             "split": None,
             "http_status": http_status_a.value,
             "error_code": None,
-            "worker_version": None,
+            "job_runner_version": None,
             "dataset_git_revision": None,
         },
         {
@@ -490,7 +490,7 @@ def test_get_cache_reports() -> None:
             "split": None,
             "http_status": http_status_b.value,
             "error_code": error_code_b,
-            "worker_version": worker_version_b,
+            "job_runner_version": job_runner_version_b,
             "dataset_git_revision": dataset_git_revision_b,
         },
     ]
@@ -506,7 +506,7 @@ def test_get_cache_reports() -> None:
                 "split": split_c,
                 "http_status": http_status_c.value,
                 "error_code": error_code_c,
-                "worker_version": None,
+                "job_runner_version": None,
                 "dataset_git_revision": None,
             },
         ],
@@ -527,7 +527,7 @@ def test_get_cache_reports() -> None:
             "http_status": http_status_a.value,
             "error_code": None,
             "content": content_a,
-            "worker_version": None,
+            "job_runner_version": None,
             "dataset_git_revision": None,
             "details": {},
             "updated_at": REDACTED_DATE,
@@ -540,7 +540,7 @@ def test_get_cache_reports() -> None:
             "http_status": http_status_b.value,
             "error_code": error_code_b,
             "content": content_b,
-            "worker_version": worker_version_b,
+            "job_runner_version": job_runner_version_b,
             "dataset_git_revision": dataset_git_revision_b,
             "details": details_b,
             "updated_at": REDACTED_DATE,
@@ -561,7 +561,7 @@ def test_get_cache_reports() -> None:
                 "http_status": http_status_c.value,
                 "error_code": error_code_c,
                 "content": content_c,
-                "worker_version": None,
+                "job_runner_version": None,
                 "dataset_git_revision": None,
                 "details": details_c,
                 "updated_at": REDACTED_DATE,

--- a/services/worker/src/worker/job_runner.py
+++ b/services/worker/src/worker/job_runner.py
@@ -268,9 +268,6 @@ class JobRunner(ABC):
         self.create_children_jobs()
         return result
 
-    def is_major_version_than(self, other_version: Optional[int]) -> bool:
-        return other_version is None or self.get_job_runner_version() > other_version
-
     def get_dataset_git_revision(self) -> Optional[str]:
         """Get the git revision of the dataset repository."""
         return get_dataset_git_revision(
@@ -306,8 +303,9 @@ class JobRunner(ABC):
         if cached_response["error_code"] in ERROR_CODES_TO_RETRY:
             # the cache entry result was a temporary error - we process it
             return False
-        if cached_response["job_runner_version"] is None or self.is_major_version_than(
-            cached_response["job_runner_version"]
+        if (
+            cached_response["job_runner_version"] is None
+            or self.get_job_runner_version() > cached_response["job_runner_version"]
         ):
             return False
         if cached_response["progress"] is not None and cached_response["progress"] < 1.0:

--- a/services/worker/src/worker/job_runner.py
+++ b/services/worker/src/worker/job_runner.py
@@ -22,7 +22,6 @@ from libcommon.simple_cache import (
     upsert_response,
 )
 from libcommon.utils import orjson_dumps
-from packaging import version
 
 from worker.config import WorkerConfig
 
@@ -199,7 +198,7 @@ class JobRunner(ABC):
 
     @staticmethod
     @abstractmethod
-    def get_version() -> str:
+    def get_job_runner_version() -> int:
         pass
 
     def __init__(
@@ -269,24 +268,8 @@ class JobRunner(ABC):
         self.create_children_jobs()
         return result
 
-    def compare_major_version(self, other_version: str) -> int:
-        """
-        Compare the major version of job runner's self version and the other version's.
-
-        Args:
-            other_version (:obj:`str`): the other semantic version
-
-        Returns:
-            :obj:`int`: the difference between the major version of both versions.
-            0 if they are equal. Negative if job runner's major version is lower than other_version, positive
-              otherwise.
-        Raises:
-            :obj:`ValueError`: if job runner's version or other_version is not a valid semantic version.
-        """
-        try:
-            return version.parse(self.get_version()).major - version.parse(other_version).major
-        except Exception as err:
-            raise RuntimeError(f"Could not get major versions: {err}") from err
+    def is_major_version_than(self, other_version: Optional[int]) -> bool:
+        return other_version is None or self.get_job_runner_version() > other_version
 
     def get_dataset_git_revision(self) -> Optional[str]:
         """Get the git revision of the dataset repository."""
@@ -323,14 +306,9 @@ class JobRunner(ABC):
         if cached_response["error_code"] in ERROR_CODES_TO_RETRY:
             # the cache entry result was a temporary error - we process it
             return False
-        if (
-            cached_response["worker_version"] is None
-            or self.compare_major_version(cached_response["worker_version"]) != 0
+        if cached_response["job_runner_version"] is None or self.is_major_version_than(
+            cached_response["job_runner_version"]
         ):
-            # no job runner version in the cache, or the job runner has been updated - we process the job to update
-            # the cache
-            # note: the collection field is named "worker_version" for historical reasons, it might be renamed
-            #   "job_runner_version" in the future.
             return False
         if cached_response["progress"] is not None and cached_response["progress"] < 1.0:
             # this job is still waiting for more inputs to be complete - we should not skip it.
@@ -375,7 +353,7 @@ class JobRunner(ABC):
                 split=self.split,
                 content=content,
                 http_status=HTTPStatus.OK,
-                worker_version=self.get_version(),
+                job_runner_version=self.get_job_runner_version(),
                 dataset_git_revision=dataset_git_revision,
                 progress=job_result.progress,
             )
@@ -403,7 +381,7 @@ class JobRunner(ABC):
                 http_status=e.status_code,
                 error_code=e.code,
                 details=dict(e.as_response_with_cause()),
-                worker_version=self.get_version(),
+                job_runner_version=self.get_job_runner_version(),
                 dataset_git_revision=dataset_git_revision,
             )
             self.debug(
@@ -510,7 +488,7 @@ class JobRunner(ABC):
             http_status=error.status_code,
             error_code=error.code,
             details=dict(error.as_response_with_cause()),
-            worker_version=self.get_version(),
+            job_runner_version=self.get_job_runner_version(),
             dataset_git_revision=self.get_dataset_git_revision(),
         )
         logging.debug(

--- a/services/worker/src/worker/job_runners/config_names.py
+++ b/services/worker/src/worker/job_runners/config_names.py
@@ -101,8 +101,8 @@ class ConfigNamesJobRunner(DatasetsBasedJobRunner):
         return "/config-names"
 
     @staticmethod
-    def get_version() -> str:
-        return "1.0.0"
+    def get_job_runner_version() -> int:
+        return 1
 
     def compute(self) -> CompleteJobResult:
         return CompleteJobResult(

--- a/services/worker/src/worker/job_runners/dataset_info.py
+++ b/services/worker/src/worker/job_runners/dataset_info.py
@@ -93,8 +93,8 @@ class DatasetInfoJobRunner(JobRunner):
         return "/dataset-info"
 
     @staticmethod
-    def get_version() -> str:
-        return "1.0.0"
+    def get_job_runner_version() -> int:
+        return 1
 
     def compute(self) -> CompleteJobResult:
         return CompleteJobResult(compute_dataset_info_response(dataset=self.dataset))

--- a/services/worker/src/worker/job_runners/first_rows.py
+++ b/services/worker/src/worker/job_runners/first_rows.py
@@ -645,8 +645,8 @@ class FirstRowsJobRunner(DatasetsBasedJobRunner):
         return "/first-rows"
 
     @staticmethod
-    def get_version() -> str:
-        return "2.0.0"
+    def get_job_runner_version() -> int:
+        return 2
 
     def __init__(
         self,

--- a/services/worker/src/worker/job_runners/parquet.py
+++ b/services/worker/src/worker/job_runners/parquet.py
@@ -96,8 +96,8 @@ class ParquetJobRunner(JobRunner):
         return "/parquet"
 
     @staticmethod
-    def get_version() -> str:
-        return "3.0.0"
+    def get_job_runner_version() -> int:
+        return 3
 
     def compute(self) -> CompleteJobResult:
         return CompleteJobResult(compute_parquet_response(dataset=self.dataset))

--- a/services/worker/src/worker/job_runners/parquet_and_dataset_info.py
+++ b/services/worker/src/worker/job_runners/parquet_and_dataset_info.py
@@ -869,8 +869,8 @@ class ParquetAndDatasetInfoJobRunner(DatasetsBasedJobRunner):
         return "/parquet-and-dataset-info"
 
     @staticmethod
-    def get_version() -> str:
-        return "1.1.0"
+    def get_job_runner_version() -> int:
+        return 1
 
     def __init__(
         self,

--- a/services/worker/src/worker/job_runners/sizes.py
+++ b/services/worker/src/worker/job_runners/sizes.py
@@ -177,8 +177,8 @@ class SizesJobRunner(JobRunner):
         return "/sizes"
 
     @staticmethod
-    def get_version() -> str:
-        return "1.0.0"
+    def get_job_runner_version() -> int:
+        return 1
 
     def compute(self) -> CompleteJobResult:
         return CompleteJobResult(compute_sizes_response(dataset=self.dataset))

--- a/services/worker/src/worker/job_runners/split_names_from_dataset_info.py
+++ b/services/worker/src/worker/job_runners/split_names_from_dataset_info.py
@@ -114,8 +114,8 @@ class SplitNamesFromDatasetInfoJobRunner(DatasetsBasedJobRunner):
         return "/split-names-from-dataset-info"
 
     @staticmethod
-    def get_version() -> str:
-        return "2.0.0"
+    def get_job_runner_version() -> int:
+        return 2
 
     def compute(self) -> CompleteJobResult:
         if self.dataset is None:

--- a/services/worker/src/worker/job_runners/split_names_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split_names_from_streaming.py
@@ -118,8 +118,8 @@ class SplitNamesFromStreamingJobRunner(DatasetsBasedJobRunner):
         return "/split-names-from-streaming"
 
     @staticmethod
-    def get_version() -> str:
-        return "2.0.0"
+    def get_job_runner_version() -> int:
+        return 2
 
     def compute(self) -> CompleteJobResult:
         if self.config is None:

--- a/services/worker/src/worker/job_runners/splits.py
+++ b/services/worker/src/worker/job_runners/splits.py
@@ -130,8 +130,8 @@ class SplitsJobRunner(DatasetsBasedJobRunner):
         return "/splits"
 
     @staticmethod
-    def get_version() -> str:
-        return "2.0.0"
+    def get_job_runner_version() -> int:
+        return 2
 
     def compute(self) -> CompleteJobResult:
         return CompleteJobResult(compute_splits_response(dataset=self.dataset, hf_token=self.common_config.hf_token))

--- a/services/worker/tests/job_runners/test__datasets_based_worker.py
+++ b/services/worker/tests/job_runners/test__datasets_based_worker.py
@@ -82,13 +82,6 @@ def get_job_runner(
     return _get_job_runner
 
 
-def test_version(app_config: AppConfig, get_job_runner: GetJobRunner) -> None:
-    dataset, config, split = get_default_config_split("dataset")
-    job_runner = get_job_runner(dataset, config, split, app_config, False)
-    assert job_runner.is_major_version_than(other_version=0)
-    assert not job_runner.is_major_version_than(other_version=10)
-
-
 @pytest.mark.parametrize(
     "dataset,config,split,force,expected",
     [

--- a/services/worker/tests/job_runners/test__datasets_based_worker.py
+++ b/services/worker/tests/job_runners/test__datasets_based_worker.py
@@ -30,8 +30,8 @@ class DummyJobRunner(DatasetsBasedJobRunner):
         # refactoring libcommon.processing_graph might help avoiding this
 
     @staticmethod
-    def get_version() -> str:
-        return "1.0.0"
+    def get_job_runner_version() -> int:
+        return 1
 
     def compute(self) -> CompleteJobResult:
         if self.config == "raise":
@@ -85,9 +85,8 @@ def get_job_runner(
 def test_version(app_config: AppConfig, get_job_runner: GetJobRunner) -> None:
     dataset, config, split = get_default_config_split("dataset")
     job_runner = get_job_runner(dataset, config, split, app_config, False)
-    assert len(job_runner.get_version().split(".")) == 3
-    assert job_runner.compare_major_version(other_version="0.0.0") > 0
-    assert job_runner.compare_major_version(other_version="1000.0.0") < 0
+    assert not job_runner.is_major_version_than(other_version=0)
+    assert job_runner.is_major_version_than(other_version=10)
 
 
 @pytest.mark.parametrize(

--- a/services/worker/tests/job_runners/test__datasets_based_worker.py
+++ b/services/worker/tests/job_runners/test__datasets_based_worker.py
@@ -85,8 +85,8 @@ def get_job_runner(
 def test_version(app_config: AppConfig, get_job_runner: GetJobRunner) -> None:
     dataset, config, split = get_default_config_split("dataset")
     job_runner = get_job_runner(dataset, config, split, app_config, False)
-    assert not job_runner.is_major_version_than(other_version=0)
-    assert job_runner.is_major_version_than(other_version=10)
+    assert job_runner.is_major_version_than(other_version=0)
+    assert not job_runner.is_major_version_than(other_version=10)
 
 
 @pytest.mark.parametrize(

--- a/services/worker/tests/job_runners/test_config_names.py
+++ b/services/worker/tests/job_runners/test_config_names.py
@@ -76,7 +76,7 @@ def test_process(app_config: AppConfig, hub_public_csv: str, get_job_runner: Get
     cached_response = get_response(kind=job_runner.processing_step.cache_kind, dataset=hub_public_csv)
     assert cached_response["http_status"] == HTTPStatus.OK
     assert cached_response["error_code"] is None
-    assert cached_response["worker_version"] == job_runner.get_version()
+    assert cached_response["job_runner_version"] == job_runner.get_job_runner_version()
     assert cached_response["dataset_git_revision"] is not None
     assert cached_response["error_code"] is None
     content = cached_response["content"]

--- a/services/worker/tests/job_runners/test_first_rows.py
+++ b/services/worker/tests/job_runners/test_first_rows.py
@@ -90,7 +90,7 @@ def test_compute(
     )
     assert cached_response["http_status"] == HTTPStatus.OK
     assert cached_response["error_code"] is None
-    assert cached_response["worker_version"] == job_runner.get_version()
+    assert cached_response["job_runner_version"] == job_runner.get_job_runner_version()
     assert cached_response["dataset_git_revision"] is not None
     content = cached_response["content"]
     assert content["features"][0]["feature_idx"] == 0

--- a/services/worker/tests/job_runners/test_parquet_and_dataset_info.py
+++ b/services/worker/tests/job_runners/test_parquet_and_dataset_info.py
@@ -130,7 +130,7 @@ def test_compute(
     cached_response = get_response(kind=job_runner.processing_step.cache_kind, dataset=dataset)
     assert cached_response["http_status"] == HTTPStatus.OK
     assert cached_response["error_code"] is None
-    assert cached_response["worker_version"] == job_runner.get_version()
+    assert cached_response["job_runner_version"] == job_runner.get_job_runner_version()
     assert cached_response["dataset_git_revision"] is not None
     content = cached_response["content"]
     assert len(content["parquet_files"]) == 1

--- a/services/worker/tests/job_runners/test_split_names_from_streaming.py
+++ b/services/worker/tests/job_runners/test_split_names_from_streaming.py
@@ -68,7 +68,7 @@ def test_process(app_config: AppConfig, get_job_runner: GetJobRunner, hub_public
     cached_response = get_response(kind=job_runner.processing_step.cache_kind, dataset=hub_public_csv, config=config)
     assert cached_response["http_status"] == HTTPStatus.OK
     assert cached_response["error_code"] is None
-    assert cached_response["worker_version"] == job_runner.get_version()
+    assert cached_response["job_runner_version"] == job_runner.get_job_runner_version()
     assert cached_response["dataset_git_revision"] is not None
     assert cached_response["error_code"] is None
     content = cached_response["content"]

--- a/services/worker/tests/job_runners/test_splits.py
+++ b/services/worker/tests/job_runners/test_splits.py
@@ -76,7 +76,7 @@ def test_process(app_config: AppConfig, hub_public_csv: str, get_job_runner: Get
     cached_response = get_response(kind=job_runner.processing_step.cache_kind, dataset=hub_public_csv)
     assert cached_response["http_status"] == HTTPStatus.OK
     assert cached_response["error_code"] is None
-    assert cached_response["worker_version"] == job_runner.get_version()
+    assert cached_response["job_runner_version"] == job_runner.get_job_runner_version()
     assert cached_response["dataset_git_revision"] is not None
     assert cached_response["error_code"] is None
     content = cached_response["content"]

--- a/services/worker/tests/test_job_runner.py
+++ b/services/worker/tests/test_job_runner.py
@@ -46,6 +46,38 @@ class DummyJobRunner(JobRunner):
         return {SplitFullName(self.dataset, "config", "split1"), SplitFullName(self.dataset, "config", "split2")}
 
 
+@pytest.mark.parametrize(
+    "other_version, expected",
+    [
+        (0, True),
+        (1, False),
+        (2, False),
+        (None, True),
+    ],
+)
+def test_is_major_version_than(test_processing_step: ProcessingStep, other_version: int, expected: bool) -> None:
+    job_id = "job_id"
+    dataset = "dataset"
+    config = "config"
+    split = "split"
+    force = False
+    job_runner = DummyJobRunner(
+        job_info={
+            "job_id": job_id,
+            "type": test_processing_step.job_type,
+            "dataset": dataset,
+            "config": config,
+            "split": split,
+            "force": force,
+            "priority": Priority.NORMAL,
+        },
+        processing_step=test_processing_step,
+        common_config=CommonConfig(),
+        worker_config=WorkerConfig(),
+    )
+    assert job_runner.is_major_version_than(other_version=other_version) == expected
+
+
 @dataclass
 class CacheEntry:
     error_code: Optional[str]

--- a/services/worker/tests/test_job_runner.py
+++ b/services/worker/tests/test_job_runner.py
@@ -46,38 +46,6 @@ class DummyJobRunner(JobRunner):
         return {SplitFullName(self.dataset, "config", "split1"), SplitFullName(self.dataset, "config", "split2")}
 
 
-@pytest.mark.parametrize(
-    "other_version, expected",
-    [
-        (0, True),
-        (1, False),
-        (2, False),
-        (None, True),
-    ],
-)
-def test_is_major_version_than(test_processing_step: ProcessingStep, other_version: int, expected: bool) -> None:
-    job_id = "job_id"
-    dataset = "dataset"
-    config = "config"
-    split = "split"
-    force = False
-    job_runner = DummyJobRunner(
-        job_info={
-            "job_id": job_id,
-            "type": test_processing_step.job_type,
-            "dataset": dataset,
-            "config": config,
-            "split": split,
-            "force": force,
-            "priority": Priority.NORMAL,
-        },
-        processing_step=test_processing_step,
-        common_config=CommonConfig(),
-        worker_config=WorkerConfig(),
-    )
-    assert job_runner.is_major_version_than(other_version=other_version) == expected
-
-
 @dataclass
 class CacheEntry:
     error_code: Optional[str]

--- a/services/worker/tests/test_job_runner.py
+++ b/services/worker/tests/test_job_runner.py
@@ -138,7 +138,7 @@ class CacheEntry:
             False,
             CacheEntry(
                 error_code=None,  # no error
-                worker_version=DummyJobRunner.get_version(),
+                job_runner_version=DummyJobRunner.get_job_runner_version(),
                 dataset_git_revision=DummyJobRunner._get_dataset_git_revision(),
                 progress=0.5,  # incomplete result
             ),
@@ -148,7 +148,7 @@ class CacheEntry:
             False,
             CacheEntry(
                 error_code=None,  # no error
-                worker_version=DummyJobRunner.get_version(),
+                job_runner_version=DummyJobRunner.get_job_runner_version(),
                 dataset_git_revision=DummyJobRunner._get_dataset_git_revision(),
                 progress=1.0,  # complete result
             ),

--- a/services/worker/tests/test_job_runner.py
+++ b/services/worker/tests/test_job_runner.py
@@ -32,12 +32,12 @@ class DummyJobRunner(JobRunner):
         return "0.1.2"
 
     @staticmethod
-    def get_job_type() -> str:
-        return "/dummy"
+    def get_job_runner_version() -> int:
+        return 1
 
     @staticmethod
-    def get_version() -> str:
-        return "1.0.1"
+    def get_job_type() -> str:
+        return "/dummy"
 
     def compute(self) -> CompleteJobResult:
         return CompleteJobResult({"key": "value"})
@@ -47,20 +47,15 @@ class DummyJobRunner(JobRunner):
 
 
 @pytest.mark.parametrize(
-    "other_version, expected, should_raise",
+    "other_version, expected",
     [
-        ("1.0.0", 0, False),
-        ("0.1.0", 1, False),
-        ("2.0.0", -1, False),
-        ("not a version", None, True),
+        (0, True),
+        (1, False),
+        (2, False),
+        (None, True),
     ],
 )
-def test_compare_major_version(
-    test_processing_step: ProcessingStep,
-    other_version: str,
-    expected: int,
-    should_raise: bool,
-) -> None:
+def test_is_major_version_than(test_processing_step: ProcessingStep, other_version: int, expected: bool) -> None:
     job_id = "job_id"
     dataset = "dataset"
     config = "config"
@@ -80,17 +75,13 @@ def test_compare_major_version(
         common_config=CommonConfig(),
         worker_config=WorkerConfig(),
     )
-    if should_raise:
-        with pytest.raises(Exception):
-            job_runner.compare_major_version(other_version)
-    else:
-        assert job_runner.compare_major_version(other_version) == expected
+    assert job_runner.is_major_version_than(other_version=other_version) == expected
 
 
 @dataclass
 class CacheEntry:
     error_code: Optional[str]
-    worker_version: Optional[str]
+    job_runner_version: Optional[int]
     dataset_git_revision: Optional[str]
     progress: Optional[float] = None
 
@@ -103,7 +94,7 @@ class CacheEntry:
             False,
             CacheEntry(
                 error_code="DoNotRetry",  # an error that we don't want to retry
-                worker_version=DummyJobRunner.get_version(),
+                job_runner_version=DummyJobRunner.get_job_runner_version(),
                 dataset_git_revision=DummyJobRunner._get_dataset_git_revision(),
             ),
             True,  # skip
@@ -112,7 +103,7 @@ class CacheEntry:
             False,
             CacheEntry(
                 error_code=None,  # no error
-                worker_version=DummyJobRunner.get_version(),
+                job_runner_version=DummyJobRunner.get_job_runner_version(),
                 dataset_git_revision=DummyJobRunner._get_dataset_git_revision(),
             ),
             True,  # skip
@@ -121,7 +112,7 @@ class CacheEntry:
             True,  # force
             CacheEntry(
                 error_code="DoNotRetry",
-                worker_version=DummyJobRunner.get_version(),
+                job_runner_version=DummyJobRunner.get_job_runner_version(),
                 dataset_git_revision=DummyJobRunner._get_dataset_git_revision(),
             ),
             False,  # process
@@ -135,7 +126,7 @@ class CacheEntry:
             False,
             CacheEntry(
                 error_code=ERROR_CODES_TO_RETRY[0],  # an error that we want to retry
-                worker_version=DummyJobRunner.get_version(),
+                job_runner_version=DummyJobRunner.get_job_runner_version(),
                 dataset_git_revision=DummyJobRunner._get_dataset_git_revision(),
             ),
             False,  # process
@@ -144,7 +135,7 @@ class CacheEntry:
             False,
             CacheEntry(
                 error_code="DoNotRetry",
-                worker_version=None,  # no version
+                job_runner_version=None,  # no version
                 dataset_git_revision=DummyJobRunner._get_dataset_git_revision(),
             ),
             False,  # process
@@ -153,7 +144,7 @@ class CacheEntry:
             False,
             CacheEntry(
                 error_code="DoNotRetry",
-                worker_version="0.0.1",  # a different version
+                job_runner_version=0,  # a different version
                 dataset_git_revision=DummyJobRunner._get_dataset_git_revision(),
             ),
             False,  # process
@@ -162,7 +153,7 @@ class CacheEntry:
             False,
             CacheEntry(
                 error_code="DoNotRetry",
-                worker_version=DummyJobRunner.get_version(),
+                job_runner_version=DummyJobRunner.get_job_runner_version(),
                 dataset_git_revision=None,  # no dataset git revision
             ),
             False,  # process
@@ -171,7 +162,7 @@ class CacheEntry:
             False,
             CacheEntry(
                 error_code="DoNotRetry",
-                worker_version=DummyJobRunner.get_version(),
+                job_runner_version=DummyJobRunner.get_job_runner_version(),
                 dataset_git_revision="different",  # a different dataset git revision
             ),
             False,  # process
@@ -229,7 +220,7 @@ def test_should_skip_job(
             http_status=HTTPStatus.OK,  # <- not important
             error_code=cache_entry.error_code,
             details=None,
-            worker_version=cache_entry.worker_version,
+            job_runner_version=cache_entry.job_runner_version,
             dataset_git_revision=cache_entry.dataset_git_revision,
             progress=cache_entry.progress,
         )

--- a/services/worker/tests/test_job_runner.py
+++ b/services/worker/tests/test_job_runner.py
@@ -86,7 +86,6 @@ class CacheEntry:
     progress: Optional[float] = None
 
 
-# .get_version()
 @pytest.mark.parametrize(
     "force,cache_entry,expected_skip",
     [

--- a/services/worker/tests/test_loop.py
+++ b/services/worker/tests/test_loop.py
@@ -22,8 +22,8 @@ class DummyJobRunner(JobRunner):
         return "/dummy"
 
     @staticmethod
-    def get_version() -> str:
-        return "1.0.1"
+    def get_job_runner_version() -> int:
+        return 1
 
     def compute(self) -> CompleteJobResult:
         return CompleteJobResult({"key": "value"})


### PR DESCRIPTION
According to conversation on https://github.com/huggingface/datasets-server/pull/912, worker_version needs to be an int value.
I renamed worker_version to job_runner_version as suggested in a comment in https://github.com/huggingface/datasets-server/blob/main/services/worker/src/worker/job_runner.py#L315 to keep consistency between class name and field.
