### PR TITLE
Support splits with dots

### DIFF
--- a/services/worker/src/worker/job_runners/parquet_and_dataset_info.py
+++ b/services/worker/src/worker/job_runners/parquet_and_dataset_info.py
@@ -159,7 +159,7 @@ def hf_hub_url(repo_id: str, filename: str, hf_endpoint: str, revision: str, url
     return (hf_endpoint + url_template) % (repo_id, quote(revision, safe=""), filename)
 
 
-p = re.compile(r"(?P<builder>[\w-]+?)-(?P<split>[\w]+?)(-[0-9]{5}-of-[0-9]{5})?.parquet")
+p = re.compile(r"(?P<builder>[\w-]+?)-(?P<split>\w+(\.\w+)*?)(-[0-9]{5}-of-[0-9]{5})?.parquet")
 
 
 def parse_repo_filename(filename: str) -> Tuple[str, str]:

--- a/services/worker/tests/job_runners/test_parquet_and_dataset_info.py
+++ b/services/worker/tests/job_runners/test_parquet_and_dataset_info.py
@@ -469,6 +469,7 @@ def test_compute_splits_response_simple_csv_error(
         ("config/builder-with-dashes-split.parquet", "split", "config", False),
         ("config/builder-split-00000-of-00001.parquet", "split", "config", False),
         ("config/builder-with-dashes-split-00000-of-00001.parquet", "split", "config", False),
+        ("config/builder-split.with.dots-00000-of-00001.parquet", "split.with.dots", "config", False),
         (
             "config/builder-with-dashes-caveat-asplitwithdashesisnotsupported-00000-of-00001.parquet",
             "asplitwithdashesisnotsupported",


### PR DESCRIPTION
The split regex is defined at https://github.com/huggingface/datasets/blob/4db8e33eb9cf6cd4453cdfa246c065e0eedf170c/src/datasets/naming.py#L28, I updated the one used to parque parquet file paths to use it