### PR TITLE
fix: 🐛 the started jobinfo always contained priority=NORMAL

### DIFF
--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -357,7 +357,7 @@ class Queue:
                 status=Status.WAITING, namespace__nin=set(started_job_namespaces), priority=priority, **filters
             )
             .order_by("+created_at")
-            .only("type", "dataset", "revision", "config", "split")
+            .only("type", "dataset", "revision", "config", "split", "priority")
             .no_cache()
             .first()
         )
@@ -400,7 +400,7 @@ class Queue:
                     **filters,
                 )
                 .order_by("+created_at")
-                .only("type", "dataset", "revision", "config", "split")
+                .only("type", "dataset", "revision", "config", "split", "priority")
                 .no_cache()
                 .first()
             )


### PR DESCRIPTION
Now we get the value as expected. This means that the backfill function will create jobs at the same level of priority, instead of moving everything to the NORMAL priority queue