### PR TITLE
feat: 🎸 get the dataset state, and backfill the missing parts

### DIFF
--- a/jobs/cache_maintenance/tests/test_backfill_cache.py
+++ b/jobs/cache_maintenance/tests/test_backfill_cache.py
@@ -22,6 +22,7 @@ def test_backfill_cache() -> None:
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=1,
             )
         ]

--- a/jobs/cache_maintenance/tests/test_collect_metrics.py
+++ b/jobs/cache_maintenance/tests/test_collect_metrics.py
@@ -33,6 +33,7 @@ def test_collect_metrics() -> None:
             required_by_dataset_viewer=False,
             ancestors=[],
             children=[],
+            parents=[],
             job_runner_version=1,
         )
     ]

--- a/jobs/cache_maintenance/tests/test_upgrade_cache.py
+++ b/jobs/cache_maintenance/tests/test_upgrade_cache.py
@@ -31,6 +31,7 @@ def test_upgrade_cache(
             required_by_dataset_viewer=False,
             ancestors=[],
             children=[],
+            parents=[],
             job_runner_version=1,
         )
     ]

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -279,41 +279,50 @@ class Queue:
 
         Returns: the job
         """
-        existing = Job.objects(type=job_type, dataset=dataset, config=config, split=split, status=Status.WAITING)
-        if existing(force=True).count() > 0:
-            force = True
-        if existing(priority=Priority.NORMAL).count() > 0:
-            priority = Priority.NORMAL
-        existing.update(finished_at=get_datetime(), status=Status.CANCELLED)
+        canceled_jobs = self.cancel_jobs(
+            job_type=job_type, dataset=dataset, config=config, split=split, statuses_to_cancel=[Status.WAITING]
+        )
+        for job in canceled_jobs:
+            if job["force"]:
+                force = True
+            if job["priority"] == Priority.NORMAL:
+                priority = Priority.NORMAL
         return self._add_job(
             job_type=job_type, dataset=dataset, config=config, split=split, force=force, priority=priority
         )
 
-    def cancel_pending_jobs(
+    def cancel_jobs(
         self,
         job_type: str,
         dataset: str,
         config: Optional[str] = None,
         split: Optional[str] = None,
-    ) -> int:
-        """Cancel pending jobs (WAITING and STARTED) from the queue.
+        statuses_to_cancel: Optional[List[Status]] = None,
+    ) -> List[JobDict]:
+        """Cancel jobs from the queue.
 
-        Returns a tuple with the max force (False<True) and priority (LOW<NORMAL) of the cancelled jobs.
+        Returns the list of canceled jobs (as JobDict, before they are canceled, to be able to know their previous
+        status)
 
         Args:
             job_type (`str`): The type of the job
             dataset (`str`): The dataset on which to apply the job.
             config (`str`, optional): The config on which to apply the job.
             split (`str`, optional): The config on which to apply the job.
+            statuses_to_cancel (`list[Status]`, optional): The list of statuses to cancel. Defaults to
+                [Status.WAITING, Status.STARTED].
 
         Returns:
-            `int`: The number of cancelled jobs
+            `list[JobDict]`: The list of canceled jobs
         """
+        if statuses_to_cancel is None:
+            statuses_to_cancel = [Status.WAITING, Status.STARTED]
         existing = Job.objects(
-            type=job_type, dataset=dataset, config=config, split=split, status__in=[Status.WAITING, Status.STARTED]
+            type=job_type, dataset=dataset, config=config, split=split, status__in=statuses_to_cancel
         )
+        job_dicts = [job.to_dict() for job in existing]
         existing.update(finished_at=get_datetime(), status=Status.CANCELLED)
-        return len(existing)
+        return job_dicts
 
     def _get_next_waiting_job_for_priority(
         self, priority: Priority, only_job_types: Optional[list[str]] = None

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -289,6 +289,32 @@ class Queue:
             job_type=job_type, dataset=dataset, config=config, split=split, force=force, priority=priority
         )
 
+    def cancel_pending_jobs(
+        self,
+        job_type: str,
+        dataset: str,
+        config: Optional[str] = None,
+        split: Optional[str] = None,
+    ) -> int:
+        """Cancel pending jobs (WAITING and STARTED) from the queue.
+
+        Returns a tuple with the max force (False<True) and priority (LOW<NORMAL) of the cancelled jobs.
+
+        Args:
+            job_type (`str`): The type of the job
+            dataset (`str`): The dataset on which to apply the job.
+            config (`str`, optional): The config on which to apply the job.
+            split (`str`, optional): The config on which to apply the job.
+
+        Returns:
+            `int`: The number of cancelled jobs
+        """
+        existing = Job.objects(
+            type=job_type, dataset=dataset, config=config, split=split, status__in=[Status.WAITING, Status.STARTED]
+        )
+        existing.update(finished_at=get_datetime(), status=Status.CANCELLED)
+        return len(existing)
+
     def _get_next_waiting_job_for_priority(
         self, priority: Priority, only_job_types: Optional[list[str]] = None
     ) -> Job:

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -184,6 +184,29 @@ def get_response_without_content(
     }
 
 
+class CacheEntryMetadata(CacheEntryWithoutContent):
+    updated_at: datetime
+
+
+# Note: we let the exceptions throw (ie DoesNotExist): it's the responsibility of the caller to manage them
+def get_response_metadata(
+    kind: str, dataset: str, config: Optional[str] = None, split: Optional[str] = None
+) -> CacheEntryMetadata:
+    response = (
+        CachedResponse.objects(kind=kind, dataset=dataset, config=config, split=split)
+        .only("http_status", "error_code", "job_runner_version", "dataset_git_revision", "progress", "updated_at")
+        .get()
+    )
+    return {
+        "http_status": response.http_status,
+        "error_code": response.error_code,
+        "dataset_git_revision": response.dataset_git_revision,
+        "job_runner_version": response.job_runner_version,
+        "progress": response.progress,
+        "updated_at": response.updated_at,
+    }
+
+
 class CacheEntry(CacheEntryWithoutContent):
     content: Mapping[str, Any]
 

--- a/libs/libcommon/src/libcommon/state.py
+++ b/libs/libcommon/src/libcommon/state.py
@@ -4,19 +4,23 @@
 from __future__ import annotations
 
 import contextlib
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from libcommon.processing_graph import ProcessingGraph, ProcessingStep
 from libcommon.queue import Priority, Queue
 from libcommon.simple_cache import (
-    CacheEntryWithoutContent,
+    CacheEntryMetadata,
     DoesNotExist,
     get_best_response,
     get_response,
-    get_response_without_content,
+    get_response_metadata,
 )
 
+# TODO: use the term Artifact elsewhere in the code (a Step should produce one or several Artifacts, depending on the
+# input level: one, one per dataset, one per config, or one per split)
+# A job and a cache entry is related to an Artifact, not to a Step
 # TODO: assets, cached_assets, parquet files
 # TODO: obsolete/dangling cache entries and jobs
 # TODO: report, show in endpoint
@@ -92,21 +96,19 @@ class CacheState:
     config: Optional[str]
     split: Optional[str]
     cache_kind: str
-    cache_entry_without_content: Optional[CacheEntryWithoutContent] = field(init=False)
+    cache_entry_metadata: Optional[CacheEntryMetadata] = field(init=False)
     exists: bool = field(init=False)
     is_success: bool = field(init=False)
 
     def __post_init__(self) -> None:
-        self.cache_entry_without_content = None
+        self.cache_entry_metadata = None
         with contextlib.suppress(DoesNotExist):
-            self.cache_entry_without_content = get_response_without_content(
+            self.cache_entry_metadata = get_response_metadata(
                 kind=self.cache_kind, dataset=self.dataset, config=self.config, split=self.split
             )
         """Whether the cache entry exists."""
-        self.exists = self.cache_entry_without_content is not None
-        self.is_success = (
-            self.cache_entry_without_content is not None and self.cache_entry_without_content["http_status"] < 400
-        )
+        self.exists = self.cache_entry_metadata is not None
+        self.is_success = self.cache_entry_metadata is not None and self.cache_entry_metadata["http_status"] < 400
 
     def as_dict(self) -> Dict[str, Any]:
         return {
@@ -114,25 +116,33 @@ class CacheState:
             "is_success": self.is_success,
         }
 
-    def should_be_refreshed(self) -> bool:
-        empty = self.cache_entry_without_content is None
-        error_to_retry = self.cache_entry_without_content is not None and (
-            self.cache_entry_without_content["http_status"] >= 400
-            and self.cache_entry_without_content["error_code"] in ERROR_CODES_TO_RETRY
+    def is_empty(self) -> bool:
+        return self.cache_entry_metadata is None
+
+    def is_error_to_retry(self) -> bool:
+        return self.cache_entry_metadata is not None and (
+            self.cache_entry_metadata["http_status"] >= 400
+            and self.cache_entry_metadata["error_code"] in ERROR_CODES_TO_RETRY
         )
-        # TODO: old git revision
-        # TODO: old job_runner_version
-        return empty or error_to_retry
+
+    def is_older_than(self, other: "CacheState") -> bool:
+        if self.cache_entry_metadata is None or other.cache_entry_metadata is None:
+            return False
+        return self.cache_entry_metadata["updated_at"] < other.cache_entry_metadata["updated_at"]
+
+    # TODO: old git revision
+    # TODO: old job_runner_version
 
 
 @dataclass
-class StepState:
-    """The state of a step for a given input."""
+class ArtifactState:
+    """The state of an artifact."""
 
+    step: ProcessingStep
     dataset: str
     config: Optional[str]
     split: Optional[str]
-    step: ProcessingStep
+
     job_state: JobState = field(init=False)
     cache_state: CacheState = field(init=False)
 
@@ -148,7 +158,8 @@ class StepState:
                 raise ValueError("Step input type is split, but config or split is None")
         else:
             raise ValueError(f"Invalid step input type: {self.step.input_type}")
-        self.id = f"{self.step.name}[{self.dataset},{self.config},{self.split}]"
+        self.id = ",".join([p for p in (self.step.name, self.dataset, self.config, self.split) if p])
+
         self.job_state = JobState(
             job_type=self.step.job_type, dataset=self.dataset, config=self.config, split=self.split
         )
@@ -156,13 +167,13 @@ class StepState:
             cache_kind=self.step.cache_kind, dataset=self.dataset, config=self.config, split=self.split
         )
 
-    def get_parent_step_states(self, parent_step: ProcessingStep) -> List["StepState"]:
+    def get_parent_artifact_states(self, parent_step: ProcessingStep) -> List["ArtifactState"]:
         if parent_step.input_type == "dataset":
-            return [StepState(step=parent_step, dataset=self.dataset, config=None, split=None)]
+            return [ArtifactState(step=parent_step, dataset=self.dataset, config=None, split=None)]
         elif parent_step.input_type == "config":
             return (
                 [
-                    StepState(
+                    ArtifactState(
                         step=parent_step,
                         dataset=self.dataset,
                         config=self.config,
@@ -171,12 +182,12 @@ class StepState:
                 ]
                 if self.step.input_type in ["config", "split"]
                 else []
-                # ^ fan-in: config->dataset. We just ignore the case
+                # ^ fan-in: config->dataset. For now, we don't return the list of parent artifact states in that case
             )
         else:
             return (
                 [
-                    StepState(
+                    ArtifactState(
                         step=parent_step,
                         dataset=self.dataset,
                         config=self.config,
@@ -185,34 +196,18 @@ class StepState:
                 ]
                 if self.step.input_type == "split"
                 else []
-                # ^ fan-in: split->config, or split->dataset. We just ignore the case
+                # ^ fan-in: split->config, or split->dataset. For now, we don't return the list of parent artifact
+                #  states in that case
             )
 
-    def get_all_parents_step_states(self) -> List[List["StepState"]]:
-        return [self.get_parent_step_states(parent_step) for parent_step in self.step.parents]
-
-    def backfill(self, force: bool = True, priority: Priority = Priority.LOW) -> None:
-        Queue().upsert_job(
-            job_type=self.step.job_type,
-            dataset=self.dataset,
-            config=self.config,
-            split=self.split,
-            force=force,
-            priority=priority,
-        )
-
-    def is_in_process(self) -> bool:
-        return self.job_state.is_in_process
-
-    def should_be_backfilled(self) -> bool:
-        return self.cache_state.should_be_refreshed() and not self.job_state.is_in_process
+    def get_all_parents_artifact_states(self) -> List[List["ArtifactState"]]:
+        return [self.get_parent_artifact_states(parent_step) for parent_step in self.step.parents]
 
     def as_dict(self) -> Dict[str, Any]:
         return {
-            "step_name": self.step.name,
+            "id": self.id,
             "job_state": self.job_state.as_dict(),
             "cache_state": self.cache_state.as_dict(),
-            "should_be_backfilled": self.should_be_backfilled(),
         }
 
 
@@ -225,11 +220,11 @@ class SplitState:
     split: str
     processing_graph: ProcessingGraph
 
-    step_states_by_step: Dict[str, StepState] = field(init=False)
+    artifact_state_by_step: Dict[str, ArtifactState] = field(init=False)
 
     def __post_init__(self) -> None:
-        self.step_state_by_step = {
-            step.name: StepState(step=step, dataset=self.dataset, config=self.config, split=self.split)
+        self.artifact_state_by_step = {
+            step.name: ArtifactState(step=step, dataset=self.dataset, config=self.config, split=self.split)
             for step in self.processing_graph.steps.values()
             if step.input_type == "split"
         }
@@ -237,7 +232,7 @@ class SplitState:
     def as_dict(self) -> Dict[str, Any]:
         return {
             "split": self.split,
-            "step_states": [step_state.as_dict() for step_state in self.step_state_by_step.values()],
+            "artifact_states": [artifact_state.as_dict() for artifact_state in self.artifact_state_by_step.values()],
         }
 
 
@@ -251,11 +246,11 @@ class ConfigState:
 
     split_names: List[str] = field(init=False)
     split_states: List[SplitState] = field(init=False)
-    step_states_by_step: Dict[str, StepState] = field(init=False)
+    artifact_state_by_step: Dict[str, ArtifactState] = field(init=False)
 
     def __post_init__(self) -> None:
-        self.step_state_by_step = {
-            step.name: StepState(step=step, dataset=self.dataset, config=self.config, split=None)
+        self.artifact_state_by_step = {
+            step.name: ArtifactState(step=step, dataset=self.dataset, config=self.config, split=None)
             for step in self.processing_graph.steps.values()
             if step.input_type == "config"
         }
@@ -274,27 +269,80 @@ class ConfigState:
         return {
             "config": self.config,
             "split_states": [split_state.as_dict() for split_state in self.split_states],
-            "step_states": [step_state.as_dict() for step_state in self.step_state_by_step.values()],
+            "artifact_states": [artifact_state.as_dict() for artifact_state in self.artifact_state_by_step.values()],
         }
 
 
 @dataclass
-class StepStatesByStatus:
-    blocked_by_parent: Dict[str, StepState] = field(default_factory=dict)
-    should_be_backfilled: Dict[str, StepState] = field(default_factory=dict)
-    in_process: Dict[str, StepState] = field(default_factory=dict)
-    up_to_date: Dict[str, StepState] = field(default_factory=dict)
-    undefined: Dict[str, StepState] = field(default_factory=dict)
+class CacheStatus:
+    blocked_by_parent: Dict[str, ArtifactState] = field(default_factory=dict)
+    cache_is_outdated_by_parent: Dict[str, ArtifactState] = field(default_factory=dict)
+    cache_is_empty: Dict[str, ArtifactState] = field(default_factory=dict)
+    cache_is_error_to_retry: Dict[str, ArtifactState] = field(default_factory=dict)
+    up_to_date: Dict[str, ArtifactState] = field(default_factory=dict)
 
-    def get_ids(self) -> Dict[str, List[str]]:
-        # for tests
-        return {
-            "blocked_by_parent": sorted(self.blocked_by_parent.keys()),
-            "should_be_backfilled": sorted(self.should_be_backfilled.keys()),
-            "in_process": sorted(self.in_process.keys()),
-            "up_to_date": sorted(self.up_to_date.keys()),
-            "undefined": sorted(self.undefined.keys()),
-        }
+
+@dataclass
+class QueueStatus:
+    in_process: Dict[str, ArtifactState] = field(default_factory=dict)
+
+
+@dataclass
+class Task(ABC):
+    artifact_state: ArtifactState
+
+    id: str = field(init=False)
+
+    @abstractmethod
+    def run(self) -> None:
+        pass
+
+
+@dataclass
+class CreateJobTask(Task):
+    force: bool
+    priority: Priority
+
+    def __post_init__(self) -> None:
+        self.id = f"CreateJob[{self.artifact_state.id}]"
+
+    def run(self) -> None:
+        Queue().upsert_job(
+            job_type=self.artifact_state.step.job_type,
+            dataset=self.artifact_state.dataset,
+            config=self.artifact_state.config,
+            split=self.artifact_state.split,
+            force=self.force,
+            priority=self.priority,
+        )
+
+
+@dataclass
+class DeleteJobTask(Task):
+    def __post_init__(self) -> None:
+        self.id = f"DeleteJob[{self.artifact_state.id}]"
+
+    def run(self) -> None:
+        # TODO: the started jobs are also canceled: we need to ensure the job runners will
+        # not try to update the cache when they finish
+        Queue().cancel_pending_jobs(
+            job_type=self.artifact_state.step.job_type,
+            dataset=self.artifact_state.dataset,
+            config=self.artifact_state.config,
+            split=self.artifact_state.split,
+        )
+
+
+@dataclass
+class Plan:
+    tasks: List[Task] = field(default_factory=list)
+
+    def add(self, task: Task) -> None:
+        self.tasks.append(task)
+
+    def run(self) -> None:
+        for task in self.tasks:
+            task.run()
 
 
 @dataclass
@@ -306,92 +354,127 @@ class DatasetState:
 
     config_names: List[str] = field(init=False)
     config_states: List[ConfigState] = field(init=False)
-    step_states_by_step: Dict[str, StepState] = field(init=False)
-    step_states_by_status: StepStatesByStatus = field(init=False)
+    artifact_state_by_step: Dict[str, ArtifactState] = field(init=False)
+    cache_status: CacheStatus = field(init=False)
+    queue_status: QueueStatus = field(init=False)
+    plan: Plan = field(init=False)
 
     def __post_init__(self) -> None:
-        self.step_state_by_step = {
-            step.name: StepState(step=step, dataset=self.dataset, config=None, split=None)
+        self.artifact_state_by_step = {
+            step.name: ArtifactState(step=step, dataset=self.dataset, config=None, split=None)
             for step in self.processing_graph.steps.values()
             if step.input_type == "dataset"
         }
-
         try:
             self.config_names = fetch_config_names(self.dataset)
         except Exception:
             self.config_names = []
-
         self.config_states = [
             ConfigState(dataset=self.dataset, config=config_name, processing_graph=self.processing_graph)
             for config_name in self.config_names
         ]
+        self.cache_status = self._get_cache_status()
+        self.queue_status = self._get_queue_status()
+        self.plan = self._create_plan()
 
-        self.step_states_by_status = self._get_step_states_by_status()
-
-    def _get_step_states_for_step(self, step: ProcessingStep) -> List[StepState]:
+    def _get_artifact_states_for_step(self, step: ProcessingStep) -> List[ArtifactState]:
         if step.input_type == "dataset":
-            step_states = [self.step_state_by_step[step.name]]
+            artifact_states = [self.artifact_state_by_step[step.name]]
         elif step.input_type == "config":
-            step_states = [config_state.step_state_by_step[step.name] for config_state in self.config_states]
+            artifact_states = [config_state.artifact_state_by_step[step.name] for config_state in self.config_states]
         elif step.input_type == "split":
-            step_states = [
-                split_state.step_state_by_step[step.name]
+            artifact_states = [
+                split_state.artifact_state_by_step[step.name]
                 for config_state in self.config_states
                 for split_state in config_state.split_states
             ]
         else:
             raise ValueError(f"Invalid input type: {step.input_type}")
-        step_states_ids = {step_state.id for step_state in step_states}
-        if len(step_states_ids) != len(step_states):
-            raise ValueError(f"Duplicate step states for step {step.name}")
-        return step_states
+        artifact_states_ids = {artifact_state.id for artifact_state in artifact_states}
+        if len(artifact_states_ids) != len(artifact_states):
+            raise ValueError(f"Duplicate artifact states for step {step.name}")
+        return artifact_states
 
-    def _get_step_states_by_status(self) -> StepStatesByStatus:
-        step_states_by_status = StepStatesByStatus()
+    def _get_cache_status(self) -> CacheStatus:
+        cache_status = CacheStatus()
 
         for step in self.processing_graph.topologically_ordered_steps:
-            step_states = self._get_step_states_for_step(step)
-            for step_state in step_states:
-                # one parent is in an undefined state?
+            artifact_states = self._get_artifact_states_for_step(step)
+            for artifact_state in artifact_states:
                 # (fan-in steps: config -> dataset, split -> config, split -> dataset)
                 # what should we do? always recompute? test the progress?
-                all_parents_step_states = step_state.get_all_parents_step_states()
-                if not all(all_parents_step_states):
-                    step_states_by_status.undefined[step_state.id] = step_state
-                    continue
+                all_not_none_parents_artifact_states = [
+                    x for x in artifact_state.get_all_parents_artifact_states() if x is not None
+                ]
 
                 # blocked by a parent?
                 if any(
-                    parent_step_state.id not in step_states_by_status.up_to_date
-                    for parent_step_states in all_parents_step_states
-                    for parent_step_state in parent_step_states
+                    parent_artifact_state.id not in cache_status.up_to_date
+                    for all_parents_artifact_state in all_not_none_parents_artifact_states
+                    for parent_artifact_state in all_parents_artifact_state
                 ):
-                    step_states_by_status.blocked_by_parent[step_state.id] = step_state
+                    cache_status.blocked_by_parent[artifact_state.id] = artifact_state
                     continue
 
-                # needs backfill?
-                if step_state.should_be_backfilled():
-                    step_states_by_status.should_be_backfilled[step_state.id] = step_state
+                # any of the parents is more recent?
+                if any(
+                    artifact_state.cache_state.is_older_than(parent_artifact_state.cache_state)
+                    for all_parents_artifact_state in all_not_none_parents_artifact_states
+                    for parent_artifact_state in all_parents_artifact_state
+                ):
+                    cache_status.cache_is_outdated_by_parent[artifact_state.id] = artifact_state
                     continue
 
-                # in process?
-                if step_state.is_in_process():
-                    step_states_by_status.in_process[step_state.id] = step_state
+                # is empty?
+                if artifact_state.cache_state.is_empty():
+                    cache_status.cache_is_empty[artifact_state.id] = artifact_state
+                    continue
+
+                # is an error that can be retried?
+                if artifact_state.cache_state.is_error_to_retry():
+                    cache_status.cache_is_error_to_retry[artifact_state.id] = artifact_state
                     continue
 
                 # ok
-                step_states_by_status.up_to_date[step_state.id] = step_state
+                cache_status.up_to_date[artifact_state.id] = artifact_state
 
-        return step_states_by_status
+        return cache_status
+
+    def _get_queue_status(self) -> QueueStatus:
+        queue_status = QueueStatus()
+
+        for step in self.processing_graph.topologically_ordered_steps:
+            artifact_states = self._get_artifact_states_for_step(step)
+            for artifact_state in artifact_states:
+                if artifact_state.job_state.is_in_process:
+                    queue_status.in_process[artifact_state.id] = artifact_state
+
+        return queue_status
+
+    def _create_plan(self) -> Plan:
+        plan = Plan()
+        remaining_in_process_artifact_state_ids = list(self.queue_status.in_process.keys())
+        artifact_states = (
+            list(self.cache_status.cache_is_empty.values())
+            + list(self.cache_status.cache_is_error_to_retry.values())
+            + list(self.cache_status.cache_is_outdated_by_parent.values())
+        )
+        for artifact_state in artifact_states:
+            if artifact_state.id in remaining_in_process_artifact_state_ids:
+                # the job already exists
+                remaining_in_process_artifact_state_ids.remove(artifact_state.id)
+                continue
+            plan.add(CreateJobTask(artifact_state=artifact_state, force=True, priority=Priority.LOW))
+        for artifact_state_id in remaining_in_process_artifact_state_ids:
+            plan.add(DeleteJobTask(artifact_state=self.queue_status.in_process[artifact_state_id]))
+        return plan
 
     def backfill(self) -> None:
-        """Backfill the cache entry for this split."""
-        for step_state in self.step_states_by_status.should_be_backfilled.values():
-            step_state.backfill(force=True, priority=Priority.LOW)
+        self.plan.run()
 
     def as_dict(self) -> Dict[str, Any]:
         return {
             "dataset": self.dataset,
             "config_states": [config_state.as_dict() for config_state in self.config_states],
-            "step_states": [step_state.as_dict() for step_state in self.step_state_by_step.values()],
+            "artifact_states": [artifact_state.as_dict() for artifact_state in self.artifact_state_by_step.values()],
         }

--- a/libs/libcommon/src/libcommon/state.py
+++ b/libs/libcommon/src/libcommon/state.py
@@ -292,10 +292,24 @@ class CacheStatus:
     cache_is_job_runner_obsolete: Dict[str, ArtifactState] = field(default_factory=dict)
     up_to_date: Dict[str, ArtifactState] = field(default_factory=dict)
 
+    def as_response(self) -> Dict[str, List[str]]:
+        return {
+            "blocked_by_parent": sorted(self.blocked_by_parent.keys()),
+            "cache_has_different_git_revision": sorted(self.cache_has_different_git_revision.keys()),
+            "cache_is_outdated_by_parent": sorted(self.cache_is_outdated_by_parent.keys()),
+            "cache_is_empty": sorted(self.cache_is_empty.keys()),
+            "cache_is_error_to_retry": sorted(self.cache_is_error_to_retry.keys()),
+            "cache_is_job_runner_obsolete": sorted(self.cache_is_job_runner_obsolete.keys()),
+            "up_to_date": sorted(self.up_to_date.keys()),
+        }
+
 
 @dataclass
 class QueueStatus:
     in_process: Dict[str, ArtifactState] = field(default_factory=dict)
+
+    def as_response(self) -> Dict[str, List[str]]:
+        return {"in_process": sorted(self.in_process.keys())}
 
 
 @dataclass
@@ -354,6 +368,9 @@ class Plan:
     def run(self) -> None:
         for task in self.tasks:
             task.run()
+
+    def as_response(self) -> List[str]:
+        return sorted(task.id for task in self.tasks)
 
 
 @dataclass
@@ -504,4 +521,12 @@ class DatasetState:
             "dataset": self.dataset,
             "config_states": [config_state.as_dict() for config_state in self.config_states],
             "artifact_states": [artifact_state.as_dict() for artifact_state in self.artifact_state_by_step.values()],
+        }
+
+    def as_response(self) -> Dict[str, Any]:
+        return {
+            "dataset": self.dataset,
+            "cache_status": self.cache_status.as_response(),
+            "queue_status": self.queue_status.as_response(),
+            "plan": self.plan.as_response(),
         }

--- a/libs/libcommon/src/libcommon/state.py
+++ b/libs/libcommon/src/libcommon/state.py
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional
+
+from libcommon.processing_graph import ProcessingGraph, ProcessingStep
+from libcommon.queue import Priority, Queue
+from libcommon.simple_cache import (
+    CacheEntryWithoutContent,
+    DoesNotExist,
+    get_best_response,
+    get_response,
+    get_response_without_content,
+)
+
+
+# TODO: assets, cached_assets, parquet files
+# TODO: obsolete/dangling cache entries and jobs
+# TODO: report, show in endpoint
+# TODO: plan what to do (backfill: create job, delete cache entries, delete assets)
+# TODO: add git version
+# TODO: add details about jobs (priority, force, status, times)
+
+HARD_CODED_CONFIG_NAMES_CACHE_KIND = "/config-names"
+HARD_CODED_SPLIT_NAMES_FROM_STREAMING_CACHE_KIND = "/split-names-from-streaming"
+HARD_CODED_SPLIT_NAMES_FROM_DATASET_INFO_CACHE_KIND = "/split-names-from-dataset-info"
+
+
+def fetch_config_names(dataset: str) -> List[str]:
+    """Fetch the list of config names from the database."""
+    config_names = []
+
+    response = get_response(HARD_CODED_CONFIG_NAMES_CACHE_KIND, dataset=dataset, config=None, split=None)
+    for config_name_item in response["content"]["config_names"]:
+        config_name = config_name_item["config"]
+        if not isinstance(config_name, str):
+            raise ValueError(f"Invalid config name: {config_name}, type should be str, got: {type(config_name)}")
+        config_names.append(config_name)
+    return config_names
+
+
+def fetch_split_names(dataset: str, config: str) -> List[str]:
+    """Fetch the list of config names from the database."""
+    split_names = []
+
+    best_response = get_best_response(
+        [HARD_CODED_SPLIT_NAMES_FROM_DATASET_INFO_CACHE_KIND, HARD_CODED_SPLIT_NAMES_FROM_STREAMING_CACHE_KIND],
+        dataset=dataset,
+        config=config,
+        split=None,
+    )
+    for split_name_item in best_response.response["content"]["split_names"]:
+        split_name = split_name_item["split"]
+        if not isinstance(split_name, str):
+            raise ValueError(f"Invalid split name: {split_name}, type should be str, got: {type(split_name)}")
+        split_names.append(split_name)
+    return split_names
+
+
+@dataclass
+class BackfillTask:
+    """A backfill task."""
+
+    job_type: str
+    dataset: str
+    config: Optional[str]
+    split: Optional[str]
+
+    def __post_init__(self) -> None:
+        self.task = f"backfill[{self.job_type},{self.dataset},{self.config},{self.split}]"
+
+    def __str__(self) -> str:
+        return self.task
+
+    def run(self, force: bool, priority: Priority) -> None:
+        Queue().upsert_job(
+            job_type=self.job_type,
+            dataset=self.dataset,
+            config=self.config,
+            split=self.split,
+            force=force,
+            priority=priority,
+        )
+
+
+@dataclass
+class JobState:
+    """The state of a job for a given input."""
+
+    dataset: str
+    config: Optional[str]
+    split: Optional[str]
+    job_type: str
+    is_in_process: bool = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.is_in_process = Queue().is_job_in_process(
+            job_type=self.job_type, dataset=self.dataset, config=self.config, split=self.split
+        )
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "is_in_process": self.is_in_process,
+        }
+
+
+ERROR_CODES_TO_RETRY: List[str] = []
+
+
+@dataclass
+class CacheState:
+    """The state of a cache entry for a given input."""
+
+    dataset: str
+    config: Optional[str]
+    split: Optional[str]
+    cache_kind: str
+    cache_entry_without_content: Optional[CacheEntryWithoutContent] = field(init=False)
+    exists: bool = field(init=False)
+    is_success: bool = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.cache_entry_without_content = None
+        with contextlib.suppress(DoesNotExist):
+            self.cache_entry_without_content = get_response_without_content(
+                kind=self.cache_kind, dataset=self.dataset, config=self.config, split=self.split
+            )
+        """Whether the cache entry exists."""
+        self.exists = self.cache_entry_without_content is not None
+        self.is_success = (
+            self.cache_entry_without_content is not None and self.cache_entry_without_content["http_status"] < 400
+        )
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "exists": self.exists,
+            "is_success": self.is_success,
+        }
+
+    def should_be_refreshed(self) -> bool:
+        empty = self.cache_entry_without_content is None
+        error_to_retry = self.cache_entry_without_content is not None and (
+            self.cache_entry_without_content["http_status"] >= 400
+            and self.cache_entry_without_content["error_code"] in ERROR_CODES_TO_RETRY
+        )
+        # TODO: old git revision
+        # TODO: old job_runner_version
+        return empty or error_to_retry
+
+
+@dataclass
+class StepState:
+    """The state of a step for a given input."""
+
+    dataset: str
+    config: Optional[str]
+    split: Optional[str]
+    step: ProcessingStep
+    job_state: JobState = field(init=False)
+    cache_state: CacheState = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.step.input_type == "dataset":
+            if self.config is not None or self.split is not None:
+                raise ValueError("Step input type is dataset, but config or split is not None")
+        elif self.step.input_type == "config":
+            if self.config is None or self.split is not None:
+                raise ValueError("Step input type is config, but config is None or split is not None")
+        elif self.step.input_type == "split":
+            if self.config is None or self.split is None:
+                raise ValueError("Step input type is split, but config or split is None")
+        else:
+            raise ValueError(f"Invalid step input type: {self.step.input_type}")
+        self.job_state = JobState(
+            job_type=self.step.job_type, dataset=self.dataset, config=self.config, split=self.split
+        )
+        self.cache_state = CacheState(
+            cache_kind=self.step.cache_kind, dataset=self.dataset, config=self.config, split=self.split
+        )
+
+    def get_backfill_tasks(self) -> List[BackfillTask]:
+        tasks: List[BackfillTask] = []
+        if self.cache_state.should_be_refreshed() and not self.job_state.is_in_process:
+            tasks.append(
+                BackfillTask(job_type=self.step.job_type, dataset=self.dataset, config=self.config, split=self.split)
+            )
+        return tasks
+
+    def backfill(self) -> None:
+        """Backfill the cache entry for this step."""
+        for backfill_tasks in self.get_backfill_tasks():
+            backfill_tasks.run(force=True, priority=Priority.LOW)
+
+    def should_be_backfilled(self) -> bool:
+        return len(self.get_backfill_tasks()) > 0
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "step_name": self.step.name,
+            "job_state": self.job_state.as_dict(),
+            "cache_state": self.cache_state.as_dict(),
+            "should_be_backfilled": self.should_be_backfilled(),
+        }
+
+
+@dataclass
+class SplitState:
+    """The state of a split."""
+
+    dataset: str
+    config: str
+    split: str
+    processing_graph: ProcessingGraph
+    step_states: List[StepState] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.step_states = [
+            StepState(step=step, dataset=self.dataset, config=self.config, split=self.split)
+            for step in self.processing_graph.steps.values()
+            if step.input_type == "split"
+        ]
+
+    def get_backfill_tasks(self) -> List[BackfillTask]:
+        tasks: List[BackfillTask] = []
+        for step_state in self.step_states:
+            tasks.extend(step_state.get_backfill_tasks())
+        return tasks
+
+    def backfill(self) -> None:
+        """Backfill the cache entry for this split."""
+        for backfill_tasks in self.get_backfill_tasks():
+            backfill_tasks.run(force=True, priority=Priority.LOW)
+
+    def should_be_backfilled(self) -> bool:
+        return len(self.get_backfill_tasks()) > 0
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "split": self.split,
+            "step_states": [step_state.as_dict() for step_state in self.step_states],
+            "should_be_backfilled": self.should_be_backfilled(),
+        }
+
+
+@dataclass
+class ConfigState:
+    """The state of a config."""
+
+    dataset: str
+    config: str
+    processing_graph: ProcessingGraph
+    split_names: List[str] = field(init=False)
+    split_states: Mapping[str, SplitState] = field(init=False)
+    step_states: List[StepState] = field(init=False)
+
+    def __post_init__(self) -> None:
+        try:
+            self.split_names = fetch_split_names(self.dataset, self.config)
+        except Exception:
+            self.split_names = []
+        self.split_states = {
+            split_name: SplitState(self.dataset, self.config, split_name, self.processing_graph)
+            for split_name in self.split_names
+        }
+        self.step_states = [
+            StepState(step=step, dataset=self.dataset, config=self.config, split=None)
+            for step in self.processing_graph.steps.values()
+            if step.input_type == "config"
+        ]
+
+    def get_backfill_tasks(self) -> List[BackfillTask]:
+        tasks: List[BackfillTask] = []
+        for step_state in self.step_states:
+            tasks.extend(step_state.get_backfill_tasks())
+        for split_state in self.split_states.values():
+            tasks.extend(split_state.get_backfill_tasks())
+        return tasks
+
+    def backfill(self) -> None:
+        """Backfill the cache entry for this split."""
+        for backfill_tasks in self.get_backfill_tasks():
+            backfill_tasks.run(force=True, priority=Priority.LOW)
+
+    def should_be_backfilled(self) -> bool:
+        return len(self.get_backfill_tasks()) > 0
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "config": self.config,
+            "split_states": [split_state.as_dict() for split_state in self.split_states.values()],
+            "step_states": [step_state.as_dict() for step_state in self.step_states],
+            "should_be_backfilled": self.should_be_backfilled(),
+        }
+
+
+@dataclass
+class DatasetState:
+    """The state of a dataset."""
+
+    config_states: Mapping[str, ConfigState] = field(init=False)
+    dataset: str
+    processing_graph: ProcessingGraph
+    config_names: List[str] = field(init=False)
+    step_states: List[StepState] = field(init=False)
+
+    def __post_init__(self) -> None:
+        try:
+            self.config_names = fetch_config_names(self.dataset)
+        except Exception:
+            self.config_names = []
+        self.config_states = {
+            config_name: ConfigState(dataset=self.dataset, config=config_name, processing_graph=self.processing_graph)
+            for config_name in self.config_names
+        }
+        self.step_states = [
+            StepState(step=step, dataset=self.dataset, config=None, split=None)
+            for step in self.processing_graph.steps.values()
+            if step.input_type == "dataset"
+        ]
+
+    def get_backfill_tasks(self) -> List[BackfillTask]:
+        tasks: List[BackfillTask] = []
+        for step_state in self.step_states:
+            tasks.extend(step_state.get_backfill_tasks())
+        for config_state in self.config_states.values():
+            tasks.extend(config_state.get_backfill_tasks())
+        return tasks
+
+    def backfill(self) -> None:
+        """Backfill the cache entry for this split."""
+        for backfill_tasks in self.get_backfill_tasks():
+            backfill_tasks.run(force=True, priority=Priority.LOW)
+
+    def should_be_backfilled(self) -> bool:
+        return len(self.get_backfill_tasks()) > 0
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "dataset": self.dataset,
+            "config_states": [config_state.as_dict() for config_state in self.config_states.values()],
+            "step_states": [step_state.as_dict() for step_state in self.step_states],
+            "should_be_backfilled": self.should_be_backfilled(),
+        }

--- a/libs/libcommon/src/libcommon/state.py
+++ b/libs/libcommon/src/libcommon/state.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from libcommon.processing_graph import ProcessingGraph, ProcessingStep
-from libcommon.queue import Priority, Queue
+from libcommon.queue import Priority, Queue, Status
 from libcommon.simple_cache import (
     CacheEntryMetadata,
     DoesNotExist,
@@ -345,11 +345,12 @@ class DeleteJobTask(Task):
     def run(self) -> None:
         # TODO: the started jobs are also canceled: we need to ensure the job runners will
         # not try to update the cache when they finish
-        Queue().cancel_pending_jobs(
+        Queue().cancel_jobs(
             job_type=self.artifact_state.step.job_type,
             dataset=self.artifact_state.dataset,
             config=self.artifact_state.config,
             split=self.artifact_state.split,
+            statuses_to_cancel=[Status.WAITING, Status.STARTED],
         )
 
 

--- a/libs/libcommon/tests/test_queue.py
+++ b/libs/libcommon/tests/test_queue.py
@@ -122,6 +122,24 @@ def test_upsert_job() -> None:
         queue.start_job()
 
 
+def test_cancel_pending_jobs() -> None:
+    test_type = "test_type"
+    test_dataset = "test_dataset"
+    # get the queue
+    queue = Queue()
+    # add a job
+    queue._add_job(job_type=test_type, dataset=test_dataset, force=True)
+    # a second call adds a second waiting job
+    queue._add_job(job_type=test_type, dataset=test_dataset)
+    assert queue.is_job_in_process(job_type=test_type, dataset=test_dataset)
+
+    queue.cancel_pending_jobs(job_type=test_type, dataset=test_dataset)
+
+    assert not queue.is_job_in_process(job_type=test_type, dataset=test_dataset)
+    with pytest.raises(EmptyQueueError):
+        queue.start_job()
+
+
 def check_job(queue: Queue, expected_dataset: str, expected_split: str) -> None:
     job_info = queue.start_job()
     assert job_info["dataset"] == expected_dataset

--- a/libs/libcommon/tests/test_queue.py
+++ b/libs/libcommon/tests/test_queue.py
@@ -3,19 +3,13 @@
 
 import time
 from datetime import datetime, timedelta
-from typing import Iterator, List, Optional
+from typing import List, Optional
 from unittest.mock import patch
 
 import pytest
 import pytz
 
-from libcommon.queue import (
-    EmptyQueueError,
-    Priority,
-    Queue,
-    Status,
-    _clean_queue_database,
-)
+from libcommon.queue import EmptyQueueError, Priority, Queue, Status
 from libcommon.resources import QueueMongoResource
 from libcommon.utils import get_datetime
 
@@ -25,16 +19,8 @@ def get_old_datetime() -> datetime:
 
 
 @pytest.fixture(autouse=True)
-def queue_mongo_resource(queue_mongo_host: str) -> Iterator[QueueMongoResource]:
-    database = "datasets_server_queue_test"
-    host = queue_mongo_host
-    if "test" not in database:
-        raise ValueError("Test must be launched on a test mongo database")
-    with QueueMongoResource(database=database, host=host, server_selection_timeout_ms=3_000) as queue_mongo_resource:
-        if not queue_mongo_resource.is_available():
-            raise RuntimeError("Mongo resource is not available")
-        yield queue_mongo_resource
-        _clean_queue_database()
+def queue_mongo_resource_autouse(queue_mongo_resource: QueueMongoResource) -> QueueMongoResource:
+    return queue_mongo_resource
 
 
 def test__add_job() -> None:

--- a/libs/libcommon/tests/test_simple_cache.py
+++ b/libs/libcommon/tests/test_simple_cache.py
@@ -4,7 +4,7 @@
 from datetime import datetime
 from http import HTTPStatus
 from time import process_time
-from typing import Dict, Iterator, List, Optional, TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 import pytest
 from pymongo.errors import DocumentTooLarge
@@ -18,7 +18,6 @@ from libcommon.simple_cache import (
     InvalidCursor,
     InvalidLimit,
     SplitFullName,
-    _clean_cache_database,
     delete_dataset_responses,
     delete_response,
     get_best_response,
@@ -37,14 +36,8 @@ from libcommon.simple_cache import (
 
 
 @pytest.fixture(autouse=True)
-def cache_mongo_resource(cache_mongo_host: str) -> Iterator[CacheMongoResource]:
-    database = "datasets_server_cache_test"
-    host = cache_mongo_host
-    if "test" not in database:
-        raise ValueError("Test must be launched on a test mongo database")
-    with CacheMongoResource(database=database, host=host) as cache_mongo_resource:
-        yield cache_mongo_resource
-        _clean_cache_database()
+def cache_mongo_resource_autouse(cache_mongo_resource: CacheMongoResource) -> CacheMongoResource:
+    return cache_mongo_resource
 
 
 def test_insert_null_values() -> None:

--- a/libs/libcommon/tests/test_state.py
+++ b/libs/libcommon/tests/test_state.py
@@ -492,26 +492,6 @@ def get_dataset_state() -> DatasetState:
     return DatasetState(dataset=DATASET_NAME, processing_graph=PROCESSING_GRAPH)
 
 
-def get_cache_status(dataset_state: DatasetState) -> Dict[str, List[str]]:
-    return {
-        "blocked_by_parent": sorted(dataset_state.cache_status.blocked_by_parent.keys()),
-        "cache_has_different_git_revision": sorted(dataset_state.cache_status.cache_has_different_git_revision.keys()),
-        "cache_is_outdated_by_parent": sorted(dataset_state.cache_status.cache_is_outdated_by_parent.keys()),
-        "cache_is_empty": sorted(dataset_state.cache_status.cache_is_empty.keys()),
-        "cache_is_error_to_retry": sorted(dataset_state.cache_status.cache_is_error_to_retry.keys()),
-        "cache_is_job_runner_obsolete": sorted(dataset_state.cache_status.cache_is_job_runner_obsolete.keys()),
-        "up_to_date": sorted(dataset_state.cache_status.up_to_date.keys()),
-    }
-
-
-def get_queue_status(dataset_state: DatasetState) -> Dict[str, List[str]]:
-    return {"in_process": sorted(dataset_state.queue_status.in_process.keys())}
-
-
-def get_tasks(dataset_state: DatasetState) -> List[str]:
-    return sorted(task.id for task in dataset_state.plan.tasks)
-
-
 def assert_dataset_state(
     config_names: List[str],
     split_names_in_first_config: List[str],
@@ -527,9 +507,9 @@ def assert_dataset_state(
     else:
         # this case is just to check the test, not the code
         assert not split_names_in_first_config
-    assert get_cache_status(dataset_state) == cache_status
-    assert get_queue_status(dataset_state) == queue_status
-    assert get_tasks(dataset_state) == tasks
+    assert dataset_state.cache_status.as_response() == cache_status
+    assert dataset_state.queue_status.as_response() == queue_status
+    assert dataset_state.plan.as_response() == tasks
     return dataset_state
 
 
@@ -581,7 +561,7 @@ def test_plan() -> None:
 def test_plan_job_creation_and_termination() -> None:
     # we launch all the backfill tasks
     dataset_state = get_dataset_state()
-    assert get_tasks(dataset_state) == [
+    assert dataset_state.plan.as_response() == [
         "CreateJob[/config-names,dataset]",
         "CreateJob[/parquet-and-dataset-info,dataset]",
         "CreateJob[dataset-info,dataset]",

--- a/libs/libcommon/tests/test_state.py
+++ b/libs/libcommon/tests/test_state.py
@@ -2,16 +2,16 @@
 # Copyright 2022 The HuggingFace Authors.
 
 from http import HTTPStatus
-from typing import Any, Dict, Iterator, List, Mapping, Optional, TypedDict
+from typing import Any, Dict, List, Mapping, Optional, TypedDict
 from unittest.mock import patch
 
 import pytest
 
 from libcommon.config import ProcessingGraphConfig
 from libcommon.processing_graph import ProcessingGraph
-from libcommon.queue import Queue, Status, _clean_queue_database
+from libcommon.queue import Queue, Status
 from libcommon.resources import CacheMongoResource, QueueMongoResource
-from libcommon.simple_cache import _clean_cache_database, upsert_response
+from libcommon.simple_cache import upsert_response
 from libcommon.state import (
     HARD_CODED_CONFIG_NAMES_CACHE_KIND,
     HARD_CODED_SPLIT_NAMES_FROM_DATASET_INFO_CACHE_KIND,
@@ -28,27 +28,13 @@ from libcommon.state import (
 
 
 @pytest.fixture(autouse=True)
-def queue_mongo_resource(queue_mongo_host: str) -> Iterator[QueueMongoResource]:
-    database = "datasets_server_queue_test"
-    host = queue_mongo_host
-    if "test" not in database:
-        raise ValueError("Test must be launched on a test mongo database")
-    with QueueMongoResource(database=database, host=host, server_selection_timeout_ms=3_000) as queue_mongo_resource:
-        if not queue_mongo_resource.is_available():
-            raise RuntimeError("Mongo resource is not available")
-        yield queue_mongo_resource
-        _clean_queue_database()
+def queue_mongo_resource_autouse(queue_mongo_resource: QueueMongoResource) -> QueueMongoResource:
+    return queue_mongo_resource
 
 
 @pytest.fixture(autouse=True)
-def cache_mongo_resource(cache_mongo_host: str) -> Iterator[CacheMongoResource]:
-    database = "datasets_server_cache_test"
-    host = cache_mongo_host
-    if "test" not in database:
-        raise ValueError("Test must be launched on a test mongo database")
-    with CacheMongoResource(database=database, host=host) as cache_mongo_resource:
-        yield cache_mongo_resource
-        _clean_cache_database()
+def cache_mongo_resource_autouse(cache_mongo_resource: CacheMongoResource) -> CacheMongoResource:
+    return cache_mongo_resource
 
 
 DATASET_NAME = "dataset"

--- a/libs/libcommon/tests/test_state.py
+++ b/libs/libcommon/tests/test_state.py
@@ -508,7 +508,7 @@ def test_get_backfill_tasks() -> None:  # sourcery skip: extract-duplicate-metho
     # Note that no config-level and split-level step is listed here, because the config names and splits names are not
     # yet known.
     # The root dataset-level steps are ready to be backfilled.
-    assert dataset_state.get_step_states_by_status().get_ids() == {
+    assert dataset_state.step_states_by_status.get_ids() == {
         "blocked_by_parent": [],
         "should_be_backfilled": ["/config-names[dataset,None,None]", "/parquet-and-dataset-info[dataset,None,None]"],
         "in_process": [],
@@ -531,7 +531,7 @@ def test_get_backfill_tasks() -> None:  # sourcery skip: extract-duplicate-metho
     # thus: no new backfill task is proposed, and the state steps are now in "in_process" status
     dataset_state = DatasetState(dataset=dataset, processing_graph=processing_graph)
     assert not dataset_state.config_names
-    assert dataset_state.get_step_states_by_status().get_ids() == {
+    assert dataset_state.step_states_by_status.get_ids() == {
         "blocked_by_parent": [],
         "should_be_backfilled": [],
         "in_process": ["/config-names[dataset,None,None]", "/parquet-and-dataset-info[dataset,None,None]"],
@@ -559,7 +559,7 @@ def test_get_backfill_tasks() -> None:  # sourcery skip: extract-duplicate-metho
     assert dataset_state.config_names == [CONFIG_NAME]
     assert len(dataset_state.config_states) == 1
     assert dataset_state.config_states[0].split_names == []
-    assert dataset_state.get_step_states_by_status().get_ids() == {
+    assert dataset_state.step_states_by_status.get_ids() == {
         "blocked_by_parent": [
             "/split-names-from-dataset-info[dataset,config,None]",
             "config-info[dataset,config,None]",
@@ -594,7 +594,7 @@ def test_get_backfill_tasks() -> None:  # sourcery skip: extract-duplicate-metho
     assert dataset_state.config_names == [CONFIG_NAME]
     assert len(dataset_state.config_states) == 1
     assert dataset_state.config_states[0].split_names == []
-    assert dataset_state.get_step_states_by_status().get_ids() == {
+    assert dataset_state.step_states_by_status.get_ids() == {
         "blocked_by_parent": ["/split-names-from-dataset-info[dataset,config,None]"],
         "should_be_backfilled": [
             "config-info[dataset,config,None]",
@@ -628,7 +628,7 @@ def test_get_backfill_tasks() -> None:  # sourcery skip: extract-duplicate-metho
     assert dataset_state.config_names == [CONFIG_NAME]
     assert len(dataset_state.config_states) == 1
     assert dataset_state.config_states[0].split_names == []
-    assert dataset_state.get_step_states_by_status().get_ids() == {
+    assert dataset_state.step_states_by_status.get_ids() == {
         "blocked_by_parent": [],
         "should_be_backfilled": ["/split-names-from-dataset-info[dataset,config,None]"],
         "in_process": [
@@ -668,7 +668,7 @@ def test_get_backfill_tasks() -> None:  # sourcery skip: extract-duplicate-metho
     assert len(dataset_state.config_states) == 1
     assert dataset_state.config_states[0].split_names == SPLIT_NAMES_OK
     # the split-level dependent steps are now ready to be backfilled
-    assert dataset_state.get_step_states_by_status().get_ids() == {
+    assert dataset_state.step_states_by_status.get_ids() == {
         "blocked_by_parent": [
             "split-first-rows-from-parquet[dataset,config,split1]",
             "split-first-rows-from-parquet[dataset,config,split2]",

--- a/libs/libcommon/tests/test_state.py
+++ b/libs/libcommon/tests/test_state.py
@@ -1,0 +1,627 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+from typing import Any, Iterator, List, Mapping, Optional, TypedDict
+
+import pytest
+from http import HTTPStatus
+
+from libcommon.config import ProcessingGraphConfig
+from libcommon.processing_graph import ProcessingGraph, ProcessingStep
+from libcommon.queue import Queue, Status, _clean_queue_database
+from libcommon.resources import CacheMongoResource, QueueMongoResource
+from libcommon.state import (
+    HARD_CODED_CONFIG_NAMES_CACHE_KIND,
+    HARD_CODED_SPLIT_NAMES_FROM_DATASET_INFO_CACHE_KIND,
+    HARD_CODED_SPLIT_NAMES_FROM_STREAMING_CACHE_KIND,
+    CacheState,
+    ConfigState,
+    DatasetState,
+    JobState,
+    SplitState,
+    StepState,
+    fetch_config_names,
+    fetch_split_names,
+)
+from libcommon.simple_cache import _clean_cache_database, upsert_response
+
+
+@pytest.fixture(autouse=True)
+def queue_mongo_resource(queue_mongo_host: str) -> Iterator[QueueMongoResource]:
+    database = "datasets_server_queue_test"
+    host = queue_mongo_host
+    if "test" not in database:
+        raise ValueError("Test must be launched on a test mongo database")
+    with QueueMongoResource(database=database, host=host, server_selection_timeout_ms=3_000) as queue_mongo_resource:
+        if not queue_mongo_resource.is_available():
+            raise RuntimeError("Mongo resource is not available")
+        yield queue_mongo_resource
+        _clean_queue_database()
+
+
+@pytest.fixture(autouse=True)
+def cache_mongo_resource(cache_mongo_host: str) -> Iterator[CacheMongoResource]:
+    database = "datasets_server_cache_test"
+    host = cache_mongo_host
+    if "test" not in database:
+        raise ValueError("Test must be launched on a test mongo database")
+    with CacheMongoResource(database=database, host=host) as cache_mongo_resource:
+        yield cache_mongo_resource
+        _clean_cache_database()
+
+
+DATASET_NAME = "dataset"
+CONFIG_NAMES_OK = ["config1", "config2"]
+CONFIG_NAMES_CONTENT_OK = {"config_names": [{"config": config_name} for config_name in CONFIG_NAMES_OK]}
+CONTENT_ERROR = {"error": "error"}
+
+
+@pytest.mark.parametrize(
+    "content,http_status,expected_config_names",
+    [
+        (CONFIG_NAMES_CONTENT_OK, HTTPStatus.OK, CONFIG_NAMES_OK),
+        (CONTENT_ERROR, HTTPStatus.INTERNAL_SERVER_ERROR, None),
+        (None, HTTPStatus.OK, None),
+    ],
+)
+def test_fetch_config_names(
+    content: Optional[Mapping[str, Any]], http_status: HTTPStatus, expected_config_names: Optional[List[str]]
+) -> None:
+    raises = expected_config_names is None
+    if content:
+        upsert_response(
+            kind=HARD_CODED_CONFIG_NAMES_CACHE_KIND,
+            dataset=DATASET_NAME,
+            config=None,
+            split=None,
+            content=content,
+            http_status=http_status,
+        )
+
+    if raises:
+        with pytest.raises(Exception):
+            fetch_config_names(dataset=DATASET_NAME)
+    else:
+        config_names = fetch_config_names(dataset=DATASET_NAME)
+        assert config_names == expected_config_names
+
+
+class ResponseSpec(TypedDict):
+    content: Mapping[str, Any]
+    http_status: HTTPStatus
+
+
+CONFIG_NAME = "config"
+SPLIT_NAMES_OK = ["split1", "split2"]
+SPLIT_NAMES_RESPONSE_OK = ResponseSpec(
+    content={
+        "split_names": [
+            {"dataset": DATASET_NAME, "config": CONFIG_NAME, "split": split_name} for split_name in SPLIT_NAMES_OK
+        ]
+    },
+    http_status=HTTPStatus.OK,
+)
+SPLIT_NAMES_RESPONSE_ERROR = ResponseSpec(content={"error": "error"}, http_status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+
+@pytest.mark.parametrize(
+    "response_spec_by_kind,expected_split_names",
+    [
+        ({HARD_CODED_SPLIT_NAMES_FROM_DATASET_INFO_CACHE_KIND: SPLIT_NAMES_RESPONSE_OK}, SPLIT_NAMES_OK),
+        ({HARD_CODED_SPLIT_NAMES_FROM_STREAMING_CACHE_KIND: SPLIT_NAMES_RESPONSE_OK}, SPLIT_NAMES_OK),
+        (
+            {
+                HARD_CODED_SPLIT_NAMES_FROM_DATASET_INFO_CACHE_KIND: SPLIT_NAMES_RESPONSE_ERROR,
+                HARD_CODED_SPLIT_NAMES_FROM_STREAMING_CACHE_KIND: SPLIT_NAMES_RESPONSE_OK,
+            },
+            SPLIT_NAMES_OK,
+        ),
+        ({HARD_CODED_SPLIT_NAMES_FROM_DATASET_INFO_CACHE_KIND: SPLIT_NAMES_RESPONSE_ERROR}, None),
+        ({}, None),
+    ],
+)
+def test_fetch_split_names(
+    response_spec_by_kind: Mapping[str, Mapping[str, Any]],
+    expected_split_names: Optional[List[str]],
+) -> None:
+    raises = expected_split_names is None
+    for kind, response_spec in response_spec_by_kind.items():
+        upsert_response(
+            kind=kind,
+            dataset=DATASET_NAME,
+            config=CONFIG_NAME,
+            split=None,
+            content=response_spec["content"],
+            http_status=response_spec["http_status"],
+        )
+
+    if raises:
+        with pytest.raises(Exception):
+            fetch_split_names(dataset=DATASET_NAME, config=CONFIG_NAME)
+    else:
+        split_names = fetch_split_names(dataset=DATASET_NAME, config=CONFIG_NAME)
+        assert split_names == expected_split_names
+
+
+SPLIT_NAME = "split"
+JOB_TYPE = "job_type"
+
+
+@pytest.mark.parametrize(
+    "dataset,config,split,job_type",
+    [
+        (DATASET_NAME, None, None, JOB_TYPE),
+        (DATASET_NAME, CONFIG_NAME, None, JOB_TYPE),
+        (DATASET_NAME, CONFIG_NAME, SPLIT_NAME, JOB_TYPE),
+    ],
+)
+def test_job_state_is_in_process(dataset: str, config: Optional[str], split: Optional[str], job_type: str) -> None:
+    queue = Queue()
+    queue.upsert_job(job_type=job_type, dataset=dataset, config=config, split=split)
+    assert JobState(dataset=dataset, config=config, split=split, job_type=job_type).is_in_process
+    job_info = queue.start_job()
+    assert JobState(dataset=dataset, config=config, split=split, job_type=job_type).is_in_process
+    queue.finish_job(job_id=job_info["job_id"], finished_status=Status.SUCCESS)
+    assert not JobState(dataset=dataset, config=config, split=split, job_type=job_type).is_in_process
+
+
+@pytest.mark.parametrize(
+    "dataset,config,split,job_type",
+    [
+        (DATASET_NAME, None, None, JOB_TYPE),
+        (DATASET_NAME, CONFIG_NAME, None, JOB_TYPE),
+        (DATASET_NAME, CONFIG_NAME, SPLIT_NAME, JOB_TYPE),
+    ],
+)
+def test_job_state_as_dict(dataset: str, config: Optional[str], split: Optional[str], job_type: str) -> None:
+    queue = Queue()
+    queue.upsert_job(job_type=job_type, dataset=dataset, config=config, split=split)
+    assert JobState(dataset=dataset, config=config, split=split, job_type=job_type).as_dict() == {
+        "is_in_process": True,
+    }
+
+
+CACHE_KIND = "cache_kind"
+
+
+@pytest.mark.parametrize(
+    "dataset,config,split,cache_kind",
+    [
+        (DATASET_NAME, None, None, CACHE_KIND),
+        (DATASET_NAME, CONFIG_NAME, None, CACHE_KIND),
+        (DATASET_NAME, CONFIG_NAME, SPLIT_NAME, CACHE_KIND),
+    ],
+)
+def test_cache_state_exists(dataset: str, config: Optional[str], split: Optional[str], cache_kind: str) -> None:
+    assert not CacheState(dataset=dataset, config=config, split=split, cache_kind=cache_kind).exists
+    upsert_response(
+        kind=cache_kind, dataset=dataset, config=config, split=split, content={}, http_status=HTTPStatus.OK
+    )
+    assert CacheState(dataset=dataset, config=config, split=split, cache_kind=cache_kind).exists
+
+
+@pytest.mark.parametrize(
+    "dataset,config,split,cache_kind",
+    [
+        (DATASET_NAME, None, None, CACHE_KIND),
+        (DATASET_NAME, CONFIG_NAME, None, CACHE_KIND),
+        (DATASET_NAME, CONFIG_NAME, SPLIT_NAME, CACHE_KIND),
+    ],
+)
+def test_cache_state_is_success(dataset: str, config: Optional[str], split: Optional[str], cache_kind: str) -> None:
+    upsert_response(
+        kind=cache_kind, dataset=dataset, config=config, split=split, content={}, http_status=HTTPStatus.OK
+    )
+    assert CacheState(dataset=dataset, config=config, split=split, cache_kind=cache_kind).is_success
+    upsert_response(
+        kind=cache_kind,
+        dataset=dataset,
+        config=config,
+        split=split,
+        content={},
+        http_status=HTTPStatus.INTERNAL_SERVER_ERROR,
+    )
+    assert not CacheState(dataset=dataset, config=config, split=split, cache_kind=cache_kind).is_success
+
+
+@pytest.mark.parametrize(
+    "dataset,config,split,cache_kind",
+    [
+        (DATASET_NAME, None, None, CACHE_KIND),
+        (DATASET_NAME, CONFIG_NAME, None, CACHE_KIND),
+        (DATASET_NAME, CONFIG_NAME, SPLIT_NAME, CACHE_KIND),
+    ],
+)
+def test_cache_state_as_dict(dataset: str, config: Optional[str], split: Optional[str], cache_kind: str) -> None:
+    assert CacheState(dataset=dataset, config=config, split=split, cache_kind=cache_kind).as_dict() == {
+        "exists": False,
+        "is_success": False,
+    }
+    upsert_response(
+        kind=cache_kind,
+        dataset=dataset,
+        config=config,
+        split=split,
+        content={"some": "content"},
+        http_status=HTTPStatus.OK,
+    )
+    assert CacheState(dataset=dataset, config=config, split=split, cache_kind=cache_kind).as_dict() == {
+        "exists": True,
+        "is_success": True,
+    }
+
+
+PROCESSING_GRAPH = ProcessingGraph(processing_graph_specification=ProcessingGraphConfig().specification)
+
+
+def test_step_state_as_dict() -> None:
+    dataset = DATASET_NAME
+    config = None
+    split = None
+    step = PROCESSING_GRAPH.get_step(name="/config-names")
+    assert StepState(dataset=dataset, config=config, split=split, step=step).as_dict() == {
+        "step_name": "/config-names",
+        "job_state": {"is_in_process": False},
+        "cache_state": {"exists": False, "is_success": False},
+        "should_be_backfilled": True,
+    }
+
+
+def test_step_state_backfill() -> None:
+    dataset = DATASET_NAME
+    config = None
+    split = None
+    step = PROCESSING_GRAPH.get_step(name="/config-names")
+    step_state = StepState(dataset=dataset, config=config, split=split, step=step)
+    assert not step_state.cache_state.exists
+    assert not step_state.job_state.is_in_process
+    assert [str(task) for task in step_state.get_backfill_tasks()] == ["backfill[/config-names,dataset,None,None]"]
+    assert step_state.should_be_backfilled()
+    step_state.backfill()
+    step_state = StepState(dataset=dataset, config=config, split=split, step=step)
+    assert not step_state.cache_state.exists
+    assert step_state.job_state.is_in_process
+    assert not step_state.get_backfill_tasks()
+    assert not step_state.should_be_backfilled()
+
+
+SPLIT1_NAME = "split1"
+SPLIT1_STATE_DICT = {
+    "split": SPLIT1_NAME,
+    "step_states": [
+        {
+            "step_name": "split-first-rows-from-streaming",
+            "job_state": {"is_in_process": False},
+            "cache_state": {"exists": False, "is_success": False},
+            "should_be_backfilled": True,
+        },
+        {
+            "step_name": "split-first-rows-from-parquet",
+            "job_state": {"is_in_process": False},
+            "cache_state": {"exists": False, "is_success": False},
+            "should_be_backfilled": True,
+        },
+    ],
+    "should_be_backfilled": True,
+}
+
+
+def test_split_state_as_dict() -> None:
+    dataset = DATASET_NAME
+    config = CONFIG_NAME
+    split = SPLIT1_NAME
+    processing_graph = PROCESSING_GRAPH
+    assert (
+        SplitState(dataset=dataset, config=config, split=split, processing_graph=processing_graph).as_dict()
+        == SPLIT1_STATE_DICT
+    )
+
+
+def test_split_state_backfill() -> None:
+    dataset = DATASET_NAME
+    config = CONFIG_NAME
+    split = SPLIT1_NAME
+    processing_graph = PROCESSING_GRAPH
+    split_state = SplitState(dataset=dataset, config=config, split=split, processing_graph=processing_graph)
+    assert all(not step_state.job_state.is_in_process for step_state in split_state.step_states)
+    assert [str(task) for task in split_state.get_backfill_tasks()] == [
+        "backfill[split-first-rows-from-streaming,dataset,config,split1]",
+        "backfill[split-first-rows-from-parquet,dataset,config,split1]",
+    ]
+    assert split_state.should_be_backfilled()
+    split_state.backfill()
+    split_state = SplitState(dataset=dataset, config=config, split=split, processing_graph=processing_graph)
+    assert all(step_state.job_state.is_in_process for step_state in split_state.step_states)
+    assert not split_state.get_backfill_tasks()
+    assert not split_state.should_be_backfilled()
+
+
+SPLIT2_NAME = "split2"
+SPLIT2_STATE_DICT = {
+    "split": SPLIT2_NAME,
+    "step_states": [
+        {
+            "step_name": "split-first-rows-from-streaming",
+            "job_state": {"is_in_process": False},
+            "cache_state": {"exists": False, "is_success": False},
+            "should_be_backfilled": True,
+        },
+        {
+            "step_name": "split-first-rows-from-parquet",
+            "job_state": {"is_in_process": False},
+            "cache_state": {"exists": False, "is_success": False},
+            "should_be_backfilled": True,
+        },
+    ],
+    "should_be_backfilled": True,
+}
+
+CONFIG_STATE_DICT = {
+    "config": "config",
+    "split_states": [
+        SPLIT1_STATE_DICT,
+        SPLIT2_STATE_DICT,
+    ],
+    "step_states": [
+        {
+            "step_name": "/split-names-from-streaming",
+            "job_state": {"is_in_process": False},
+            "cache_state": {"exists": False, "is_success": False},
+            "should_be_backfilled": True,
+        },
+        {
+            "step_name": "config-parquet-and-info",
+            "job_state": {"is_in_process": False},
+            "cache_state": {"exists": False, "is_success": False},
+            "should_be_backfilled": True,
+        },
+        {
+            "step_name": "config-parquet",
+            "job_state": {"is_in_process": False},
+            "cache_state": {"exists": False, "is_success": False},
+            "should_be_backfilled": True,
+        },
+        {
+            "step_name": "config-info",
+            "job_state": {"is_in_process": False},
+            "cache_state": {"exists": False, "is_success": False},
+            "should_be_backfilled": True,
+        },
+        {
+            "step_name": "/split-names-from-dataset-info",
+            "job_state": {"is_in_process": False},
+            "cache_state": {"exists": True, "is_success": True},  # <- this entry is in the cache
+            "should_be_backfilled": False,  # <- thus: no need to backfill
+        },
+        {
+            "step_name": "config-size",
+            "job_state": {"is_in_process": False},
+            "cache_state": {"exists": False, "is_success": False},
+            "should_be_backfilled": True,
+        },
+    ],
+    "should_be_backfilled": True,
+}
+
+
+def test_config_state_as_dict() -> None:
+    dataset = DATASET_NAME
+    config = CONFIG_NAME
+    upsert_response(
+        kind=HARD_CODED_SPLIT_NAMES_FROM_DATASET_INFO_CACHE_KIND,
+        dataset=DATASET_NAME,
+        config=CONFIG_NAME,
+        split=None,
+        content=SPLIT_NAMES_RESPONSE_OK["content"],
+        http_status=SPLIT_NAMES_RESPONSE_OK["http_status"],
+    )
+    processing_graph = PROCESSING_GRAPH
+    assert (
+        ConfigState(dataset=dataset, config=config, processing_graph=processing_graph).as_dict() == CONFIG_STATE_DICT
+    )
+
+
+def test_config_state_backfill() -> None:
+    dataset = DATASET_NAME
+    config = CONFIG_NAME
+    processing_graph = PROCESSING_GRAPH
+    config_state = ConfigState(dataset=dataset, config=config, processing_graph=processing_graph)
+    assert not config_state.split_names
+    assert [str(task) for task in config_state.get_backfill_tasks()] == [
+        "backfill[/split-names-from-streaming,dataset,config,None]",
+        "backfill[config-parquet-and-info,dataset,config,None]",
+        "backfill[config-parquet,dataset,config,None]",
+        "backfill[config-info,dataset,config,None]",
+        "backfill[/split-names-from-dataset-info,dataset,config,None]",
+        "backfill[config-size,dataset,config,None]",
+    ]
+    assert config_state.should_be_backfilled()
+    config_state.backfill()
+    # simulate that the split names are now in the cache
+    upsert_response(
+        kind=HARD_CODED_SPLIT_NAMES_FROM_DATASET_INFO_CACHE_KIND,
+        dataset=DATASET_NAME,
+        config=CONFIG_NAME,
+        split=None,
+        content=SPLIT_NAMES_RESPONSE_OK["content"],
+        http_status=SPLIT_NAMES_RESPONSE_OK["http_status"],
+    )
+    job_info = Queue().start_job(only_job_types=[HARD_CODED_SPLIT_NAMES_FROM_DATASET_INFO_CACHE_KIND])
+    Queue().finish_job(job_id=job_info["job_id"], finished_status=Status.SUCCESS)
+    config_state = ConfigState(dataset=dataset, config=config, processing_graph=processing_graph)
+    assert config_state.split_names == [
+        split_item["split"] for split_item in SPLIT_NAMES_RESPONSE_OK["content"]["split_names"]
+    ]
+    # still: should_be_backfilled() is True, because the split steps are not in the cache
+    # the config steps, on the other hand, are in process, so not appearing in the list of backfill tasks
+    assert [str(task) for task in config_state.get_backfill_tasks()] == [
+        "backfill[split-first-rows-from-streaming,dataset,config,split1]",
+        "backfill[split-first-rows-from-parquet,dataset,config,split1]",
+        "backfill[split-first-rows-from-streaming,dataset,config,split2]",
+        "backfill[split-first-rows-from-parquet,dataset,config,split2]",
+    ]
+    assert config_state.should_be_backfilled()
+    config_state.backfill()
+    config_state = ConfigState(dataset=dataset, config=config, processing_graph=processing_graph)
+    assert not config_state.get_backfill_tasks()
+    assert not config_state.should_be_backfilled()
+
+
+ONE_CONFIG_NAME_CONTENT_OK = {"config_names": [{"config": CONFIG_NAME}]}
+
+
+def test_dataset_state_as_dict() -> None:
+    dataset = DATASET_NAME
+    upsert_response(
+        kind=HARD_CODED_CONFIG_NAMES_CACHE_KIND,
+        dataset=DATASET_NAME,
+        config=None,
+        split=None,
+        content=ONE_CONFIG_NAME_CONTENT_OK,
+        http_status=HTTPStatus.OK,
+    )
+    upsert_response(
+        kind=HARD_CODED_SPLIT_NAMES_FROM_DATASET_INFO_CACHE_KIND,
+        dataset=DATASET_NAME,
+        config=CONFIG_NAME,
+        split=None,
+        content=SPLIT_NAMES_RESPONSE_OK["content"],
+        http_status=SPLIT_NAMES_RESPONSE_OK["http_status"],
+    )
+    processing_graph = PROCESSING_GRAPH
+    assert DatasetState(dataset=dataset, processing_graph=processing_graph).as_dict() == {
+        "dataset": "dataset",
+        "config_states": [CONFIG_STATE_DICT],
+        "step_states": [
+            {
+                "step_name": "/config-names",
+                "job_state": {"is_in_process": False},
+                "cache_state": {"exists": True, "is_success": True},  # <- this entry is in the cache
+                "should_be_backfilled": False,  # <- thus: no need to backfill
+            },
+            {
+                "step_name": "/parquet-and-dataset-info",
+                "job_state": {"is_in_process": False},
+                "cache_state": {"exists": False, "is_success": False},
+                "should_be_backfilled": True,
+            },
+            {
+                "step_name": "dataset-parquet",
+                "job_state": {"is_in_process": False},
+                "cache_state": {"exists": False, "is_success": False},
+                "should_be_backfilled": True,
+            },
+            {
+                "step_name": "dataset-info",
+                "job_state": {"is_in_process": False},
+                "cache_state": {"exists": False, "is_success": False},
+                "should_be_backfilled": True,
+            },
+            {
+                "step_name": "dataset-size",
+                "job_state": {"is_in_process": False},
+                "cache_state": {"exists": False, "is_success": False},
+                "should_be_backfilled": True,
+            },
+            {
+                "step_name": "dataset-split-names-from-streaming",
+                "job_state": {"is_in_process": False},
+                "cache_state": {"exists": False, "is_success": False},
+                "should_be_backfilled": True,
+            },
+            {
+                "step_name": "dataset-split-names-from-dataset-info",
+                "job_state": {"is_in_process": False},
+                "cache_state": {"exists": False, "is_success": False},
+                "should_be_backfilled": True,
+            },
+            {
+                "step_name": "dataset-split-names",
+                "job_state": {"is_in_process": False},
+                "cache_state": {"exists": False, "is_success": False},
+                "should_be_backfilled": True,
+            },
+            {
+                "step_name": "dataset-is-valid",
+                "job_state": {"is_in_process": False},
+                "cache_state": {"exists": False, "is_success": False},
+                "should_be_backfilled": True,
+            },
+        ],
+        "should_be_backfilled": True,
+    }
+
+
+def test_dataset_state_backfill() -> None:
+    dataset = DATASET_NAME
+    processing_graph = PROCESSING_GRAPH
+    dataset_state = DatasetState(dataset=dataset, processing_graph=processing_graph)
+    assert not dataset_state.config_names
+    assert [str(task) for task in dataset_state.get_backfill_tasks()] == [
+        "backfill[/config-names,dataset,None,None]",
+        "backfill[/parquet-and-dataset-info,dataset,None,None]",
+        "backfill[dataset-parquet,dataset,None,None]",
+        "backfill[dataset-info,dataset,None,None]",
+        "backfill[dataset-size,dataset,None,None]",
+        "backfill[dataset-split-names-from-streaming,dataset,None,None]",
+        "backfill[dataset-split-names-from-dataset-info,dataset,None,None]",
+        "backfill[dataset-split-names,dataset,None,None]",
+        "backfill[dataset-is-valid,dataset,None,None]",
+    ]
+    assert dataset_state.should_be_backfilled()
+    dataset_state.backfill()
+    # simulate that the config names are now in the cache
+    upsert_response(
+        kind=HARD_CODED_CONFIG_NAMES_CACHE_KIND,
+        dataset=DATASET_NAME,
+        config=None,
+        split=None,
+        content=ONE_CONFIG_NAME_CONTENT_OK,
+        http_status=HTTPStatus.OK,
+    )
+    job_info = Queue().start_job(only_job_types=[HARD_CODED_CONFIG_NAMES_CACHE_KIND])
+    Queue().finish_job(job_id=job_info["job_id"], finished_status=Status.SUCCESS)
+
+    dataset_state = DatasetState(dataset=dataset, processing_graph=processing_graph)
+    assert dataset_state.config_names == [CONFIG_NAME]
+    # still: should_be_backfilled() is True, because the config steps are not in the cache
+    # the dataset steps, on the other hand, are in process, so not appearing in the list of backfill tasks
+    assert [str(task) for task in dataset_state.get_backfill_tasks()] == [
+        "backfill[/split-names-from-streaming,dataset,config,None]",
+        "backfill[config-parquet-and-info,dataset,config,None]",
+        "backfill[config-parquet,dataset,config,None]",
+        "backfill[config-info,dataset,config,None]",
+        "backfill[/split-names-from-dataset-info,dataset,config,None]",
+        "backfill[config-size,dataset,config,None]",
+    ]
+    assert dataset_state.should_be_backfilled()
+    dataset_state.backfill()
+    # simulate that the config names are now in the cache
+    upsert_response(
+        kind=HARD_CODED_SPLIT_NAMES_FROM_DATASET_INFO_CACHE_KIND,
+        dataset=DATASET_NAME,
+        config=CONFIG_NAME,
+        split=None,
+        content=SPLIT_NAMES_RESPONSE_OK["content"],
+        http_status=SPLIT_NAMES_RESPONSE_OK["http_status"],
+    )
+    job_info = Queue().start_job(only_job_types=[HARD_CODED_SPLIT_NAMES_FROM_DATASET_INFO_CACHE_KIND])
+    Queue().finish_job(job_id=job_info["job_id"], finished_status=Status.SUCCESS)
+
+    dataset_state = DatasetState(dataset=dataset, processing_graph=processing_graph)
+    assert dataset_state.config_states[CONFIG_NAME].split_names == [
+        split_item["split"] for split_item in SPLIT_NAMES_RESPONSE_OK["content"]["split_names"]
+    ]
+    # still: should_be_backfilled() is True, because the split steps are not in the cache
+    # the config steps, on the other hand, are in process, so not appearing in the list of backfill tasks
+    assert [str(task) for task in dataset_state.get_backfill_tasks()] == [
+        "backfill[split-first-rows-from-streaming,dataset,config,split1]",
+        "backfill[split-first-rows-from-parquet,dataset,config,split1]",
+        "backfill[split-first-rows-from-streaming,dataset,config,split2]",
+        "backfill[split-first-rows-from-parquet,dataset,config,split2]",
+    ]
+    assert dataset_state.should_be_backfilled()
+    dataset_state.backfill()
+    dataset_state = DatasetState(dataset=dataset, processing_graph=processing_graph)
+    assert not dataset_state.get_backfill_tasks()
+    assert not dataset_state.should_be_backfilled()

--- a/libs/libcommon/tests/test_state.py
+++ b/libs/libcommon/tests/test_state.py
@@ -452,7 +452,7 @@ CONFIG_PARQUET_AND_INFO_OK = {"config": CONFIG_NAME, "content": "not important"}
 CONFIG_INFO_OK = {"config": CONFIG_NAME, "content": "not important"}
 
 
-def finish_task(job_type: str, content: Any) -> None:
+def finish_job(job_type: str, content: Any) -> None:
     job_info = Queue().start_job(only_job_types=[job_type])
     upsert_response(
         kind=job_info["type"],
@@ -578,8 +578,8 @@ def test_backfill() -> None:
         tasks=[],
     )
 
-    # simulate that the "backfill[/config-names,dataset]" task has finished
-    finish_task(job_type="/config-names", content=ONE_CONFIG_NAME_CONTENT_OK)
+    # simulate that the job for the "/config-names,dataset" artifact has finished
+    finish_job(job_type="/config-names", content=ONE_CONFIG_NAME_CONTENT_OK)
 
     dataset_state = assert_dataset_state(
         # The config names are known
@@ -635,8 +635,8 @@ def test_backfill() -> None:
 
     # launch the backfill tasks
     dataset_state.backfill()
-    # and simulate that the "backfill[config-parquet-and-info,dataset,config]" task has finished
-    finish_task(job_type="config-parquet-and-info", content=CONFIG_PARQUET_AND_INFO_OK)
+    # and simulate that the job for the "config-parquet-and-info,dataset,config" artifact has finished
+    finish_job(job_type="config-parquet-and-info", content=CONFIG_PARQUET_AND_INFO_OK)
 
     dataset_state = assert_dataset_state(
         # The config names are known
@@ -689,8 +689,8 @@ def test_backfill() -> None:
 
     # launch the backfill tasks
     dataset_state.backfill()
-    # and simulate that the "backfill[config-info,dataset,config]" task has finished
-    finish_task(job_type="config-info", content=CONFIG_INFO_OK)
+    # and simulate that the job for the "config-info,dataset,config" artifact has finished
+    finish_job(job_type="config-info", content=CONFIG_INFO_OK)
 
     # "config-info" is up-to-date
     # "/split-names-from-dataset-info" is no more blocked, and is ready to be backfilled
@@ -741,10 +741,10 @@ def test_backfill() -> None:
 
     # launch the backfill tasks
     dataset_state.backfill()
-    # simulate that the "backfill[/split-names-from-dataset-info,dataset,config]" task and
-    # the "backfill[/split-names-from-streaming,dataset,config]" have finished
-    finish_task(job_type="/split-names-from-dataset-info", content=SPLIT_NAMES_RESPONSE_OK["content"])
-    finish_task(job_type="/split-names-from-streaming", content=SPLIT_NAMES_RESPONSE_OK["content"])
+    # and simulate that the job for the "/split-names-from-dataset-info,dataset,config" and
+    # "/split-names-from-streaming,dataset,config" artifacts have finished
+    finish_job(job_type="/split-names-from-dataset-info", content=SPLIT_NAMES_RESPONSE_OK["content"])
+    finish_job(job_type="/split-names-from-streaming", content=SPLIT_NAMES_RESPONSE_OK["content"])
 
     # "/split-names-from-dataset-info" and "/split-names-from-streaming" are up-to-date for the config
     # the split names are now available
@@ -802,7 +802,7 @@ def test_backfill() -> None:
         ],
     )
 
-    # force an update of the /config-names step
+    # force an update of the /config-names artifact
     upsert_response(
         kind="/config-names",
         dataset="dataset",

--- a/services/admin/src/admin/app.py
+++ b/services/admin/src/admin/app.py
@@ -98,6 +98,8 @@ def create_app() -> Starlette:
                 "/dataset-state",
                 endpoint=create_dataset_state_endpoint(
                     processing_graph=processing_graph,
+                    hf_endpoint=app_config.common.hf_endpoint,
+                    hf_token=app_config.common.hf_token,
                     max_age=app_config.admin.max_age,
                     external_auth_url=app_config.admin.external_auth_url,
                     organization=app_config.admin.hf_organization,

--- a/services/admin/src/admin/app.py
+++ b/services/admin/src/admin/app.py
@@ -25,6 +25,7 @@ from admin.routes.cache_reports_with_content import (
     create_cache_reports_with_content_endpoint,
 )
 from admin.routes.cancel_jobs import create_cancel_jobs_endpoint
+from admin.routes.dataset_state import create_dataset_state_endpoint
 from admin.routes.dataset_status import create_dataset_status_endpoint
 from admin.routes.force_refresh import create_force_refresh_endpoint
 from admin.routes.healthcheck import healthcheck_endpoint
@@ -76,6 +77,15 @@ def create_app() -> Starlette:
                 "/pending-jobs",
                 endpoint=create_pending_jobs_endpoint(
                     processing_steps=processing_steps,
+                    max_age=app_config.admin.max_age,
+                    external_auth_url=app_config.admin.external_auth_url,
+                    organization=app_config.admin.hf_organization,
+                ),
+            ),
+            Route(
+                "/dataset-state",
+                endpoint=create_dataset_state_endpoint(
+                    processing_graph=processing_graph,
                     max_age=app_config.admin.max_age,
                     external_auth_url=app_config.admin.external_auth_url,
                     organization=app_config.admin.hf_organization,

--- a/services/admin/src/admin/app.py
+++ b/services/admin/src/admin/app.py
@@ -25,6 +25,7 @@ from admin.routes.cache_reports_with_content import (
     create_cache_reports_with_content_endpoint,
 )
 from admin.routes.cancel_jobs import create_cancel_jobs_endpoint
+from admin.routes.dataset_backfill import create_dataset_backfill_endpoint
 from admin.routes.dataset_state import create_dataset_state_endpoint
 from admin.routes.dataset_status import create_dataset_status_endpoint
 from admin.routes.force_refresh import create_force_refresh_endpoint
@@ -81,6 +82,17 @@ def create_app() -> Starlette:
                     external_auth_url=app_config.admin.external_auth_url,
                     organization=app_config.admin.hf_organization,
                 ),
+            ),
+            Route(
+                "/dataset-backfill",
+                endpoint=create_dataset_backfill_endpoint(
+                    processing_graph=processing_graph,
+                    hf_endpoint=app_config.common.hf_endpoint,
+                    hf_token=app_config.common.hf_token,
+                    external_auth_url=app_config.admin.external_auth_url,
+                    organization=app_config.admin.hf_organization,
+                ),
+                methods=["POST"],
             ),
             Route(
                 "/dataset-state",

--- a/services/admin/src/admin/routes/dataset_backfill.py
+++ b/services/admin/src/admin/routes/dataset_backfill.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+import logging
+from typing import Optional
+
+from libcommon.dataset import DatasetError, check_support
+from libcommon.processing_graph import ProcessingGraph
+from libcommon.state import DatasetState
+from starlette.requests import Request
+from starlette.responses import Response
+
+from admin.authentication import auth_check
+from admin.utils import (
+    AdminCustomError,
+    Endpoint,
+    MissingRequiredParameterError,
+    UnexpectedError,
+    are_valid_parameters,
+    get_json_admin_error_response,
+    get_json_ok_response,
+)
+
+
+def create_dataset_backfill_endpoint(
+    processing_graph: ProcessingGraph,
+    hf_endpoint: str,
+    hf_token: Optional[str] = None,
+    external_auth_url: Optional[str] = None,
+    organization: Optional[str] = None,
+) -> Endpoint:
+    async def dataset_backfill_endpoint(request: Request) -> Response:
+        try:
+            dataset = request.query_params.get("dataset")
+            if not are_valid_parameters([dataset]) or not dataset:
+                raise MissingRequiredParameterError("Parameter 'dataset' is required")
+            logging.info(f"/dataset-backfill, dataset={dataset}")
+
+            # if auth_check fails, it will raise an exception that will be caught below
+            auth_check(external_auth_url=external_auth_url, request=request, organization=organization)
+            check_support(dataset=dataset, hf_endpoint=hf_endpoint, hf_token=hf_token)
+            dataset_state = DatasetState(dataset=dataset, processing_graph=processing_graph)
+            dataset_state.backfill()
+            tasks_list = ", ".join(dataset_state.plan.as_response())
+            return get_json_ok_response(
+                {"status": "ok", "message": f"Backfilling dataset. Tasks: {tasks_list}"},
+                max_age=0,
+            )
+        except (DatasetError, AdminCustomError) as e:
+            return get_json_admin_error_response(e, max_age=0)
+        except Exception as e:
+            return get_json_admin_error_response(UnexpectedError("Unexpected error.", e), max_age=0)
+
+    return dataset_backfill_endpoint

--- a/services/admin/src/admin/routes/dataset_backfill.py
+++ b/services/admin/src/admin/routes/dataset_backfill.py
@@ -4,7 +4,7 @@
 import logging
 from typing import Optional
 
-from libcommon.dataset import DatasetError, check_support
+from libcommon.dataset import DatasetError, get_dataset_git_revision
 from libcommon.processing_graph import ProcessingGraph
 from libcommon.state import DatasetState
 from starlette.requests import Request
@@ -25,9 +25,10 @@ from admin.utils import (
 def create_dataset_backfill_endpoint(
     processing_graph: ProcessingGraph,
     hf_endpoint: str,
-    hf_token: Optional[str] = None,
     external_auth_url: Optional[str] = None,
     organization: Optional[str] = None,
+    hf_token: Optional[str] = None,
+    hf_timeout_seconds: Optional[float] = None,
 ) -> Endpoint:
     async def dataset_backfill_endpoint(request: Request) -> Response:
         try:
@@ -38,8 +39,13 @@ def create_dataset_backfill_endpoint(
 
             # if auth_check fails, it will raise an exception that will be caught below
             auth_check(external_auth_url=external_auth_url, request=request, organization=organization)
-            check_support(dataset=dataset, hf_endpoint=hf_endpoint, hf_token=hf_token)
-            dataset_state = DatasetState(dataset=dataset, processing_graph=processing_graph)
+
+            dataset_git_revision = get_dataset_git_revision(
+                dataset=dataset, hf_endpoint=hf_endpoint, hf_token=hf_token, hf_timeout_seconds=hf_timeout_seconds
+            )
+            dataset_state = DatasetState(
+                dataset=dataset, processing_graph=processing_graph, revision=dataset_git_revision
+            )
             dataset_state.backfill()
             tasks_list = ", ".join(dataset_state.plan.as_response())
             return get_json_ok_response(

--- a/services/admin/src/admin/routes/dataset_state.py
+++ b/services/admin/src/admin/routes/dataset_state.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+import logging
+from typing import Optional
+
+from libcommon.processing_graph import ProcessingGraph
+from libcommon.state import DatasetState
+from starlette.requests import Request
+from starlette.responses import Response
+
+from admin.authentication import auth_check
+from admin.utils import (
+    AdminCustomError,
+    Endpoint,
+    MissingRequiredParameterError,
+    UnexpectedError,
+    are_valid_parameters,
+    get_json_admin_error_response,
+    get_json_ok_response,
+)
+
+
+def create_dataset_state_endpoint(
+    processing_graph: ProcessingGraph,
+    max_age: int,
+    external_auth_url: Optional[str] = None,
+    organization: Optional[str] = None,
+) -> Endpoint:
+    async def dataset_state_endpoint(request: Request) -> Response:
+        try:
+            dataset = request.query_params.get("dataset")
+            if not are_valid_parameters([dataset]) or not dataset:
+                raise MissingRequiredParameterError("Parameter 'dataset' is required")
+            logging.info(f"/dataset-state, dataset={dataset}")
+
+            # if auth_check fails, it will raise an exception that will be caught below
+            auth_check(external_auth_url=external_auth_url, request=request, organization=organization)
+
+            dataset_state = DatasetState(dataset=dataset, processing_graph=processing_graph)
+            return get_json_ok_response(dataset_state.as_response(), max_age=max_age)
+        except AdminCustomError as e:
+            return get_json_admin_error_response(e, max_age=max_age)
+        except Exception as e:
+            return get_json_admin_error_response(UnexpectedError("Unexpected error.", e), max_age=max_age)
+
+    return dataset_state_endpoint

--- a/services/api/tests/routes/test_valid.py
+++ b/services/api/tests/routes/test_valid.py
@@ -15,6 +15,7 @@ dataset_step = ProcessingStep(
     required_by_dataset_viewer=False,
     ancestors=[],
     children=[],
+    parents=[],
     job_runner_version=1,
 )
 config_step = ProcessingStep(
@@ -24,6 +25,7 @@ config_step = ProcessingStep(
     required_by_dataset_viewer=False,
     ancestors=[],
     children=[],
+    parents=[],
     job_runner_version=1,
 )
 split_step = ProcessingStep(
@@ -33,6 +35,7 @@ split_step = ProcessingStep(
     required_by_dataset_viewer=False,
     ancestors=[],
     children=[],
+    parents=[],
     job_runner_version=1,
 )
 

--- a/services/worker/tests/conftest.py
+++ b/services/worker/tests/conftest.py
@@ -122,6 +122,7 @@ def test_processing_step() -> ProcessingStep:
         required_by_dataset_viewer=False,
         ancestors=[],
         children=[],
+        parents=[],
         job_runner_version=1,
     )
 

--- a/services/worker/tests/job_runners/config/test_info.py
+++ b/services/worker/tests/job_runners/config/test_info.py
@@ -165,6 +165,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=ConfigInfoJobRunner.get_job_runner_version(),
             ),
         )

--- a/services/worker/tests/job_runners/config/test_parquet.py
+++ b/services/worker/tests/job_runners/config/test_parquet.py
@@ -63,6 +63,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=ConfigParquetJobRunner.get_job_runner_version(),
             ),
         )

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -96,6 +96,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=ConfigParquetAndInfoJobRunner.get_job_runner_version(),
             ),
             hf_datasets_cache=libraries_resource.hf_datasets_cache,

--- a/services/worker/tests/job_runners/config/test_size.py
+++ b/services/worker/tests/job_runners/config/test_size.py
@@ -58,6 +58,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=ConfigSizeJobRunner.get_job_runner_version(),
             ),
         )

--- a/services/worker/tests/job_runners/config/test_split_names_from_dataset_info.py
+++ b/services/worker/tests/job_runners/config/test_split_names_from_dataset_info.py
@@ -55,6 +55,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=SplitNamesFromDatasetInfoJobRunner.get_job_runner_version(),
             ),
             hf_datasets_cache=libraries_resource.hf_datasets_cache,

--- a/services/worker/tests/job_runners/config/test_split_names_from_streaming.py
+++ b/services/worker/tests/job_runners/config/test_split_names_from_streaming.py
@@ -55,6 +55,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=SplitNamesFromStreamingJobRunner.get_job_runner_version(),
             ),
             hf_datasets_cache=libraries_resource.hf_datasets_cache,

--- a/services/worker/tests/job_runners/dataset/test_info.py
+++ b/services/worker/tests/job_runners/dataset/test_info.py
@@ -136,6 +136,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=DatasetInfoJobRunner.get_job_runner_version(),
             ),
         )

--- a/services/worker/tests/job_runners/dataset/test_is_valid.py
+++ b/services/worker/tests/job_runners/dataset/test_is_valid.py
@@ -93,6 +93,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=DatasetIsValidJobRunner.get_job_runner_version(),
             ),
         )

--- a/services/worker/tests/job_runners/dataset/test_parquet.py
+++ b/services/worker/tests/job_runners/dataset/test_parquet.py
@@ -62,6 +62,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=DatasetParquetJobRunner.get_job_runner_version(),
             ),
         )

--- a/services/worker/tests/job_runners/dataset/test_size.py
+++ b/services/worker/tests/job_runners/dataset/test_size.py
@@ -59,6 +59,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=DatasetSizeJobRunner.get_job_runner_version(),
             ),
         )

--- a/services/worker/tests/job_runners/dataset/test_split_names.py
+++ b/services/worker/tests/job_runners/dataset/test_split_names.py
@@ -49,6 +49,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=DatasetSplitNamesJobRunner.get_job_runner_version(),
             ),
         )

--- a/services/worker/tests/job_runners/dataset/test_split_names_from_dataset_info.py
+++ b/services/worker/tests/job_runners/dataset/test_split_names_from_dataset_info.py
@@ -49,6 +49,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=DatasetSplitNamesFromDatasetInfoJobRunner.get_job_runner_version(),
             ),
         )

--- a/services/worker/tests/job_runners/dataset/test_split_names_from_streaming.py
+++ b/services/worker/tests/job_runners/dataset/test_split_names_from_streaming.py
@@ -49,6 +49,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=DatasetSplitNamesFromStreamingJobRunner.get_job_runner_version(),
             ),
         )

--- a/services/worker/tests/job_runners/split/test_first_rows_from_parquet.py
+++ b/services/worker/tests/job_runners/split/test_first_rows_from_parquet.py
@@ -62,6 +62,7 @@ def get_job_runner(
                 required_by_dataset_viewer=True,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=SplitFirstRowsFromParquetJobRunner.get_job_runner_version(),
             ),
             hf_datasets_cache=libraries_resource.hf_datasets_cache,

--- a/services/worker/tests/job_runners/split/test_first_rows_from_streaming.py
+++ b/services/worker/tests/job_runners/split/test_first_rows_from_streaming.py
@@ -61,6 +61,7 @@ def get_job_runner(
                 required_by_dataset_viewer=True,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=SplitFirstRowsFromStreamingJobRunner.get_job_runner_version(),
             ),
             hf_datasets_cache=libraries_resource.hf_datasets_cache,

--- a/services/worker/tests/job_runners/test__datasets_based_worker.py
+++ b/services/worker/tests/job_runners/test__datasets_based_worker.py
@@ -74,6 +74,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=DummyJobRunner.get_job_runner_version(),
             ),
             hf_datasets_cache=libraries_resource.hf_datasets_cache,

--- a/services/worker/tests/job_runners/test_config_names.py
+++ b/services/worker/tests/job_runners/test_config_names.py
@@ -50,6 +50,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=ConfigNamesJobRunner.get_job_runner_version(),
             ),
             hf_datasets_cache=libraries_resource.hf_datasets_cache,

--- a/services/worker/tests/job_runners/test_parquet_and_dataset_info.py
+++ b/services/worker/tests/job_runners/test_parquet_and_dataset_info.py
@@ -92,6 +92,7 @@ def get_job_runner(
                 required_by_dataset_viewer=False,
                 ancestors=[],
                 children=[],
+                parents=[],
                 job_runner_version=ParquetAndDatasetInfoJobRunner.get_job_runner_version(),
             ),
             hf_datasets_cache=libraries_resource.hf_datasets_cache,

--- a/services/worker/tests/test_job_runner.py
+++ b/services/worker/tests/test_job_runner.py
@@ -229,6 +229,7 @@ def test_check_type(
         required_by_dataset_viewer=False,
         ancestors=[],
         children=[],
+        parents=[],
         job_runner_version=1,
     )
     with pytest.raises(ValueError):


### PR DESCRIPTION
Creates two new endpoints:

- `GET /admin/dataset-state?dataset=[dataset]`: get the current state of the dataset (queue and cache)
- `POST /admin/dataset-backfill?dataset=[dataset]`: create (and delete) the jobs required to fix a dataset if necessary

They rely on the new class `DatasetState`. Please review the details of the implementation.

---

Here is a screencast of the two endpoints.

https://user-images.githubusercontent.com/1676121/232551041-4a12f9b9-490d-4d4b-b63a-ad7dbfe68e4b.mov

---

Not to be discussed here: as a follow-up, I think that most of the logic of the queue and DAG should go through that class, within a small orchestrator, instead of through the job runners.

- currently: when a job runner finishes a job, it tries to create the following jobs in the DAG order.
- proposal: when a job runner finishes a job, it sends the result to the orchestrator, that computes the dataset state and launches the missing jobs.