### PR TITLE
fix: 🐛 add missing "config" parameter

### DIFF
--- a/services/worker/src/worker/job_runners/config/split_names_from_dataset_info.py
+++ b/services/worker/src/worker/job_runners/config/split_names_from_dataset_info.py
@@ -90,7 +90,7 @@ def compute_split_names_from_dataset_info_response(dataset: str, config: str) ->
     """
     logging.info(f"get split names from dataset info for dataset={dataset}, config={config}")
     try:
-        response = get_response(kind="config-info", dataset=dataset)
+        response = get_response(kind="config-info", dataset=dataset, config=config)
     except DoesNotExist as e:
         raise DatasetNotFoundError("No response found in previous step for this dataset: 'config-info'.", e) from e
     if response["http_status"] != HTTPStatus.OK:

--- a/services/worker/tests/job_runners/config/test_split_names_from_dataset_info.py
+++ b/services/worker/tests/job_runners/config/test_split_names_from_dataset_info.py
@@ -127,8 +127,11 @@ def test_compute(
     error_code: str,
     content: Any,
 ) -> None:
-    upsert_response(kind="config-info", dataset=dataset, content=upstream_content, http_status=upstream_status)
-    job_runner = get_job_runner(dataset, "config_name", app_config, False)
+    config = "config_name"
+    upsert_response(
+        kind="config-info", dataset=dataset, config=config, content=upstream_content, http_status=upstream_status
+    )
+    job_runner = get_job_runner(dataset, config, app_config, False)
     job_runner.get_dataset_git_revision = Mock(return_value="1.0.0")  # type: ignore
 
     if error_code:


### PR DESCRIPTION
when fetching the previous step (config-info)