### PR TITLE
check if /splits-name-from-* exists before processing it 

### DIFF
--- a/services/worker/src/worker/job_runner.py
+++ b/services/worker/src/worker/job_runner.py
@@ -204,7 +204,7 @@ class JobRunner(ABC):
     worker_config: WorkerConfig
     common_config: CommonConfig
     processing_step: ProcessingStep
-    dataset_git_revision: Optional[str] = None
+    _dataset_git_revision: Optional[str] = None
 
     @staticmethod
     @abstractmethod
@@ -285,11 +285,11 @@ class JobRunner(ABC):
 
     def get_dataset_git_revision(self) -> Optional[str]:
         """Get the git revision of the dataset repository."""
-        if self.dataset_git_revision is None:
-            self.dataset_git_revision = get_dataset_git_revision(
+        if self._dataset_git_revision is None:
+            self._dataset_git_revision = get_dataset_git_revision(
                 dataset=self.dataset, hf_endpoint=self.common_config.hf_endpoint, hf_token=self.common_config.hf_token
             )
-        return self.dataset_git_revision
+        return self._dataset_git_revision
 
     # TODO: set the git revision as part of the job_info -> no need to get info from the Hub
     # if None: run the job

--- a/services/worker/src/worker/job_runner.py
+++ b/services/worker/src/worker/job_runner.py
@@ -204,6 +204,7 @@ class JobRunner(ABC):
     worker_config: WorkerConfig
     common_config: CommonConfig
     processing_step: ProcessingStep
+    dataset_git_revision: Optional[str] = None
 
     @staticmethod
     @abstractmethod
@@ -284,9 +285,11 @@ class JobRunner(ABC):
 
     def get_dataset_git_revision(self) -> Optional[str]:
         """Get the git revision of the dataset repository."""
-        return get_dataset_git_revision(
-            dataset=self.dataset, hf_endpoint=self.common_config.hf_endpoint, hf_token=self.common_config.hf_token
-        )
+        if self.dataset_git_revision is None:
+            self.dataset_git_revision = get_dataset_git_revision(
+                dataset=self.dataset, hf_endpoint=self.common_config.hf_endpoint, hf_token=self.common_config.hf_token
+            )
+        return self.dataset_git_revision
 
     # TODO: set the git revision as part of the job_info -> no need to get info from the Hub
     # if None: run the job

--- a/services/worker/tests/job_runners/config/test_split_names_from_dataset_info.py
+++ b/services/worker/tests/job_runners/config/test_split_names_from_dataset_info.py
@@ -3,8 +3,10 @@
 
 from http import HTTPStatus
 from typing import Any, Callable
+from unittest.mock import Mock
 
 import pytest
+from libcommon.constants import PROCESSING_STEP_SPLIT_NAMES_FROM_STREAMING_VERSION
 from libcommon.dataset import DatasetNotFoundError
 from libcommon.exceptions import CustomError
 from libcommon.processing_graph import ProcessingStep
@@ -127,6 +129,8 @@ def test_compute(
 ) -> None:
     upsert_response(kind="config-info", dataset=dataset, content=upstream_content, http_status=upstream_status)
     job_runner = get_job_runner(dataset, "config_name", app_config, False)
+    job_runner.get_dataset_git_revision = Mock(return_value="1.0.0")  # type: ignore
+
     if error_code:
         with pytest.raises(Exception) as e:
             job_runner.compute()
@@ -146,30 +150,37 @@ def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> No
 
 
 @pytest.mark.parametrize(
-    "streaming_response_status,error_code,status_code",
+    "streaming_response_status,dataset_git_revision,error_code,status_code",
     [
-        (HTTPStatus.OK, "ResponseAlreadyComputedError", HTTPStatus.INTERNAL_SERVER_ERROR),
-        (HTTPStatus.INTERNAL_SERVER_ERROR, "DatasetNotFoundError", HTTPStatus.NOT_FOUND),
+        (HTTPStatus.OK, "CURRENT_GIT_REVISION", "ResponseAlreadyComputedError", HTTPStatus.INTERNAL_SERVER_ERROR),
+        (HTTPStatus.INTERNAL_SERVER_ERROR, "CURRENT_GIT_REVISION", "DatasetNotFoundError", HTTPStatus.NOT_FOUND),
+        (HTTPStatus.OK, "DIFFERENT_GIT_REVISION", "DatasetNotFoundError", HTTPStatus.NOT_FOUND),
     ],
 )
 def test_response_already_computed(
     app_config: AppConfig,
     get_job_runner: GetJobRunner,
     streaming_response_status: HTTPStatus,
+    dataset_git_revision: str,
     error_code: str,
     status_code: HTTPStatus,
 ) -> None:
     dataset = "dataset"
     config = "config"
+    current_dataset_git_revision = "CURRENT_GIT_REVISION"
     upsert_response(
         kind="/split-names-from-streaming",
         dataset=dataset,
         config=config,
         content={},
+        dataset_git_revision=dataset_git_revision,
+        job_runner_version=PROCESSING_STEP_SPLIT_NAMES_FROM_STREAMING_VERSION,
+        progress=1.0,
         http_status=streaming_response_status,
     )
-    worker = get_job_runner(dataset, config, app_config, False)
+    job_runner = get_job_runner(dataset, config, app_config, False)
+    job_runner.get_dataset_git_revision = Mock(return_value=current_dataset_git_revision)  # type: ignore
     with pytest.raises(CustomError) as exc_info:
-        worker.compute()
+        job_runner.compute()
     assert exc_info.value.status_code == status_code
     assert exc_info.value.code == error_code

--- a/services/worker/tests/job_runners/config/test_split_names_from_streaming.py
+++ b/services/worker/tests/job_runners/config/test_split_names_from_streaming.py
@@ -4,8 +4,10 @@
 from dataclasses import replace
 from http import HTTPStatus
 from typing import Callable
+from unittest.mock import Mock
 
 import pytest
+from libcommon.constants import PROCESSING_STEP_SPLIT_NAMES_FROM_DATASET_INFO_VERSION
 from libcommon.exceptions import CustomError
 from libcommon.processing_graph import ProcessingStep
 from libcommon.queue import Priority
@@ -65,6 +67,7 @@ def get_job_runner(
 def test_process(app_config: AppConfig, get_job_runner: GetJobRunner, hub_public_csv: str) -> None:
     dataset, config, _ = get_default_config_split(hub_public_csv)
     job_runner = get_job_runner(dataset, config, app_config, False)
+    job_runner.get_dataset_git_revision = Mock(return_value="1.0.0")  # type: ignore
     assert job_runner.process()
     cached_response = get_response(kind=job_runner.processing_step.cache_kind, dataset=hub_public_csv, config=config)
     assert cached_response["http_status"] == HTTPStatus.OK
@@ -117,6 +120,7 @@ def test_compute_split_names_from_streaming_response(
         app_config if use_token else replace(app_config, common=replace(app_config.common, hf_token=None)),
         False,
     )
+    job_runner.get_dataset_git_revision = Mock(return_value="1.0.0")  # type: ignore
     if error_code is None:
         result = job_runner.compute().content
         assert result == expected_configs_response
@@ -137,29 +141,35 @@ def test_compute_split_names_from_streaming_response(
 
 
 @pytest.mark.parametrize(
-    "streaming_response_status,error_code",
+    "dataset_info_response_status,dataset_git_revision,error_code",
     [
-        (HTTPStatus.OK, "ResponseAlreadyComputedError"),
-        (HTTPStatus.INTERNAL_SERVER_ERROR, "SplitNamesFromStreamingError"),
+        (HTTPStatus.OK, "CURRENT_GIT_REVISION", "ResponseAlreadyComputedError"),
+        (HTTPStatus.INTERNAL_SERVER_ERROR, "CURRENT_GIT_REVISION", "SplitNamesFromStreamingError"),
     ],
 )
 def test_response_already_computed(
     app_config: AppConfig,
     get_job_runner: GetJobRunner,
-    streaming_response_status: HTTPStatus,
+    dataset_info_response_status: HTTPStatus,
+    dataset_git_revision: str,
     error_code: str,
 ) -> None:
     dataset = "dataset"
     config = "config"
+    current_dataset_git_revision = "CURRENT_GIT_REVISION"
     upsert_response(
         kind="/split-names-from-dataset-info",
         dataset=dataset,
         config=config,
         content={},
-        http_status=streaming_response_status,
+        dataset_git_revision=dataset_git_revision,
+        job_runner_version=PROCESSING_STEP_SPLIT_NAMES_FROM_DATASET_INFO_VERSION,
+        progress=1.0,
+        http_status=dataset_info_response_status,
     )
-    worker = get_job_runner(dataset, config, app_config, False)
+    job_runner = get_job_runner(dataset, config, app_config, False)
+    job_runner.get_dataset_git_revision = Mock(return_value=current_dataset_git_revision)  # type: ignore
     with pytest.raises(CustomError) as exc_info:
-        worker.compute()
+        job_runner.compute()
     assert exc_info.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
     assert exc_info.value.code == error_code

--- a/services/worker/tests/job_runners/config/test_split_names_from_streaming.py
+++ b/services/worker/tests/job_runners/config/test_split_names_from_streaming.py
@@ -10,7 +10,7 @@ from libcommon.exceptions import CustomError
 from libcommon.processing_graph import ProcessingStep
 from libcommon.queue import Priority
 from libcommon.resources import CacheMongoResource, QueueMongoResource
-from libcommon.simple_cache import DoesNotExist, get_response
+from libcommon.simple_cache import DoesNotExist, get_response, upsert_response
 
 from worker.config import AppConfig
 from worker.job_runners.config.split_names_from_streaming import (
@@ -134,3 +134,32 @@ def test_compute_split_names_from_streaming_response(
         assert response_dict["cause_exception"] == cause
         assert isinstance(response_dict["cause_traceback"], list)
         assert response_dict["cause_traceback"][0] == "Traceback (most recent call last):\n"
+
+
+@pytest.mark.parametrize(
+    "streaming_response_status,error_code",
+    [
+        (HTTPStatus.OK, "ResponseAlreadyComputedError"),
+        (HTTPStatus.INTERNAL_SERVER_ERROR, "SplitNamesFromStreamingError"),
+    ],
+)
+def test_response_already_computed(
+    app_config: AppConfig,
+    get_job_runner: GetJobRunner,
+    streaming_response_status: HTTPStatus,
+    error_code: str,
+) -> None:
+    dataset = "dataset"
+    config = "config"
+    upsert_response(
+        kind="/split-names-from-dataset-info",
+        dataset=dataset,
+        config=config,
+        content={},
+        http_status=streaming_response_status,
+    )
+    worker = get_job_runner(dataset, config, app_config, False)
+    with pytest.raises(CustomError) as exc_info:
+        worker.compute()
+    assert exc_info.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert exc_info.value.code == error_code

--- a/services/worker/tests/job_runners/config/test_split_names_from_streaming.py
+++ b/services/worker/tests/job_runners/config/test_split_names_from_streaming.py
@@ -145,6 +145,7 @@ def test_compute_split_names_from_streaming_response(
     [
         (HTTPStatus.OK, "CURRENT_GIT_REVISION", "ResponseAlreadyComputedError"),
         (HTTPStatus.INTERNAL_SERVER_ERROR, "CURRENT_GIT_REVISION", "SplitNamesFromStreamingError"),
+        (HTTPStatus.OK, "DIFFERENT_GIT_REVISION", "SplitNamesFromStreamingError"),
     ],
 )
 def test_response_already_computed(


### PR DESCRIPTION
Closes https://github.com/huggingface/datasets-server/issues/963

Adding validation on split names - config level job runners to throw an error if the response of the same info has already been computed.