### PR TITLE
fix: 🐛 report backfill every 100 anaylized datasets

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -126,8 +126,8 @@ cacheMaintenance:
 backfill:
   enabled: true
   action: "backfill"
-  schedule: "0 * * * *"
-  # every hour
+  schedule: "40 */6 * * *"
+  # every six hour
   nodeSelector: {}
   resources:
     requests:

--- a/jobs/cache_maintenance/src/cache_maintenance/backfill.py
+++ b/jobs/cache_maintenance/src/cache_maintenance/backfill.py
@@ -40,7 +40,7 @@ def backfill_cache(
             backfilled_datasets += 1
             created_jobs += dataset_state.backfill()
 
-        if backfilled_datasets % log_batch == 0:
+        if analyzed_datasets % log_batch == 0:
             log()
 
     log()


### PR DESCRIPTION
Also: only run backfill job every 6 hours