### PR TITLE
feat: 🎸 add backfill tasks, and button to launch backfill

### DIFF
--- a/front/admin_ui/app.py
+++ b/front/admin_ui/app.py
@@ -78,6 +78,10 @@ with gr.Blocks() as demo:
                 cached_responses_table = gr.DataFrame()
                 gr.Markdown("### Pending jobs")
                 jobs_table = gr.DataFrame()
+                backfill_message = gr.Markdown("", visible=False)
+                backfill_plan_table = gr.DataFrame(visible=False)
+                backfill_execute_button = gr.Button("Execute backfill plan", visible=False)
+                backfill_execute_error = gr.Markdown("", visible=False)
 
 
     def auth(token):
@@ -175,6 +179,46 @@ with gr.Blocks() as demo:
                 cached_responses_table: gr.update(value=None),
                 jobs_table: gr.update(value=None)
             }
+    
+    def get_backfill_plan(token, dataset):
+        headers = {"Authorization": f"Bearer {token}"}
+        response = requests.get(f"{DSS_ENDPOINT}/admin/dataset-state?dataset={dataset}", headers=headers, timeout=60)
+        if response.status_code != 200:
+            return {
+                backfill_message: gr.update(value=f"❌ Failed to get backfill plan for {dataset} (error {response.status_code})", visible=True),
+                backfill_plan_table: gr.update(value=None,visible=False),
+                backfill_execute_button: gr.update( visible=False),
+                backfill_execute_error: gr.update( visible=False)
+            }
+        dataset_state = response.json()
+        tasks_df = pd.DataFrame(dataset_state["plan"])
+        has_tasks = len(tasks_df) > 0
+        return {
+            backfill_message: gr.update(
+                value="""### Backfill plan
+
+The cache is outdated or in an incoherent state. Here is the plan to backfill the cache."""
+            ,visible=has_tasks),
+            backfill_plan_table: gr.update(value=tasks_df,visible=has_tasks),
+            backfill_execute_button: gr.update(visible=has_tasks),
+            backfill_execute_error: gr.update(visible=False),
+        }
+
+    def get_dataset_status_and_backfill_plan(token, dataset):
+        return {**get_dataset_status(token, dataset), **get_backfill_plan(token, dataset)}
+
+
+    def execute_backfill_plan(token, dataset):
+        headers = {"Authorization": f"Bearer {token}"}
+        response = requests.post(f"{DSS_ENDPOINT}/admin/dataset-backfill?dataset={dataset}", headers=headers, timeout=60)
+        state = get_dataset_status_and_backfill_plan(token, dataset)
+        message = (
+            "✅ Backfill plan executed"
+            if response.status_code == 200
+            else f"❌ Failed to execute backfill plan (error {response.status_code})<pre>{response.text}</pre>"
+        )
+        state[backfill_execute_error] = gr.update(value=message, visible=True)
+        return state
 
     def query_jobs(pending_jobs_query):
         global pending_jobs_df
@@ -223,7 +267,8 @@ with gr.Blocks() as demo:
     query_pending_jobs_button.click(query_jobs, inputs=pending_jobs_query, outputs=[pending_jobs_query_result_df])
     
     refresh_dataset_button.click(refresh_dataset, inputs=[token_box, refresh_type, refresh_dataset_name, refresh_config_name, refresh_split_name], outputs=refresh_dataset_output)
-    dataset_status_button.click(get_dataset_status, inputs=[token_box, dataset_name], outputs=[cached_responses_table, jobs_table])
+    dataset_status_button.click(get_dataset_status_and_backfill_plan, inputs=[token_box, dataset_name], outputs=[cached_responses_table, jobs_table, backfill_message, backfill_plan_table, backfill_execute_button, backfill_execute_error])
+    backfill_execute_button.click(execute_backfill_plan, inputs=[token_box, dataset_name], outputs=[cached_responses_table, jobs_table, backfill_message, backfill_plan_table, backfill_execute_button, backfill_execute_error])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
See it in action. Here we see than a repo that does not exists shows an error (we could improve it), and then when the repo is created (but empty), the cache entries are created. Note that currently, the setup is a bit weird:
- the local hub does not send webhooks to the local datasets-server
- but: as the local hub has tried to get the list of first rows from the datasets-server, it has triggered an update of the dataset (see how service/api works when a cache entry is missing)
- thus: some cache entries have been created
- BUT: it was done using the "job runner" logic, where every step creates the following steps after the job has been finished. This logic has some flaws, which is why the backfill plan shows some missing tasks: some other jobs should have been created

https://user-images.githubusercontent.com/1676121/233086733-133866c0-bcaf-4f62-903b-9bb7a5c29f40.mov

Here we show that, once we add files to the empty repository, the backfill plan is to refresh a lot of cache entries. We execute the backfill, and then the dataset viewer works.

https://user-images.githubusercontent.com/1676121/233087075-d8aeeb11-817f-4bae-b412-ea792e32796a.mov

