### PR TITLE
fix: 🐛 don't fill truncated_cells w/ unsupported cols on /rows

### DIFF
--- a/services/api/src/api/routes/rows.py
+++ b/services/api/src/api/routes/rows.py
@@ -320,7 +320,7 @@ def to_rows_list(
         {
             "row_idx": idx + offset,
             "row": row,
-            "truncated_cells": unsupported_columns,
+            "truncated_cells": [],
         }
         for idx, row in enumerate(transformed_rows)
     ]


### PR DESCRIPTION
See
https://github.com/huggingface/moon-landing/pull/6300#issuecomment-1547590109 for reference (internal link).