### PR TITLE
Fix parent class for split-names-from-dataset-info and first-rows-from-parquet

### DIFF
--- a/services/worker/src/worker/job_runner_factory.py
+++ b/services/worker/src/worker/job_runner_factory.py
@@ -157,9 +157,9 @@ class JobRunnerFactory(BaseJobRunnerFactory):
         if job_type == SplitNamesFromDatasetInfoJobRunner.get_job_type():
             return SplitNamesFromDatasetInfoJobRunner(
                 job_info=job_info,
-                app_config=self.app_config,
+                common_config=self.app_config.common,
+                worker_config=self.app_config.worker,
                 processing_step=processing_step,
-                hf_datasets_cache=self.hf_datasets_cache,
             )
         if job_type == DatasetSplitNamesJobRunner.get_job_type():
             return DatasetSplitNamesJobRunner(
@@ -180,7 +180,6 @@ class JobRunnerFactory(BaseJobRunnerFactory):
                 job_info=job_info,
                 app_config=self.app_config,
                 processing_step=processing_step,
-                hf_datasets_cache=self.hf_datasets_cache,
                 assets_directory=self.assets_directory,
             )
         if job_type == DatasetIsValidJobRunner.get_job_type():

--- a/services/worker/src/worker/job_runners/config/split_names_from_dataset_info.py
+++ b/services/worker/src/worker/job_runners/config/split_names_from_dataset_info.py
@@ -13,11 +13,11 @@ from libcommon.simple_cache import SplitFullName
 
 from worker.job_runner import (
     CompleteJobResult,
+    JobRunner,
     JobRunnerError,
     ParameterMissingError,
     get_previous_step_or_raise,
 )
-from worker.job_runners._datasets_based_job_runner import DatasetsBasedJobRunner
 from worker.utils import SplitItem, SplitsList
 
 SplitNamesFromDatasetInfoJobRunnerErrorCode = Literal[
@@ -95,7 +95,7 @@ def compute_split_names_from_dataset_info_response(dataset: str, config: str) ->
     return SplitsList(splits=split_name_items)
 
 
-class SplitNamesFromDatasetInfoJobRunner(DatasetsBasedJobRunner):
+class SplitNamesFromDatasetInfoJobRunner(JobRunner):
     @staticmethod
     def get_job_type() -> str:
         return "/split-names-from-dataset-info"

--- a/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
@@ -4,7 +4,6 @@
 import logging
 from functools import partial
 from http import HTTPStatus
-from pathlib import Path
 from typing import Any, List, Literal, Mapping, Optional
 
 import pyarrow as pa
@@ -27,10 +26,10 @@ from tqdm.contrib.concurrent import thread_map
 from worker.config import AppConfig, FirstRowsConfig
 from worker.job_runner import (
     CompleteJobResult,
+    JobRunner,
     JobRunnerError,
     get_previous_step_or_raise,
 )
-from worker.job_runners._datasets_based_job_runner import DatasetsBasedJobRunner
 from worker.utils import (
     Row,
     RowItem,
@@ -280,7 +279,7 @@ def compute_first_rows_response(
     return response
 
 
-class SplitFirstRowsFromParquetJobRunner(DatasetsBasedJobRunner):
+class SplitFirstRowsFromParquetJobRunner(JobRunner):
     assets_directory: StrPath
     first_rows_config: FirstRowsConfig
 
@@ -297,14 +296,13 @@ class SplitFirstRowsFromParquetJobRunner(DatasetsBasedJobRunner):
         job_info: JobInfo,
         app_config: AppConfig,
         processing_step: ProcessingStep,
-        hf_datasets_cache: Path,
         assets_directory: StrPath,
     ) -> None:
         super().__init__(
             job_info=job_info,
-            app_config=app_config,
+            common_config=app_config.common,
+            worker_config=app_config.worker,
             processing_step=processing_step,
-            hf_datasets_cache=hf_datasets_cache,
         )
         self.first_rows_config = app_config.first_rows
         self.assets_directory = assets_directory

--- a/services/worker/tests/job_runners/config/test_split_names_from_dataset_info.py
+++ b/services/worker/tests/job_runners/config/test_split_names_from_dataset_info.py
@@ -19,14 +19,12 @@ from worker.job_runners.config.split_names_from_dataset_info import (
     PreviousStepFormatError,
     SplitNamesFromDatasetInfoJobRunner,
 )
-from worker.resources import LibrariesResource
 
 GetJobRunner = Callable[[str, str, AppConfig, bool], SplitNamesFromDatasetInfoJobRunner]
 
 
 @pytest.fixture
 def get_job_runner(
-    libraries_resource: LibrariesResource,
     cache_mongo_resource: CacheMongoResource,
     queue_mongo_resource: QueueMongoResource,
 ) -> GetJobRunner:
@@ -46,7 +44,8 @@ def get_job_runner(
                 "force": force,
                 "priority": Priority.NORMAL,
             },
-            app_config=app_config,
+            common_config=app_config.common,
+            worker_config=app_config.worker,
             processing_step=ProcessingStep(
                 name=SplitNamesFromDatasetInfoJobRunner.get_job_type(),
                 input_type="config",
@@ -57,7 +56,6 @@ def get_job_runner(
                 parents=[],
                 job_runner_version=SplitNamesFromDatasetInfoJobRunner.get_job_runner_version(),
             ),
-            hf_datasets_cache=libraries_resource.hf_datasets_cache,
         )
 
     return _get_job_runner

--- a/services/worker/tests/job_runners/split/test_first_rows_from_parquet.py
+++ b/services/worker/tests/job_runners/split/test_first_rows_from_parquet.py
@@ -21,7 +21,6 @@ from worker.config import AppConfig
 from worker.job_runners.split.first_rows_from_parquet import (
     SplitFirstRowsFromParquetJobRunner,
 )
-from worker.resources import LibrariesResource
 from worker.utils import get_json_size
 
 from ...fixtures.hub import get_default_config_split

--- a/services/worker/tests/job_runners/split/test_first_rows_from_parquet.py
+++ b/services/worker/tests/job_runners/split/test_first_rows_from_parquet.py
@@ -32,7 +32,6 @@ GetJobRunner = Callable[[str, str, str, AppConfig, bool], SplitFirstRowsFromParq
 @pytest.fixture
 def get_job_runner(
     assets_directory: StrPath,
-    libraries_resource: LibrariesResource,
     cache_mongo_resource: CacheMongoResource,
     queue_mongo_resource: QueueMongoResource,
 ) -> GetJobRunner:
@@ -64,7 +63,6 @@ def get_job_runner(
                 parents=[],
                 job_runner_version=SplitFirstRowsFromParquetJobRunner.get_job_runner_version(),
             ),
-            hf_datasets_cache=libraries_resource.hf_datasets_cache,
             assets_directory=assets_directory,
         )
 


### PR DESCRIPTION
 split-names-from-dataset-info and first-rows-from-parquet don't need to inherit from DatasetsBasedJobRunner, changing to JobRunner