### PR TITLE
Access docker host

### DIFF
--- a/tools/docker-compose-dev-base.yml
+++ b/tools/docker-compose-dev-base.yml
@@ -9,11 +9,11 @@ services:
       # huggingface_hub
       HF_ENDPOINT: ${COMMON_HF_ENDPOINT-https://hub-ci.huggingface.co} # see https://github.com/huggingface/datasets/pull/5196#issuecomment-1322191411
       # cache
-      CACHE_MONGO_URL: ${CACHE_MONGO_URL-mongodb://mongodb} # use mongo container by default
+      CACHE_MONGO_URL: ${CACHE_MONGO_URL-mongodb://localhost:${MONGO_PORT-27017}} # use mongo container by default
       CACHE_MONGO_DATABASE: ${CACHE_MONGO_DATABASE-datasets_server_cache}
       # queue
       QUEUE_MAX_JOBS_PER_NAMESPACE: ${QUEUE_MAX_JOBS_PER_NAMESPACE-1}
-      QUEUE_MONGO_URL: ${QUEUE_MONGO_URL-mongodb://mongodb} # use mongo container by default
+      QUEUE_MONGO_URL: ${QUEUE_MONGO_URL-mongodb://localhost:${MONGO_PORT-27017}} # use mongo container by default
       QUEUE_MONGO_DATABASE: ${QUEUE_MONGO_DATABASE-datasets_server_queue}
       # worker
       WORKER_CONTENT_MAX_BYTES: ${WORKER_CONTENT_MAX_BYTES-10_000_000}

--- a/tools/docker-compose-dev-datasets-server.yml
+++ b/tools/docker-compose-dev-datasets-server.yml
@@ -44,6 +44,8 @@ services:
     ports:
       # for debug
       - ${ADMIN_UVICORN_PORT-8081}:${ADMIN_UVICORN_PORT-8081}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   api:
     build:
       context: ..
@@ -68,6 +70,8 @@ services:
     ports:
       # for debug
       - ${API_UVICORN_PORT-8080}:${API_UVICORN_PORT-8080}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       - mongodb
     restart: unless-stopped
@@ -98,6 +102,8 @@ services:
       PARQUET_AND_DATASET_INFO_URL_TEMPLATE: ${PARQUET_AND_DATASET_INFO_URL_TEMPLATE-/datasets/%s/resolve/%s/%s}
       WORKER_STORAGE_PATHS: ${ASSETS_STORAGE_DIRECTORY-/assets}
       # ^ note: the datasets cache is automatically added, so no need to add it here
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       - mongodb
     restart: always

--- a/tools/docker-compose-dev-datasets-server.yml
+++ b/tools/docker-compose-dev-datasets-server.yml
@@ -79,6 +79,8 @@ services:
     build:
       context: ..
       dockerfile: services/worker/dev.Dockerfile
+    deploy:
+      replicas: 4
     volumes:
       - assets:${ASSETS_STORAGE_DIRECTORY-/assets}:rw
     extends:

--- a/tools/docker-compose-dev-datasets-server.yml
+++ b/tools/docker-compose-dev-datasets-server.yml
@@ -13,8 +13,10 @@ services:
       ASSETS_DIRECTORY: ${ASSETS_STORAGE_DIRECTORY-/assets}
       HOST: localhost
       PORT: 80
-      URL_ADMIN: http://admin:${ADMIN_UVICORN_PORT-8081}
-      URL_API: http://api:${API_UVICORN_PORT-8080}
+      URL_ADMIN: http://host.docker.internal:${ADMIN_UVICORN_PORT-8081}
+      URL_API: http://host.docker.internal:${API_UVICORN_PORT-8080}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       - api
       - admin
@@ -41,11 +43,7 @@ services:
     depends_on:
       - mongodb
     restart: always
-    ports:
-      # for debug
-      - ${ADMIN_UVICORN_PORT-8081}:${ADMIN_UVICORN_PORT-8081}
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    network_mode: host
   api:
     build:
       context: ..
@@ -67,11 +65,7 @@ services:
       API_UVICORN_HOSTNAME: 0.0.0.0 # required for docker compose
       API_UVICORN_NUM_WORKERS: ${API_UVICORN_NUM_WORKERS-2}
       API_UVICORN_PORT: ${API_UVICORN_PORT-8080}
-    ports:
-      # for debug
-      - ${API_UVICORN_PORT-8080}:${API_UVICORN_PORT-8080}
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    network_mode: host
     depends_on:
       - mongodb
     restart: unless-stopped
@@ -104,17 +98,13 @@ services:
       PARQUET_AND_DATASET_INFO_URL_TEMPLATE: ${PARQUET_AND_DATASET_INFO_URL_TEMPLATE-/datasets/%s/resolve/%s/%s}
       WORKER_STORAGE_PATHS: ${ASSETS_STORAGE_DIRECTORY-/assets}
       # ^ note: the datasets cache is automatically added, so no need to add it here
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-      - mongodb
+    network_mode: host
     restart: always
   mongodb:
     image: docker.io/mongo
     volumes:
       - mongo:/data/db:rw
     ports:
-      # for debug
       - "${MONGO_PORT-27017}:27017"
 volumes:
   assets:


### PR DESCRIPTION
- give the docker services access to the host network. It is required to be able to access a local port on the same machine,
for example.
- run 4 workers in parallel, it helps processing the jobs quicker