### PR TITLE
fix: 🐛 reduce the k8s job TTL to 5 minutes

### DIFF
--- a/chart/templates/jobs/cache-maintenance/job.yaml
+++ b/chart/templates/jobs/cache-maintenance/job.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
 spec:
-  ttlSecondsAfterFinished: 86400
+  ttlSecondsAfterFinished: 300
   template:
     metadata:
       labels: {{ include "labels.cacheMaintenance" . | nindent 8 }}


### PR DESCRIPTION
It is required to allow helm uninstall quickly if necessary.

✅ Closes: https://github.com/huggingface/datasets-server/issues/1035