### PR TITLE
Overcommit a bit less

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -261,11 +261,11 @@ workers:
     workerJobTypesOnly: ""
     nodeSelector:
       role-datasets-server-worker: "true"
-    replicas: 80
+    replicas: 40
     resources:
       requests:
         cpu: 1
-        memory: "2Gi"
+        memory: "4Gi"
       limits:
         cpu: 2
         memory: "8Gi"

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -261,7 +261,7 @@ workers:
     workerJobTypesOnly: ""
     nodeSelector:
       role-datasets-server-worker: "true"
-    replicas: 40
+    replicas: 20
     resources:
       requests:
         cpu: 1


### PR DESCRIPTION
Reduce the overcommitment to avoid having too many nodes killed by was. I also reduced a lot the number of workers, because we currently don't need as many.