### PR TITLE
Disable full backfill action

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -103,7 +103,7 @@ mongodbMigration:
 # --- jobs (post-upgrade hooks) ---
 
 cacheMaintenance:
-  action: "backfill"
+  action: "skip"
   resources:
     requests:
       cpu: 100m

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -109,7 +109,7 @@ mongodbMigration:
 # --- jobs (post-upgrade hooks) ---
 
 cacheMaintenance:
-  action: "backfill"
+  action: "skip"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
Disabling backfill Job action since it was intended to run only one time.
Later, it will be a cron job (But should backfill only missing cache records in order to avoid appending too many jobs). 