### PR TITLE
Adding ligth worker

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -161,9 +161,9 @@ workers:
   -
     deployName: "all"
     maxJobsPerNamespace: 1
-    workerOnlyJobTypes: "/config-names,/split-names-from-streaming,splits,/first-rows,/parquet-and-dataset-info,"
+    workerOnlyJobTypes: ""
     nodeSelector: {}
-    replicas: 6
+    replicas: 1
     resources:
       requests:
         cpu: 100m
@@ -177,7 +177,7 @@ workers:
     maxJobsPerNamespace: 1
     workerOnlyJobTypes: "config-parquet,dataset-parquet,/dataset-info,/split-names-from-dataset-info,config-size,dataset-size,dataset-split-names-from-streaming,dataset-split-names-from-dataset-info"
     nodeSelector: {}
-    replicas: 4
+    replicas: 1
     resources:
       requests:
         cpu: 100m

--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -159,11 +159,11 @@ api:
 
 workers:
   -
-    deployName: "generic"
+    deployName: "all"
     maxJobsPerNamespace: 1
-    workerOnlyJobTypes: ""
+    workerOnlyJobTypes: "/config-names,/split-names-from-streaming,splits,/first-rows,/parquet-and-dataset-info,"
     nodeSelector: {}
-    replicas: 1
+    replicas: 6
     resources:
       requests:
         cpu: 100m
@@ -175,37 +175,9 @@ workers:
   -
     deployName: "light"
     maxJobsPerNamespace: 1
-    workerOnlyJobTypes: "dataset-split-names-from-streaming,dataset-split-names-from-dataset-info"
+    workerOnlyJobTypes: "config-parquet,dataset-parquet,/dataset-info,/split-names-from-dataset-info,config-size,dataset-size,dataset-split-names-from-streaming,dataset-split-names-from-dataset-info"
     nodeSelector: {}
-    replicas: 1
-    resources:
-      requests:
-        cpu: 100m
-        memory: "512Mi"
-      limits:
-        cpu: 1
-        memory: "4Gi"
-    tolerations: []
-  -
-    deployName: "first-rows"
-    maxJobsPerNamespace: 1
-    workerOnlyJobTypes: "/first-rows"
-    nodeSelector: {}
-    replicas: 1
-    resources:
-      requests:
-        cpu: 100m
-        memory: "512Mi"
-      limits:
-        cpu: 1
-        memory: "4Gi"
-    tolerations: []
-  -
-    deployName: "parquet-and-dataset-info"
-    maxJobsPerNamespace: 1
-    workerOnlyJobTypes: "/parquet-and-dataset-info"
-    nodeSelector: {}
-    replicas: 1
+    replicas: 4
     resources:
       requests:
         cpu: 100m

--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -173,6 +173,20 @@ workers:
         memory: "4Gi"
     tolerations: []
   -
+    deployName: "light"
+    maxJobsPerNamespace: 1
+    workerOnlyJobTypes: "dataset-split-names-from-streaming,dataset-split-names-from-dataset-info"
+    nodeSelector: {}
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: "512Mi"
+      limits:
+        cpu: 1
+        memory: "4Gi"
+    tolerations: []
+  -
     deployName: "first-rows"
     maxJobsPerNamespace: 1
     workerOnlyJobTypes: "/first-rows"

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -202,6 +202,22 @@ workers:
         memory: "8Gi"
     tolerations: []
   -
+    deployName: "light"
+    maxJobsPerNamespace: 20
+    workerOnlyJobTypes: "dataset-split-names-from-streaming,dataset-split-names-from-dataset-info"
+    nodeSelector:
+      role-datasets-server-worker: "true"
+    replicas: 2
+    resources:
+      requests:
+        cpu: 1
+        memory: "2Gi"
+      limits:
+        cpu: 2
+        memory: "8Gi"
+    tolerations: []
+
+  -
     deployName: "config-names"
     maxJobsPerNamespace: 20
     workerOnlyJobTypes: "/config-names"

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -189,7 +189,7 @@ workers:
   -
     deployName: "all"
     maxJobsPerNamespace: 20
-    workerOnlyJobTypes: "/config-names,/split-names-from-streaming,splits,/first-rows,/parquet-and-dataset-info,"
+    workerOnlyJobTypes: ""
     nodeSelector:
       role-datasets-server-worker: "true"
     replicas: 22
@@ -207,7 +207,7 @@ workers:
     workerOnlyJobTypes: "config-parquet,dataset-parquet,/dataset-info,/split-names-from-dataset-info,config-size,dataset-size,dataset-split-names-from-streaming,dataset-split-names-from-dataset-info"
     nodeSelector:
       role-datasets-server-worker: "true"
-    replicas: 16
+    replicas: 2
     resources:
       requests:
         cpu: 200m

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -187,12 +187,12 @@ api:
 
 workers:
   -
-    deployName: "generic"
+    deployName: "all"
     maxJobsPerNamespace: 20
-    workerOnlyJobTypes: ""
+    workerOnlyJobTypes: "/config-names,/split-names-from-streaming,splits,/first-rows,/parquet-and-dataset-info,"
     nodeSelector:
       role-datasets-server-worker: "true"
-    replicas: 12
+    replicas: 22
     resources:
       requests:
         cpu: 1
@@ -204,146 +204,10 @@ workers:
   -
     deployName: "light"
     maxJobsPerNamespace: 20
-    workerOnlyJobTypes: "dataset-split-names-from-streaming,dataset-split-names-from-dataset-info"
+    workerOnlyJobTypes: "config-parquet,dataset-parquet,/dataset-info,/split-names-from-dataset-info,config-size,dataset-size,dataset-split-names-from-streaming,dataset-split-names-from-dataset-info"
     nodeSelector:
       role-datasets-server-worker: "true"
-    replicas: 2
-    resources:
-      requests:
-        cpu: 1
-        memory: "2Gi"
-      limits:
-        cpu: 2
-        memory: "8Gi"
-    tolerations: []
-
-  -
-    deployName: "config-names"
-    maxJobsPerNamespace: 20
-    workerOnlyJobTypes: "/config-names"
-    nodeSelector:
-      role-datasets-server-worker: "true"
-    replicas: 2
-    resources:
-      requests:
-        cpu: 1
-        memory: "2Gi"
-      limits:
-        cpu: 2
-        memory: "8Gi"
-    tolerations: []
-  -
-    deployName: "split-names-from-streaming"
-    maxJobsPerNamespace: 20
-    workerOnlyJobTypes: "/split-names-from-streaming"
-    nodeSelector:
-      role-datasets-server-worker: "true"
-    replicas: 2
-    resources:
-      requests:
-        cpu: 1
-        memory: "2Gi"
-      limits:
-        cpu: 2
-        memory: "8Gi"
-    tolerations: []
-  -
-    deployName: "splits"
-    maxJobsPerNamespace: 20
-    workerOnlyJobTypes: "/splits"
-    nodeSelector:
-      role-datasets-server-worker: "true"
-    replicas: 2
-    resources:
-      requests:
-        cpu: 1
-        memory: "2Gi"
-      limits:
-        cpu: 2
-        memory: "8Gi"
-    tolerations: []
-  -
-    deployName: "first-rows"
-    maxJobsPerNamespace: 20
-    workerOnlyJobTypes: "/first-rows"
-    nodeSelector:
-      role-datasets-server-worker: "true"
-    replicas: 2
-    resources:
-      requests:
-        cpu: 1
-        memory: "2Gi"
-      limits:
-        cpu: 2
-        memory: "8Gi"
-    tolerations: []
-  -
-    deployName: "parquet-and-dataset-info"
-    maxJobsPerNamespace: 20
-    workerOnlyJobTypes: "/parquet-and-dataset-info"
-    nodeSelector:
-      role-datasets-server-worker: "true"
-    replicas: 2
-    resources:
-      requests:
-        cpu: 1
-        memory: "2Gi"
-      limits:
-        cpu: 2
-        memory: "8Gi"
-    tolerations: []
-  -
-    deployName: "parquet"
-    maxJobsPerNamespace: 20
-    workerOnlyJobTypes: "dataset-parquet,config-parquet"
-    nodeSelector:
-      role-datasets-server-worker: "true"
-    replicas: 2
-    resources:
-      requests:
-        cpu: 200m
-        memory: "100Mi"
-      limits:
-        cpu: 2
-        memory: "1Gi"
-    tolerations: []
-  -
-    deployName: "dataset-info"
-    maxJobsPerNamespace: 20
-    workerOnlyJobTypes: "/dataset-info"
-    nodeSelector:
-      role-datasets-server-worker: "true"
-    replicas: 2
-    resources:
-      requests:
-        cpu: 200m
-        memory: "100Mi"
-      limits:
-        cpu: 2
-        memory: "1Gi"
-    tolerations: []
-  -
-    deployName: "split-names-from-dataset-info"
-    maxJobsPerNamespace: 20
-    workerOnlyJobTypes: "/split-names-from-dataset-info"
-    nodeSelector:
-      role-datasets-server-worker: "true"
-    replicas: 2
-    resources:
-      requests:
-        cpu: 200m
-        memory: "100Mi"
-      limits:
-        cpu: 2
-        memory: "1Gi"
-    tolerations: []
-  -
-    deployName: "sizes"
-    maxJobsPerNamespace: 20
-    workerOnlyJobTypes: "config-size,dataset-size"
-    nodeSelector:
-      role-datasets-server-worker: "true"
-    replicas: 2
+    replicas: 16
     resources:
       requests:
         cpu: 200m

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -290,13 +290,13 @@ api:
 workers:
   -
     # name of the deployment
-    deployName: "generic"
+    deployName: "all"
     # Maximum number of jobs running at the same time for the same namespace
     maxJobsPerNamespace: 1
     # job types that this worker can process
-    workerOnlyJobTypes: ""
+    workerOnlyJobTypes: "/config-names,/split-names-from-streaming,splits,/first-rows,/parquet-and-dataset-info,"
     nodeSelector: {}
-    replicas: 1
+    replicas: 6
     resources:
       requests:
         cpu: 0
@@ -309,144 +309,9 @@ workers:
     # Maximum number of jobs running at the same time for the same namespace
     maxJobsPerNamespace: 1
     # job types that this worker can process
-    workerOnlyJobTypes: "dataset-split-names-from-streaming,dataset-split-names-from-dataset-info"
+    workerOnlyJobTypes: "config-parquet,dataset-parquet,/dataset-info,/split-names-from-dataset-info,config-size,dataset-size,dataset-split-names-from-streaming,dataset-split-names-from-dataset-info"
     nodeSelector: {}
-    replicas: 1
-    resources:
-      requests:
-        cpu: 0
-      limits:
-        cpu: 0
-    tolerations: []
-  -
-    # name of the deployment
-    deployName: "config-names"
-    # Maximum number of jobs running at the same time for the same namespace
-    maxJobsPerNamespace: 1
-    # job types that this worker can process
-    workerOnlyJobTypes: "/config-names"
-    nodeSelector: {}
-    replicas: 1
-    resources:
-      requests:
-        cpu: 1
-      limits:
-        cpu: 1
-    tolerations: []
-  -
-    # name of the deployment
-    deployName: "split-names-from-streaming"
-    # Maximum number of jobs running at the same time for the same namespace
-    maxJobsPerNamespace: 1
-    # job types that this worker can process
-    workerOnlyJobTypes: "/split-names-from-streaming"
-    nodeSelector: {}
-    replicas: 1
-    resources:
-      requests:
-        cpu: 1
-      limits:
-        cpu: 1
-    tolerations: []
-  -
-    # name of the deployment
-    deployName: "splits"
-    # Maximum number of jobs running at the same time for the same namespace
-    maxJobsPerNamespace: 1
-    # job types that this worker can process
-    workerOnlyJobTypes: "/splits"
-    nodeSelector: {}
-    replicas: 1
-    resources:
-      requests:
-        cpu: 0
-      limits:
-        cpu: 0
-    tolerations: []
-  -
-    # name of the deployment
-    deployName: "first-rows"
-    # Maximum number of jobs running at the same time for the same namespace
-    maxJobsPerNamespace: 1
-    # job types that this worker can process
-    workerOnlyJobTypes: "/first-rows"
-    nodeSelector: {}
-    replicas: 1
-    resources:
-      requests:
-        cpu: 0
-      limits:
-        cpu: 0
-    tolerations: []
-  -
-    # name of the deployment
-    deployName: "parquet-and-dataset-info"
-    # Maximum number of jobs running at the same time for the same namespace
-    maxJobsPerNamespace: 1
-    # job types that this worker can process
-    workerOnlyJobTypes: "/parquet-and-dataset-info"
-    nodeSelector: {}
-    replicas: 1
-    resources:
-      requests:
-        cpu: 0
-      limits:
-        cpu: 0
-    tolerations: []
-  -
-    # name of the deployment
-    deployName: "parquet"
-    # Maximum number of jobs running at the same time for the same namespace
-    maxJobsPerNamespace: 1
-    # job types that this worker can process
-    workerOnlyJobTypes: "dataset-parquet,config-parquet"
-    nodeSelector: {}
-    replicas: 1
-    resources:
-      requests:
-        cpu: 0
-      limits:
-        cpu: 0
-    tolerations: []
-  -
-    # name of the deployment
-    deployName: "dataset-info"
-    # Maximum number of jobs running at the same time for the same namespace
-    maxJobsPerNamespace: 1
-    # job types that this worker can process
-    workerOnlyJobTypes: "/dataset-info"
-    nodeSelector: {}
-    replicas: 1
-    resources:
-      requests:
-        cpu: 0
-      limits:
-        cpu: 0
-    tolerations: []
-  -
-    # name of the deployment
-    deployName: "split-names-from-dataset-info"
-    # Maximum number of jobs running at the same time for the same namespace
-    maxJobsPerNamespace: 1
-    # job types that this worker can process
-    workerOnlyJobTypes: "/split-names-from-dataset-info"
-    nodeSelector: {}
-    replicas: 1
-    resources:
-      requests:
-        cpu: 0
-      limits:
-        cpu: 0
-    tolerations: []
-  -
-    # name of the deployment
-    deployName: "sizes"
-    # Maximum number of jobs running at the same time for the same namespace
-    maxJobsPerNamespace: 1
-    # job types that this worker can process
-    workerOnlyJobTypes: "config-size,dataset-size"
-    nodeSelector: {}
-    replicas: 1
+    replicas: 4
     resources:
       requests:
         cpu: 0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -305,6 +305,21 @@ workers:
     tolerations: []
   -
     # name of the deployment
+    deployName: "light"
+    # Maximum number of jobs running at the same time for the same namespace
+    maxJobsPerNamespace: 1
+    # job types that this worker can process
+    workerOnlyJobTypes: "dataset-split-names-from-streaming,dataset-split-names-from-dataset-info"
+    nodeSelector: {}
+    replicas: 1
+    resources:
+      requests:
+        cpu: 0
+      limits:
+        cpu: 0
+    tolerations: []
+  -
+    # name of the deployment
     deployName: "config-names"
     # Maximum number of jobs running at the same time for the same namespace
     maxJobsPerNamespace: 1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -294,9 +294,9 @@ workers:
     # Maximum number of jobs running at the same time for the same namespace
     maxJobsPerNamespace: 1
     # job types that this worker can process
-    workerOnlyJobTypes: "/config-names,/split-names-from-streaming,splits,/first-rows,/parquet-and-dataset-info,"
+    workerOnlyJobTypes: ""
     nodeSelector: {}
-    replicas: 6
+    replicas: 1
     resources:
       requests:
         cpu: 0
@@ -311,7 +311,7 @@ workers:
     # job types that this worker can process
     workerOnlyJobTypes: "config-parquet,dataset-parquet,/dataset-info,/split-names-from-dataset-info,config-size,dataset-size,dataset-split-names-from-streaming,dataset-split-names-from-dataset-info"
     nodeSelector: {}
-    replicas: 4
+    replicas: 1
     resources:
       requests:
         cpu: 0


### PR DESCRIPTION
Given the new job runners/ job types: `dataset-split-names-from-streaming and dataset-split-names-from-dataset-info`, we will move them to be processed in a dedicated "light" worker with 2 pods.