### PR TITLE
Raise error when the viewer is disabled

### DIFF
--- a/docs/source/valid.mdx
+++ b/docs/source/valid.mdx
@@ -128,6 +128,12 @@ If a dataset is not valid, then the response looks like:
 {"valid": false}
 ```
 
+Some cases where a dataset is not valid are:
+- the dataset viewer is disabled
+- the dataset is gated but the access is not granted: no token is passed or the passed token is not authorized
+- the dataset is private
+- the dataset contains no data or the data format is not supported
+
 <Tip>
   Remember if a dataset is <a href="./quick_start#gated-datasets">gated</a>, you'll need to provide your user token to submit a successful query!
 </Tip>

--- a/libs/libcommon/src/libcommon/dataset.py
+++ b/libs/libcommon/src/libcommon/dataset.py
@@ -204,6 +204,7 @@ def get_dataset_info_for_supported_datasets(
         - [`~libcommon.dataset.GatedExtraFieldsError`]: if the dataset is gated, with extra fields.
             Programmatic access is not implemented for this type of dataset because there is no easy
             way to get the list of extra fields.
+        - [`~libcommon.dataset.DisabledViewerError`]: if the dataset viewer is disabled.
         - [`~libcommon.dataset.GatedDisabledError`]: if the dataset is gated, but disabled.
         - [`~libcommon.dataset.DatasetNotFoundError`]: if the dataset does not exist, or if the
             token does not give the sufficient access to the dataset, or if the dataset is private
@@ -276,6 +277,7 @@ def get_dataset_git_revision(
         - [`~libcommon.dataset.GatedExtraFieldsError`]: if the dataset is gated, with extra fields.
             Programmatic access is not implemented for this type of dataset because there is no easy
             way to get the list of extra fields.
+        - [`~libcommon.dataset.DisabledViewerError`]: if the dataset viewer is disabled.
         - [`~libcommon.dataset.GatedDisabledError`]: if the dataset is gated, but disabled.
         - [`~libcommon.dataset.DatasetNotFoundError`]: if the dataset does not exist, or if the
             token does not give the sufficient access to the dataset, or if the dataset is private
@@ -316,6 +318,7 @@ def check_support(
         - [`~libcommon.dataset.GatedExtraFieldsError`]: if the dataset is gated, with extra fields.
             Programmatic access is not implemented for this type of dataset because there is no easy
             way to get the list of extra fields.
+        - [`~libcommon.dataset.DisabledViewerError`]: if the dataset viewer is disabled.
         - [`~libcommon.dataset.GatedDisabledError`]: if the dataset is gated, but disabled.
         - [`~libcommon.dataset.DatasetNotFoundError`]: if the dataset does not exist, or if the
             token does not give the sufficient access to the dataset, or if the dataset is private

--- a/libs/libcommon/src/libcommon/dataset.py
+++ b/libs/libcommon/src/libcommon/dataset.py
@@ -75,6 +75,19 @@ class DatasetNotFoundError(DatasetError):
         )
 
 
+class DisabledViewerError(DatasetError):
+    """Raised when the dataset viewer is disabled."""
+
+    def __init__(self, message: str, cause: Optional[BaseException] = None):
+        super().__init__(
+            message=message,
+            status_code=HTTPStatus.NOT_FOUND,
+            code="DisabledViewerError",
+            cause=cause,
+            disclose_cause=False,
+        )
+
+
 class GatedDisabledError(DatasetError):
     """Raised when the dataset is gated, but disabled."""
 

--- a/libs/libcommon/src/libcommon/dataset.py
+++ b/libs/libcommon/src/libcommon/dataset.py
@@ -15,6 +15,7 @@ DatasetErrorCode = Literal[
     "AskAccessHubRequestError",
     "DatasetInfoHubRequestError",
     "DatasetNotFoundError",
+    "DisabledViewerError",
     "GatedDisabledError",
     "GatedExtraFieldsError",
 ]

--- a/libs/libcommon/src/libcommon/dataset.py
+++ b/libs/libcommon/src/libcommon/dataset.py
@@ -242,6 +242,8 @@ def get_dataset_info_for_supported_datasets(
         ) from err
     if dataset_info.private:
         raise DatasetNotFoundError("The dataset is private and private datasets are not yet supported.")
+    if dataset_info.cardData and not dataset_info.cardData.get("viewer", True):
+        raise DisabledViewerError("The dataset viewer has been disabled on this dataset.")
     return dataset_info
 
 


### PR DESCRIPTION
This PR raises error when the viewer is disabled, thus making the server fail quickly instead of relying on moon-landing.

Fix #1004.