### PR TITLE
Removing non necessary attributes in job runner init

### DIFF
--- a/services/worker/src/worker/job_runner.py
+++ b/services/worker/src/worker/job_runner.py
@@ -34,10 +34,6 @@ class JobRunner(ABC):
         self.job_info = job_info
         self.app_config = app_config
         self.processing_step = processing_step
-        self.job_type = job_info["type"]
-        self.job_id = job_info["job_id"]
-        self.force = job_info["force"]
-        self.priority = job_info["priority"]
 
     def pre_compute(self) -> None:
         """Hook method called before the compute method."""

--- a/services/worker/src/worker/job_runners/_datasets_based_job_runner.py
+++ b/services/worker/src/worker/job_runners/_datasets_based_job_runner.py
@@ -53,7 +53,7 @@ class DatasetsBasedJobRunner(JobRunner):
             self.job_info["params"]["dataset"],
             self.job_info["params"]["config"],
             self.job_info["params"]["split"],
-            self.force,
+            self.job_info["force"],
         )
         hash_suffix = sha1(json.dumps(payload, sort_keys=True).encode(), usedforsecurity=False).hexdigest()[:8]
         prefix = f"{date_str}-{self.get_job_type()}-{self.job_info['params']['dataset']}"[:64]


### PR DESCRIPTION
Small fix for https://github.com/huggingface/datasets-server/pull/1146#discussion_r1191621514
We don't need to initialize job_manager attributes on job_runner