### PR TITLE
First rows skip compute if a response already exists

### DIFF
--- a/services/worker/src/worker/job_runner.py
+++ b/services/worker/src/worker/job_runner.py
@@ -33,6 +33,7 @@ GeneralJobRunnerErrorCode = Literal[
     "TooBigContentError",
     "JobRunnerCrashedError",
     "JobRunnerExceededMaximumDurationError",
+    "ResponseAlreadyComputedError",
 ]
 
 # List of error codes that should trigger a retry.
@@ -176,6 +177,19 @@ class JobRunnerExceededMaximumDurationError(GeneralJobRunnerError):
             code="JobRunnerExceededMaximumDurationError",
             cause=cause,
             disclose_cause=False,
+        )
+
+
+class ResponseAlreadyComputedError(GeneralJobRunnerError):
+    """Raised when reponse has been already computed by another job runner."""
+
+    def __init__(self, message: str, cause: Optional[BaseException] = None):
+        super().__init__(
+            message=message,
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            code="ResponseAlreadyComputedError",
+            cause=cause,
+            disclose_cause=True,
         )
 
 
@@ -530,3 +544,22 @@ class JobRunner(ABC):
             f"response for dataset={self.dataset} config={self.config} split={self.split} had an error (exceeded"
             " maximum duration), cache updated"
         )
+
+    def raise_if_parallel_response_exists(self, parallel_job_type: str, parallel_job_version: int) -> None:
+        try:
+            existing_response = get_response_without_content(
+                kind=parallel_job_type, dataset=self.dataset, config=self.config, split=self.split
+            )
+            dataset_git_revision = self.get_dataset_git_revision()
+            if (
+                existing_response["http_status"] == HTTPStatus.OK
+                and existing_response["job_runner_version"] == parallel_job_version
+                and existing_response["progress"] == 1.0  # completed response
+                and dataset_git_revision is not None
+                and existing_response["dataset_git_revision"] == dataset_git_revision
+            ):
+                raise ResponseAlreadyComputedError(
+                    f"Response has already been computed by {parallel_job_type}. Compute will be skipped."
+                )
+        except DoesNotExist:
+            logging.debug(f"no cache found for {parallel_job_type}.")

--- a/services/worker/src/worker/job_runners/config/split_names_from_dataset_info.py
+++ b/services/worker/src/worker/job_runners/config/split_names_from_dataset_info.py
@@ -10,12 +10,7 @@ from libcommon.constants import (
     PROCESSING_STEP_SPLIT_NAMES_FROM_STREAMING_VERSION,
 )
 from libcommon.dataset import DatasetNotFoundError
-from libcommon.simple_cache import (
-    DoesNotExist,
-    SplitFullName,
-    get_response,
-    get_response_without_content,
-)
+from libcommon.simple_cache import DoesNotExist, SplitFullName, get_response
 
 from worker.job_runner import CompleteJobResult, JobRunnerError
 from worker.job_runners._datasets_based_job_runner import DatasetsBasedJobRunner
@@ -65,9 +60,7 @@ class ResponseAlreadyComputedError(SplitNamesFromDatasetInfoJobRunnerError):
         super().__init__(message, HTTPStatus.INTERNAL_SERVER_ERROR, "ResponseAlreadyComputedError", cause, True)
 
 
-def compute_split_names_from_dataset_info_response(
-    dataset: str, config: str, dataset_git_revision: Optional[str]
-) -> SplitsList:
+def compute_split_names_from_dataset_info_response(dataset: str, config: str) -> SplitsList:
     """
     Get the response of /split-names-from-dataset-info for one specific dataset and config on huggingface.co
     computed from cached response in dataset-info step.
@@ -96,22 +89,6 @@ def compute_split_names_from_dataset_info_response(
     </Tip>
     """
     logging.info(f"get split names from dataset info for dataset={dataset}, config={config}")
-    try:
-        streaming_response = get_response_without_content(
-            kind="/split-names-from-streaming", dataset=dataset, config=config
-        )
-        if (
-            streaming_response["http_status"] == HTTPStatus.OK
-            and streaming_response["job_runner_version"] == PROCESSING_STEP_SPLIT_NAMES_FROM_STREAMING_VERSION
-            and streaming_response["progress"] == 1.0  # completed response
-            and dataset_git_revision is not None
-            and streaming_response["dataset_git_revision"] == dataset_git_revision
-        ):
-            raise ResponseAlreadyComputedError(
-                "Response has already been computed by /split-names-from-streaming. Compute will be skipped."
-            )
-    except DoesNotExist:
-        logging.debug("no cache found for /split-names-from-streaming, will proceed to compute from config-info")
     try:
         response = get_response(kind="config-info", dataset=dataset)
     except DoesNotExist as e:
@@ -147,11 +124,12 @@ class SplitNamesFromDatasetInfoJobRunner(DatasetsBasedJobRunner):
             raise ValueError("dataset is required")
         if self.config is None:
             raise ValueError("config is required")
-        dataset_git_revision = self.get_dataset_git_revision()
+        self.raise_if_parallel_response_exists(
+            parallel_job_type="/split-names-from-streaming",
+            parallel_job_version=PROCESSING_STEP_SPLIT_NAMES_FROM_STREAMING_VERSION,
+        )
         return CompleteJobResult(
-            compute_split_names_from_dataset_info_response(
-                dataset=self.dataset, config=self.config, dataset_git_revision=dataset_git_revision
-            )
+            compute_split_names_from_dataset_info_response(dataset=self.dataset, config=self.config)
         )
 
     def get_new_splits(self, content: Mapping[str, Any]) -> set[SplitFullName]:

--- a/services/worker/src/worker/job_runners/config/split_names_from_streaming.py
+++ b/services/worker/src/worker/job_runners/config/split_names_from_streaming.py
@@ -11,11 +11,7 @@ from libcommon.constants import (
     PROCESSING_STEP_SPLIT_NAMES_FROM_DATASET_INFO_VERSION,
     PROCESSING_STEP_SPLIT_NAMES_FROM_STREAMING_VERSION,
 )
-from libcommon.simple_cache import (
-    DoesNotExist,
-    SplitFullName,
-    get_response_without_content,
-)
+from libcommon.simple_cache import SplitFullName
 
 from worker.job_runner import CompleteJobResult, JobRunnerError
 from worker.job_runners._datasets_based_job_runner import DatasetsBasedJobRunner
@@ -68,7 +64,6 @@ class ResponseAlreadyComputedError(SplitNamesFromStreamingJobRunnerError):
 def compute_split_names_from_streaming_response(
     dataset: str,
     config: str,
-    dataset_git_revision: Optional[str],
     hf_token: Optional[str] = None,
 ) -> SplitsList:
     """
@@ -105,23 +100,6 @@ def compute_split_names_from_streaming_response(
     </Tip>
     """
     logging.info(f"get split names for dataset={dataset}, config={config}")
-    try:
-        dataset_info_response = get_response_without_content(
-            kind="/split-names-from-dataset-info", dataset=dataset, config=config
-        )
-        if (
-            dataset_info_response["http_status"] == HTTPStatus.OK
-            and dataset_info_response["job_runner_version"] == PROCESSING_STEP_SPLIT_NAMES_FROM_DATASET_INFO_VERSION
-            and dataset_info_response["progress"] == 1.0  # completed response
-            and dataset_git_revision is not None
-            and dataset_info_response["dataset_git_revision"] == dataset_git_revision
-        ):
-            raise ResponseAlreadyComputedError(
-                "Response has already been computed by /split-names-from-dataset-info. Compute will be skipped."
-            )
-    except DoesNotExist:
-        logging.debug("no cache found for /split-names-from-dataset-info, will proceed to compute from streaming")
-
     use_auth_token: Union[bool, str, None] = hf_token if hf_token is not None else False
 
     try:
@@ -153,12 +131,14 @@ class SplitNamesFromStreamingJobRunner(DatasetsBasedJobRunner):
             raise ValueError("dataset is required")
         if self.config is None:
             raise ValueError("config is required")
-        dataset_git_revision = self.get_dataset_git_revision()
+        self.raise_if_parallel_response_exists(
+            parallel_job_type="/split-names-from-dataset-info",
+            parallel_job_version=PROCESSING_STEP_SPLIT_NAMES_FROM_DATASET_INFO_VERSION,
+        )
         return CompleteJobResult(
             compute_split_names_from_streaming_response(
                 dataset=self.dataset,
                 config=self.config,
-                dataset_git_revision=dataset_git_revision,
                 hf_token=self.common_config.hf_token,
             )
         )

--- a/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
@@ -14,6 +14,7 @@ from hffs.fs import HfFileSystem
 from libcommon.constants import (
     PARQUET_REVISION,
     PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_PARQUET_VERSION,
+    PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_STREAMING_VERSION,
 )
 from libcommon.processing_graph import ProcessingStep
 from libcommon.queue import JobInfo
@@ -324,6 +325,10 @@ class SplitFirstRowsFromParquetJobRunner(DatasetsBasedJobRunner):
     def compute(self) -> CompleteJobResult:
         if self.config is None or self.split is None:
             raise ValueError("config and split are required")
+        self.raise_if_parallel_response_exists(
+            parallel_job_type="split-first-rows-from-streaming",
+            parallel_job_version=PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_STREAMING_VERSION,
+        )
         return CompleteJobResult(
             compute_first_rows_response(
                 dataset=self.dataset,

--- a/services/worker/tests/job_runners/config/test_split_names_from_streaming.py
+++ b/services/worker/tests/job_runners/config/test_split_names_from_streaming.py
@@ -67,7 +67,6 @@ def get_job_runner(
 def test_process(app_config: AppConfig, get_job_runner: GetJobRunner, hub_public_csv: str) -> None:
     dataset, config, _ = get_default_config_split(hub_public_csv)
     job_runner = get_job_runner(dataset, config, app_config, False)
-    job_runner.get_dataset_git_revision = Mock(return_value="1.0.0")  # type: ignore
     assert job_runner.process()
     cached_response = get_response(kind=job_runner.processing_step.cache_kind, dataset=hub_public_csv, config=config)
     assert cached_response["http_status"] == HTTPStatus.OK

--- a/services/worker/tests/job_runners/split/test_first_rows_from_parquet.py
+++ b/services/worker/tests/job_runners/split/test_first_rows_from_parquet.py
@@ -5,9 +5,10 @@ import os
 from dataclasses import replace
 from http import HTTPStatus
 from typing import Callable
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
+from libcommon.constants import PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_STREAMING_VERSION
 from libcommon.exceptions import CustomError
 from libcommon.processing_graph import ProcessingStep
 from libcommon.queue import Priority
@@ -139,6 +140,7 @@ def test_compute(
             False,
         )
 
+        job_runner.get_dataset_git_revision = Mock(return_value="1.0.0")  # type: ignore
         if error_code:
             with pytest.raises(CustomError) as error_info:
                 job_runner.compute()
@@ -169,3 +171,50 @@ def test_compute(
             assert response["rows"][2]["truncated_cells"] == []
             assert response["rows"][2]["row"] == {"col1": 3, "col2": "c"}
         os.chdir(initial_location)
+
+
+@pytest.mark.parametrize(
+    "streaming_response_status,dataset_git_revision,error_code,status_code",
+    [
+        (HTTPStatus.OK, "CURRENT_GIT_REVISION", "ResponseAlreadyComputedError", HTTPStatus.INTERNAL_SERVER_ERROR),
+        (HTTPStatus.INTERNAL_SERVER_ERROR, "CURRENT_GIT_REVISION", "ConfigNotFoundError", HTTPStatus.NOT_FOUND),
+        (HTTPStatus.OK, "DIFFERENT_GIT_REVISION", "ConfigNotFoundError", HTTPStatus.NOT_FOUND),
+    ],
+)
+def test_response_already_computed(
+    app_config: AppConfig,
+    first_rows_config: FirstRowsConfig,
+    get_job_runner: GetJobRunner,
+    streaming_response_status: HTTPStatus,
+    dataset_git_revision: str,
+    error_code: str,
+    status_code: HTTPStatus,
+) -> None:
+    dataset = "dataset"
+    config = "config"
+    split = "split"
+    current_dataset_git_revision = "CURRENT_GIT_REVISION"
+    upsert_response(
+        kind="split-first-rows-from-streaming",
+        dataset=dataset,
+        config=config,
+        split=split,
+        content={},
+        dataset_git_revision=dataset_git_revision,
+        job_runner_version=PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_STREAMING_VERSION,
+        progress=1.0,
+        http_status=streaming_response_status,
+    )
+    job_runner = get_job_runner(
+        dataset,
+        config,
+        split,
+        app_config,
+        first_rows_config,
+        False,
+    )
+    job_runner.get_dataset_git_revision = Mock(return_value=current_dataset_git_revision)  # type: ignore
+    with pytest.raises(CustomError) as exc_info:
+        job_runner.compute()
+    assert exc_info.value.status_code == status_code
+    assert exc_info.value.code == error_code

--- a/services/worker/tests/job_runners/split/test_first_rows_from_streaming.py
+++ b/services/worker/tests/job_runners/split/test_first_rows_from_streaming.py
@@ -7,6 +7,7 @@ from typing import Callable
 from unittest.mock import Mock
 
 import pytest
+from libcommon.constants import PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_PARQUET_VERSION
 from datasets.packaged_modules import csv
 from libcommon.exceptions import CustomError
 from libcommon.processing_graph import ProcessingStep
@@ -275,3 +276,50 @@ def test_truncation(
     else:
         response = job_runner.compute().content
         assert get_json_size(response) <= rows_max_bytes
+
+
+@pytest.mark.parametrize(
+    "streaming_response_status,dataset_git_revision,error_code,status_code",
+    [
+        (HTTPStatus.OK, "CURRENT_GIT_REVISION", "ResponseAlreadyComputedError", HTTPStatus.INTERNAL_SERVER_ERROR),
+        (HTTPStatus.INTERNAL_SERVER_ERROR, "CURRENT_GIT_REVISION", "ConfigNotFoundError", HTTPStatus.NOT_FOUND),
+        (HTTPStatus.OK, "DIFFERENT_GIT_REVISION", "ConfigNotFoundError", HTTPStatus.NOT_FOUND),
+    ],
+)
+def test_response_already_computed(
+    app_config: AppConfig,
+    first_rows_config: FirstRowsConfig,
+    get_job_runner: GetJobRunner,
+    streaming_response_status: HTTPStatus,
+    dataset_git_revision: str,
+    error_code: str,
+    status_code: HTTPStatus,
+) -> None:
+    dataset = "dataset"
+    config = "config"
+    split = "split"
+    current_dataset_git_revision = "CURRENT_GIT_REVISION"
+    upsert_response(
+        kind="split-first-rows-from-parquet",
+        dataset=dataset,
+        config=config,
+        split=split,
+        content={},
+        dataset_git_revision=dataset_git_revision,
+        job_runner_version=PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_PARQUET_VERSION,
+        progress=1.0,
+        http_status=streaming_response_status,
+    )
+    job_runner = get_job_runner(
+        dataset,
+        config,
+        split,
+        app_config,
+        first_rows_config,
+        False,
+    )
+    job_runner.get_dataset_git_revision = Mock(return_value=current_dataset_git_revision)  # type: ignore
+    with pytest.raises(CustomError) as exc_info:
+        job_runner.compute()
+    assert exc_info.value.status_code == status_code
+    assert exc_info.value.code == error_code

--- a/services/worker/tests/job_runners/split/test_first_rows_from_streaming.py
+++ b/services/worker/tests/job_runners/split/test_first_rows_from_streaming.py
@@ -7,8 +7,8 @@ from typing import Callable
 from unittest.mock import Mock
 
 import pytest
-from libcommon.constants import PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_PARQUET_VERSION
 from datasets.packaged_modules import csv
+from libcommon.constants import PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_PARQUET_VERSION
 from libcommon.exceptions import CustomError
 from libcommon.processing_graph import ProcessingStep
 from libcommon.queue import Priority

--- a/services/worker/tests/job_runners/split/test_first_rows_from_streaming.py
+++ b/services/worker/tests/job_runners/split/test_first_rows_from_streaming.py
@@ -4,6 +4,7 @@
 from dataclasses import replace
 from http import HTTPStatus
 from typing import Callable
+from unittest.mock import Mock
 
 import pytest
 from datasets.packaged_modules import csv
@@ -173,6 +174,8 @@ def test_number_rows(
         first_rows_config,
         False,
     )
+    job_runner.get_dataset_git_revision = Mock(return_value="1.0.0")  # type: ignore
+
     if error_code is None:
         upsert_response(
             kind="/split-names-from-streaming",
@@ -262,6 +265,8 @@ def test_truncation(
         content={"splits": [{"dataset": dataset, "config": config, "split": split}]},
         http_status=HTTPStatus.OK,
     )
+
+    job_runner.get_dataset_git_revision = Mock(return_value="1.0.0")  # type: ignore
 
     if error_code:
         with pytest.raises(CustomError) as error_info:


### PR DESCRIPTION
Add validation on first-rows job runners to skip compute if a similar response already exists (Parallel response split-first-rows-from-streaming vs split-first-rows-from-parquet).
I moved the validation at job runner level since we have exactly same logic for split-names-from-streaming vs split-names-from-dataset-info.
Context: https://github.com/huggingface/datasets-server/pull/988#issuecomment-1491968842