### PR TITLE
Remove worker version

### DIFF
--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -26,6 +26,9 @@ from mongodb_migration.migrations._20230309123100_cache_add_progress import (
 from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version import (
     MigrationAddJobRunnerVersionToCacheResponse,
 )
+from mongodb_migration.migrations._20230313164200_cache_remove_worker_version import (
+    MigrationRemoveWorkerVersionFromCachedResponse,
+)
 
 
 # TODO: add a way to automatically collect migrations from the migrations/ folder
@@ -60,5 +63,8 @@ class MigrationsCollector:
             ),
             MigrationAddJobRunnerVersionToCacheResponse(
                 version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
+            ),
+            MigrationRemoveWorkerVersionFromCachedResponse(
+                version="20230313164200", description="remove 'worker_version' field from cache"
             ),
         ]

--- a/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230313164200_cache_remove_worker_version.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230313164200_cache_remove_worker_version.py
@@ -13,7 +13,6 @@ from mongodb_migration.migration import IrreversibleMigration, Migration
 # connection already occurred in the main.py (caveat: we use globals)
 class MigrationRemoveWorkerVersionFromCachedResponse(Migration):
     def up(self) -> None:
-        # See https://docs.mongoengine.org/guide/migration.html#example-1-addition-of-a-field
         logging.info("Removing 'worker_version' field.")
         db = get_db("cache")
         db["cachedResponsesBlue"].update_many({}, {"$unset": {"worker_version": ""}})

--- a/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230313164200_cache_remove_worker_version.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230313164200_cache_remove_worker_version.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+import logging
+
+from libcommon.simple_cache import CachedResponse
+from mongoengine.connection import get_db
+
+from mongodb_migration.check import check_documents
+from mongodb_migration.migration import IrreversibleMigration, Migration
+
+
+# connection already occurred in the main.py (caveat: we use globals)
+class MigrationRemoveWorkerVersionFromCachedResponse(Migration):
+    def up(self) -> None:
+        # See https://docs.mongoengine.org/guide/migration.html#example-1-addition-of-a-field
+        logging.info("Removing 'worker_version' field.")
+        db = get_db("cache")
+        db["cachedResponsesBlue"].update_many({}, {"$unset": {"worker_version": ""}})
+
+    def down(self) -> None:
+        raise IrreversibleMigration("This migration does not support rollback")
+
+    def validate(self) -> None:
+        logging.info("Ensure that a random selection of cached results don't have 'worker_version' field")
+
+        check_documents(DocCls=CachedResponse, sample_size=10)

--- a/jobs/mongodb_migration/tests/migrations/test_20230309141600_cache_add_job_runner_version.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230309141600_cache_add_job_runner_version.py
@@ -1,38 +1,52 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
+from typing import Optional
 
+import pytest
 from libcommon.resources import MongoResource
 from mongoengine.connection import get_db
-from pytest import raises
 
-from mongodb_migration.migration import IrreversibleMigration
-from mongodb_migration.migrations._20230313164200_cache_remove_worker_version import (
-    MigrationRemoveWorkerVersionFromCachedResponse,
+from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version import (
+    MigrationAddJobRunnerVersionToCacheResponse,
 )
 
 
-def test_cache_remove_worker_version(mongo_host: str) -> None:
-    with MongoResource(database="test_cache_remove_worker_version", host=mongo_host, mongoengine_alias="cache"):
+def test_cache_add_job_runner_version_without_worker_version(mongo_host: str) -> None:
+    with MongoResource(database="test_cache_add_job_runner_version", host=mongo_host, mongoengine_alias="cache"):
         db = get_db("cache")
-        db["cachedResponsesBlue"].delete_many({})
         db["cachedResponsesBlue"].insert_many(
-            [
-                {
-                    "kind": "/splits",
-                    "dataset": "dataset_without_worker_version",
-                    "http_status": 200,
-                    "worker_version": "1.0.0",
-                }
-            ]
+            [{"kind": "/splits", "dataset": "dataset_without_worker_version", "http_status": 200}]
         )
-        migration = MigrationRemoveWorkerVersionFromCachedResponse(
-            version="20230313164200", description="remove 'worker_version' field from cache"
+        migration = MigrationAddJobRunnerVersionToCacheResponse(
+            version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
         )
         migration.up()
         result = db["cachedResponsesBlue"].find_one({"dataset": "dataset_without_worker_version"})
         assert result
-        assert "worker_version" not in result
+        assert not result["job_runner_version"]
+        db["cachedResponsesBlue"].drop()
 
-        with raises(IrreversibleMigration):
-            migration.down()
+
+@pytest.mark.parametrize(
+    "worker_version,expected",
+    [
+        ("2.0.0", 2),
+        ("1.5.0", 1),
+        ("WrongFormat", None),
+        (None, None),
+    ],
+)
+def test_cache_add_job_runner_version(mongo_host: str, worker_version: str, expected: Optional[int]) -> None:
+    with MongoResource(database="test_cache_add_job_runner_version", host=mongo_host, mongoengine_alias="cache"):
+        db = get_db("cache")
+        db["cachedResponsesBlue"].insert_many(
+            [{"kind": "/splits", "dataset": "dataset", "http_status": 200, "worker_version": worker_version}]
+        )
+        migration = MigrationAddJobRunnerVersionToCacheResponse(
+            version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
+        )
+        migration.up()
+        result = db["cachedResponsesBlue"].find_one({"dataset": "dataset"})
+        assert result
+        assert result["job_runner_version"] == expected
         db["cachedResponsesBlue"].drop()

--- a/jobs/mongodb_migration/tests/migrations/test_20230309141600_cache_add_job_runner_version.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230309141600_cache_add_job_runner_version.py
@@ -1,52 +1,38 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
-from typing import Optional
 
-import pytest
 from libcommon.resources import MongoResource
 from mongoengine.connection import get_db
+from pytest import raises
 
-from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version import (
-    MigrationAddJobRunnerVersionToCacheResponse,
+from mongodb_migration.migration import IrreversibleMigration
+from mongodb_migration.migrations._20230313164200_cache_remove_worker_version import (
+    MigrationRemoveWorkerVersionFromCachedResponse,
 )
 
 
-def test_cache_add_job_runner_version_without_worker_version(mongo_host: str) -> None:
-    with MongoResource(database="test_cache_add_job_runner_version", host=mongo_host, mongoengine_alias="cache"):
+def test_cache_remove_worker_version(mongo_host: str) -> None:
+    with MongoResource(database="test_cache_remove_worker_version", host=mongo_host, mongoengine_alias="cache"):
         db = get_db("cache")
         db["cachedResponsesBlue"].delete_many({})
         db["cachedResponsesBlue"].insert_many(
-            [{"kind": "/splits", "dataset": "dataset_without_worker_version", "http_status": 200}]
+            [
+                {
+                    "kind": "/splits",
+                    "dataset": "dataset_without_worker_version",
+                    "http_status": 200,
+                    "worker_version": "1.0.0",
+                }
+            ]
         )
-        migration = MigrationAddJobRunnerVersionToCacheResponse(
-            version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
+        migration = MigrationRemoveWorkerVersionFromCachedResponse(
+            version="20230313164200", description="remove 'worker_version' field from cache"
         )
         migration.up()
         result = db["cachedResponsesBlue"].find_one({"dataset": "dataset_without_worker_version"})
         assert result
-        assert not result["job_runner_version"]
+        assert "worker_version" not in result
 
-
-@pytest.mark.parametrize(
-    "worker_version,expected",
-    [
-        ("2.0.0", 2),
-        ("1.5.0", 1),
-        ("WrongFormat", None),
-        (None, None),
-    ],
-)
-def test_cache_add_job_runner_version(mongo_host: str, worker_version: str, expected: Optional[int]) -> None:
-    with MongoResource(database="test_cache_add_job_runner_version", host=mongo_host, mongoengine_alias="cache"):
-        db = get_db("cache")
-        db["cachedResponsesBlue"].delete_many({})
-        db["cachedResponsesBlue"].insert_many(
-            [{"kind": "/splits", "dataset": "dataset", "http_status": 200, "worker_version": worker_version}]
-        )
-        migration = MigrationAddJobRunnerVersionToCacheResponse(
-            version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
-        )
-        migration.up()
-        result = db["cachedResponsesBlue"].find_one({"dataset": "dataset"})
-        assert result
-        assert result["job_runner_version"] == expected
+        with raises(IrreversibleMigration):
+            migration.down()
+        db["cachedResponsesBlue"].drop()

--- a/jobs/mongodb_migration/tests/migrations/test_20230313164200_cache_remove_worker_version.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230313164200_cache_remove_worker_version.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+from typing import Optional
+
+import pytest
+from libcommon.resources import MongoResource
+from mongoengine.connection import get_db
+
+from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version import (
+    MigrationAddJobRunnerVersionToCacheResponse,
+)
+
+
+def test_cache_add_job_runner_version_without_worker_version(mongo_host: str) -> None:
+    with MongoResource(database="test_cache_add_job_runner_version", host=mongo_host, mongoengine_alias="cache"):
+        db = get_db("cache")
+        db["cachedResponsesBlue"].insert_many(
+            [{"kind": "/splits", "dataset": "dataset_without_worker_version", "http_status": 200}]
+        )
+        migration = MigrationAddJobRunnerVersionToCacheResponse(
+            version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
+        )
+        migration.up()
+        result = db["cachedResponsesBlue"].find_one({"dataset": "dataset_without_worker_version"})
+        assert result
+        assert not result["job_runner_version"]
+        db["cachedResponsesBlue"].drop()
+
+
+@pytest.mark.parametrize(
+    "worker_version,expected",
+    [
+        ("2.0.0", 2),
+        ("1.5.0", 1),
+        ("WrongFormat", None),
+        (None, None),
+    ],
+)
+def test_cache_add_job_runner_version(mongo_host: str, worker_version: str, expected: Optional[int]) -> None:
+    with MongoResource(database="test_cache_add_job_runner_version", host=mongo_host, mongoengine_alias="cache"):
+        db = get_db("cache")
+        db["cachedResponsesBlue"].insert_many(
+            [{"kind": "/splits", "dataset": "dataset", "http_status": 200, "worker_version": worker_version}]
+        )
+        migration = MigrationAddJobRunnerVersionToCacheResponse(
+            version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
+        )
+        migration.up()
+        result = db["cachedResponsesBlue"].find_one({"dataset": "dataset"})
+        assert result
+        assert result["job_runner_version"] == expected
+        db["cachedResponsesBlue"].drop()

--- a/jobs/mongodb_migration/tests/migrations/test_20230313164200_cache_remove_worker_version.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230313164200_cache_remove_worker_version.py
@@ -1,52 +1,39 @@
+
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
-from typing import Optional
 
-import pytest
 from libcommon.resources import MongoResource
 from mongoengine.connection import get_db
+from pytest import raises
 
-from mongodb_migration.migrations._20230309141600_cache_add_job_runner_version import (
-    MigrationAddJobRunnerVersionToCacheResponse,
+from mongodb_migration.migration import IrreversibleMigration
+from mongodb_migration.migrations._20230313164200_cache_remove_worker_version import (
+    MigrationRemoveWorkerVersionFromCachedResponse,
 )
 
 
-def test_cache_add_job_runner_version_without_worker_version(mongo_host: str) -> None:
-    with MongoResource(database="test_cache_add_job_runner_version", host=mongo_host, mongoengine_alias="cache"):
+def test_cache_remove_worker_version(mongo_host: str) -> None:
+    with MongoResource(database="test_cache_remove_worker_version", host=mongo_host, mongoengine_alias="cache"):
         db = get_db("cache")
+        db["cachedResponsesBlue"].delete_many({})
         db["cachedResponsesBlue"].insert_many(
-            [{"kind": "/splits", "dataset": "dataset_without_worker_version", "http_status": 200}]
+            [
+                {
+                    "kind": "/splits",
+                    "dataset": "dataset_without_worker_version",
+                    "http_status": 200,
+                    "worker_version": "1.0.0",
+                }
+            ]
         )
-        migration = MigrationAddJobRunnerVersionToCacheResponse(
-            version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
+        migration = MigrationRemoveWorkerVersionFromCachedResponse(
+            version="20230313164200", description="remove 'worker_version' field from cache"
         )
         migration.up()
         result = db["cachedResponsesBlue"].find_one({"dataset": "dataset_without_worker_version"})
         assert result
-        assert not result["job_runner_version"]
-        db["cachedResponsesBlue"].drop()
+        assert "worker_version" not in result
 
-
-@pytest.mark.parametrize(
-    "worker_version,expected",
-    [
-        ("2.0.0", 2),
-        ("1.5.0", 1),
-        ("WrongFormat", None),
-        (None, None),
-    ],
-)
-def test_cache_add_job_runner_version(mongo_host: str, worker_version: str, expected: Optional[int]) -> None:
-    with MongoResource(database="test_cache_add_job_runner_version", host=mongo_host, mongoengine_alias="cache"):
-        db = get_db("cache")
-        db["cachedResponsesBlue"].insert_many(
-            [{"kind": "/splits", "dataset": "dataset", "http_status": 200, "worker_version": worker_version}]
-        )
-        migration = MigrationAddJobRunnerVersionToCacheResponse(
-            version="20230309141600", description="add 'job_runner_version' field based on 'worker_version' value"
-        )
-        migration.up()
-        result = db["cachedResponsesBlue"].find_one({"dataset": "dataset"})
-        assert result
-        assert result["job_runner_version"] == expected
+        with raises(IrreversibleMigration):
+            migration.down()
         db["cachedResponsesBlue"].drop()

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -79,7 +79,6 @@ class CachedResponse(Document):
         content (`dict`): The content of the cached response. Can be an error or a valid content.
         details (`dict`, optional): Additional details, eg. a detailed error that we don't want to send as a response.
         updated_at (`datetime`): When the cache entry has been last updated.
-        worker_version (`str`): The semver version of the worker that cached the response.
         job_runner_version (`int`): The version of the job runner that cached the response.
         dataset_git_revision (`str`): The commit (of the git dataset repo) used to generate the response.
         progress (`float`): Progress percentage (between 0. and 1.) if the result is not complete yet.
@@ -95,7 +94,6 @@ class CachedResponse(Document):
     http_status = EnumField(HTTPStatus, required=True)
     error_code = StringField()
     content = DictField(required=True)
-    worker_version = StringField()
     dataset_git_revision = StringField()
     progress = FloatField(min_value=0.0, max_value=1.0)
     job_runner_version = IntField()


### PR DESCRIPTION
In PR https://github.com/huggingface/datasets-server/pull/916, `job_runner_version` new field was created in order to version `JobRunner` with int instead of string. Now that we have all the logic depending on the new field `worker_version` is no more needed.