### PR TITLE
feat: 🎸 reduce the number of allowed jobs for one namespace

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -191,7 +191,7 @@ api:
 workers:
   -
     deployName: "all"
-    maxJobsPerNamespace: 20
+    maxJobsPerNamespace: 5
     workerOnlyJobTypes: ""
     nodeSelector:
       role-datasets-server-worker: "true"
@@ -206,8 +206,8 @@ workers:
     tolerations: []
   -
     deployName: "light"
-    maxJobsPerNamespace: 20
-    workerOnlyJobTypes: "config-parquet,dataset-parquet,/dataset-info,/split-names-from-dataset-info,config-size,dataset-size,dataset-split-names-from-streaming,dataset-split-names-from-dataset-info"
+    maxJobsPerNamespace: 2
+    workerOnlyJobTypes: "/config-names,config-parquet,dataset-parquet,/dataset-info,/split-names-from-dataset-info,config-size,dataset-size,dataset-split-names-from-streaming,dataset-split-names-from-dataset-info"
     nodeSelector:
       role-datasets-server-worker: "true"
     replicas: 2


### PR DESCRIPTION
Currently, 20 jobs are only for one namespace, blocking all the other users/datasets (220 waiting jobs). Also: moving config-names to the list of "light" jobs (even if it's not as light as the other ones, it's quick because it only creates the dataset builder.