### PR TITLE
ci: 🎡 use the public key of the CI Hub

### DIFF
--- a/.github/workflows/_e2e_tests.yml
+++ b/.github/workflows/_e2e_tests.yml
@@ -72,7 +72,8 @@ jobs:
           ADMIN_UVICORN_PORT: "8081"
           COMMON_LOG_LEVEL: "DEBUG"
           API_HF_TIMEOUT_SECONDS: "10"
-          API_HF_JWT_PUBLIC_KEY_URL: "https://huggingface.co/api/keys/jwt"
+          # JWT: it's not tested in the e2e tests, but it's good to ensure we're able to fetch it at least.
+          API_HF_JWT_PUBLIC_KEY_URL: "https://hub-ci.huggingface.co/api/keys/jwt"
           API_HF_JWT_ALGORITHM: "EdDSA"
         run: |
           poetry run python -m pytest -vv -x tests


### PR DESCRIPTION
Note that it would not change anything because we don't e2e test the Hub sending a request to the datasets-server...