### PR TITLE
Set datetime types in admin ui

### DIFF
--- a/front/admin_ui/app.py
+++ b/front/admin_ui/app.py
@@ -189,7 +189,6 @@ with gr.Blocks() as demo:
                     "config": job["config"],
                     "split": job["split"],
                     "namespace": job["namespace"],
-                    "force": job["force"],
                     "priority": job["priority"],
                     "status": job["status"],
                     "created_at": job["created_at"],

--- a/front/admin_ui/app.py
+++ b/front/admin_ui/app.py
@@ -137,6 +137,12 @@ with gr.Blocks() as demo:
                 for job_state in pending_jobs[job_type]
                 for job in pending_jobs[job_type][job_state]
             ])
+            if "started_at" in pending_jobs_df.columns:
+                pending_jobs_df["started_at"] = pd.to_datetime(pending_jobs_df["started_at"], errors="coerce")
+            if "finished_at" in pending_jobs_df.columns:
+                pending_jobs_df["finished_at"] = pd.to_datetime(pending_jobs_df["finished_at"], errors="coerce")
+            if "last_heartbeat" in pending_jobs_df.columns:
+                pending_jobs_df["last_heartbeat"] = pd.to_datetime(pending_jobs_df["last_heartbeat"], errors="coerce")
             if "created_at" in pending_jobs_df.columns:
                 pending_jobs_df["created_at"] = pd.to_datetime(pending_jobs_df["created_at"], errors="coerce")
                 most_recent = pending_jobs_df.nlargest(5, "created_at")
@@ -183,6 +189,7 @@ with gr.Blocks() as demo:
                     "config": job["config"],
                     "split": job["split"],
                     "namespace": job["namespace"],
+                    "force": job["force"],
                     "priority": job["priority"],
                     "status": job["status"],
                     "created_at": job["created_at"],


### PR DESCRIPTION
to fix errors when duckdb tries to cast the columns like "started_at"

(already deployed on HF - I ran my tests there ^^')