### PR TITLE
Use parquet metadata in /rows

### DIFF
--- a/libs/libcommon/src/libcommon/config.py
+++ b/libs/libcommon/src/libcommon/config.py
@@ -234,6 +234,7 @@ class ProcessingGraphConfig:
                 "input_type": "config",
                 "triggered_by": "config-parquet",
                 "job_runner_version": PROCESSING_STEP_CONFIG_PARQUET_METADATA_VERSION,
+                "provides_config_parquet_metadata": True,
             },
             "split-first-rows-from-parquet": {
                 "input_type": "split",

--- a/libs/libcommon/src/libcommon/processing_graph.py
+++ b/libs/libcommon/src/libcommon/processing_graph.py
@@ -166,7 +166,9 @@ class ProcessingGraph:
                 raise ValueError(f"Processing step {name} provides config parquet but its input type is {input_type}.")
             provides_config_parquet_metadata = specification.get("provides_config_parquet_metadata", False)
             if provides_config_parquet_metadata and input_type != "config":
-                raise ValueError(f"Processing step {name} provides config parquet metadata but its input type is {input_type}.")
+                raise ValueError(
+                    f"Processing step {name} provides config parquet metadata but its input type is {input_type}."
+                )
             if (
                 _nx_graph.has_node(name)
                 or name in _processing_steps

--- a/services/api/src/api/app.py
+++ b/services/api/src/api/app.py
@@ -5,7 +5,7 @@ import uvicorn
 from libcommon.log import init_logging
 from libcommon.processing_graph import ProcessingGraph
 from libcommon.resources import CacheMongoResource, QueueMongoResource, Resource
-from libcommon.storage import exists, init_cached_assets_dir
+from libcommon.storage import exists, init_cached_assets_dir, init_parquet_metadata_dir
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -33,6 +33,7 @@ def create_app_with_config(app_config: AppConfig, endpoint_config: EndpointConfi
     init_logging(level=app_config.log.level)
     # ^ set first to have logs as soon as possible
     cached_assets_directory = init_cached_assets_dir(directory=app_config.cached_assets.storage_directory)
+    parquet_metadata_directory = init_parquet_metadata_dir(directory=app_config.parquet_metadata.storage_directory)
     if not exists(cached_assets_directory):
         raise RuntimeError("The assets storage directory could not be accessed. Exiting.")
 
@@ -111,6 +112,7 @@ def create_app_with_config(app_config: AppConfig, endpoint_config: EndpointConfi
                 processing_graph=processing_graph,
                 cached_assets_base_url=app_config.cached_assets.base_url,
                 cached_assets_directory=cached_assets_directory,
+                parquet_metadata_directory=parquet_metadata_directory,
                 hf_endpoint=app_config.common.hf_endpoint,
                 hf_token=app_config.common.hf_token,
                 hf_jwt_public_key=hf_jwt_public_key,

--- a/services/api/src/api/config.py
+++ b/services/api/src/api/config.py
@@ -10,6 +10,7 @@ from libcommon.config import (
     CachedAssetsConfig,
     CommonConfig,
     LogConfig,
+    ParquetMetadataConfig,
     ProcessingGraphConfig,
     QueueConfig,
 )
@@ -85,6 +86,7 @@ class AppConfig:
     log: LogConfig = field(default_factory=LogConfig)
     queue: QueueConfig = field(default_factory=QueueConfig)
     processing_graph: ProcessingGraphConfig = field(default_factory=ProcessingGraphConfig)
+    parquet_metadata: ParquetMetadataConfig = field(default_factory=ParquetMetadataConfig)
 
     @classmethod
     def from_env(cls) -> "AppConfig":
@@ -97,6 +99,7 @@ class AppConfig:
             processing_graph=ProcessingGraphConfig.from_env(),
             queue=QueueConfig.from_env(),
             api=ApiConfig.from_env(common_config=common_config),
+            parquet_metadata=ParquetMetadataConfig.from_env(),
         )
 
 

--- a/services/api/src/api/routes/rows.py
+++ b/services/api/src/api/routes/rows.py
@@ -260,9 +260,9 @@ class ParquetIndexWithMetadata:
             parquet_offset = (
                 offset - parquet_file_offsets[first_parquet_file_id - 1] if first_parquet_file_id > 0 else offset
             )
-            urls = self.parquet_files_urls[first_parquet_file_id : last_parquet_file_id + 1]
-            metadata_paths = self.metadata_paths[first_parquet_file_id : last_parquet_file_id + 1]
-            num_bytes = self.num_bytes[first_parquet_file_id : last_parquet_file_id + 1]
+            urls = self.parquet_files_urls[first_parquet_file_id:last_parquet_file_id + 1]
+            metadata_paths = self.metadata_paths[first_parquet_file_id:last_parquet_file_id + 1]
+            num_bytes = self.num_bytes[first_parquet_file_id:last_parquet_file_id + 1]
 
         with StepProfiler(
             method="rows.query.with_metadata", step="load the remote parquet files using metadata from disk"

--- a/services/api/src/api/routes/rows.py
+++ b/services/api/src/api/routes/rows.py
@@ -260,9 +260,9 @@ class ParquetIndexWithMetadata:
             parquet_offset = (
                 offset - parquet_file_offsets[first_parquet_file_id - 1] if first_parquet_file_id > 0 else offset
             )
-            urls = self.parquet_files_urls[first_parquet_file_id:last_parquet_file_id + 1]
-            metadata_paths = self.metadata_paths[first_parquet_file_id:last_parquet_file_id + 1]
-            num_bytes = self.num_bytes[first_parquet_file_id:last_parquet_file_id + 1]
+            urls = self.parquet_files_urls[first_parquet_file_id : last_parquet_file_id + 1]  # noqa: E203
+            metadata_paths = self.metadata_paths[first_parquet_file_id : last_parquet_file_id + 1]  # noqa: E203
+            num_bytes = self.num_bytes[first_parquet_file_id : last_parquet_file_id + 1]  # noqa: E203
 
         with StepProfiler(
             method="rows.query.with_metadata", step="load the remote parquet files using metadata from disk"

--- a/services/api/src/api/routes/rows.py
+++ b/services/api/src/api/routes/rows.py
@@ -120,7 +120,7 @@ def get_hf_parquet_uris(paths: List[str], dataset: str) -> List[str]:
     return [f"hf://datasets/{dataset}@{safe_quote(PARQUET_REVISION)}/{path}" for path in paths]
 
 
-UNSUPPORTED_FEATURES_MAGIC_STRINGS = ["Image(", "Audio(", "'binary'"]
+UNSUPPORTED_FEATURES_MAGIC_STRINGS = ["'binary'"]
 
 
 def get_supported_unsupported_columns(features: Features) -> Tuple[List[str], List[str]]:

--- a/services/api/src/api/routes/rows.py
+++ b/services/api/src/api/routes/rows.py
@@ -1,19 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
 
+import asyncio
 import logging
 import os
 import random
 import shutil
+from dataclasses import dataclass
 from functools import lru_cache, partial
 from itertools import islice
 from os import PathLike
-from typing import Any, Callable, List, Mapping, Optional, TypedDict, Union
+from typing import Any, Callable, List, Mapping, Optional, Tuple, TypedDict, Union
 
 import numpy as np
+import numpy.typing as npt
 import pyarrow as pa
 import pyarrow.parquet as pq
 from datasets import Features
+from fsspec.implementations.http import HTTPFile, HTTPFileSystem
 from huggingface_hub import HfFileSystem
 from huggingface_hub.hf_file_system import safe_quote
 from libcommon.processing_graph import ProcessingGraph
@@ -42,6 +46,11 @@ from api.utils import (
 
 logger = logging.getLogger(__name__)
 
+
+httpfs = HTTPFileSystem()
+session = asyncio.run(httpfs.set_session())
+
+
 MAX_ROWS = 100
 
 PARQUET_REVISION = "refs/convert/parquet"
@@ -64,6 +73,26 @@ class ParquetResponseEmptyError(Exception):
 
 class ParquetDataProcessingError(Exception):
     pass
+
+
+class ParquetFileItem(TypedDict):
+    dataset: str
+    config: str
+    split: str
+    url: str
+    filename: str
+    size: int
+
+
+class ParquetFileMetadataItem(TypedDict):
+    dataset: str
+    config: str
+    split: str
+    url: str
+    filename: str
+    size: int
+    num_rows: int
+    parquet_metadata_subpath: str
 
 
 # TODO: how to invalidate the cache when the parquet branch is created or deleted?
@@ -94,109 +123,26 @@ def get_hf_parquet_uris(paths: List[str], dataset: str) -> List[str]:
 UNSUPPORTED_FEATURES_MAGIC_STRINGS = ["Image(", "Audio(", "'binary'"]
 
 
-class RowsIndex:
-    def __init__(
-        self,
-        dataset: str,
-        config: str,
-        split: str,
-        processing_graph: ProcessingGraph,
-        hf_endpoint: str,
-        hf_token: Optional[str],
-    ):
-        self.dataset = dataset
-        self.revision: Optional[str] = None
-        self.config = config
-        self.split = split
-        self.processing_graph = processing_graph
-        self.__post_init__(
-            hf_endpoint=hf_endpoint,
-            hf_token=hf_token,
-        )
+def get_supported_unsupported_columns(features: Features) -> Tuple[List[str], List[str]]:
+    supported_columns, unsupported_columns = [], []
+    for column, feature in features.items():
+        str_feature = str(feature)
+        str_column = str(column)
+        if any(magic_string in str_feature for magic_string in UNSUPPORTED_FEATURES_MAGIC_STRINGS):
+            unsupported_columns.append(str_column)
+        else:
+            supported_columns.append(str_column)
+    return supported_columns, unsupported_columns
 
-    def __post_init__(
-        self,
-        hf_endpoint: str,
-        hf_token: Optional[str],
-    ) -> None:
-        with StepProfiler(method="rows.index", step="all"):
-            # get the list of parquet files
-            with StepProfiler(method="rows.index", step="get list of parquet files for split"):
-                config_parquet_processing_steps = self.processing_graph.get_config_parquet_processing_steps()
-                if not config_parquet_processing_steps:
-                    raise RuntimeError("No processing steps are configured to provide a config's parquet response.")
-                try:
-                    result = get_cache_entry_from_steps(
-                        processing_steps=config_parquet_processing_steps,
-                        dataset=self.dataset,
-                        config=self.config,
-                        split=None,
-                        processing_graph=self.processing_graph,
-                        hf_endpoint=hf_endpoint,
-                        hf_token=hf_token,
-                    )
-                    self.revision = result["dataset_git_revision"]
-                    content = result["content"]
-                except ApiCustomError as e:
-                    raise e
-                except Exception as e:
-                    raise UnexpectedError("Could not get the list of parquet files to fetch the rows from.") from e
-                    # ^ TODO: improve the error, depending on the case
-                try:
-                    sources = sorted(
-                        f"{self.config}/{parquet_file['filename']}"
-                        for parquet_file in content["parquet_files"]
-                        if parquet_file["split"] == self.split and parquet_file["config"] == self.config
-                    )
-                except Exception as e:
-                    raise ParquetResponseFormatError(f"Could not parse the list of parquet files: {e}") from e
-                logging.debug(
-                    f"Found {len(sources)} parquet files for dataset={self.dataset}, config={self.config},"
-                    f" split={self.split}: {sources}"
-                )
-                if not sources:
-                    raise ParquetResponseEmptyError("No parquet files found.")
-            with StepProfiler(method="rows.index", step="get the Hub's dataset filesystem"):
-                fs = get_hf_fs(hf_token=hf_token)
-            with StepProfiler(method="rows.index", step="get the source URIs"):
-                source_uris = get_hf_parquet_uris(sources, dataset=self.dataset)
-            with StepProfiler(method="rows.index", step="get one parquet reader per parquet file"):
-                desc = f"{self.dataset}/{self.config}/{self.split}"
-                try:
-                    parquet_files: List[pq.ParquetFile] = thread_map(
-                        partial(pq.ParquetFile, filesystem=fs), source_uris, desc=desc, unit="pq", disable=True
-                    )
-                except Exception as e:
-                    raise FileSystemError(f"Could not read the parquet files: {e}") from e
-            with StepProfiler(method="rows.index", step="get the dataset's features"):
-                self.features = Features.from_arrow_schema(parquet_files[0].schema.to_arrow_schema())
 
-            self.supported_columns, self.unsupported_columns = [], []
-            for column, feature in self.features.items():
-                str_feature = str(feature)
-                str_column = str(column)
-                if any(magic_string in str_feature for magic_string in UNSUPPORTED_FEATURES_MAGIC_STRINGS):
-                    self.unsupported_columns.append(str_column)
-                else:
-                    self.supported_columns.append(str_column)
+@dataclass
+class ParquetIndexWithoutMetadata:
+    features: Features
+    supported_columns: List[str]
+    unsupported_columns: List[str]
+    row_group_offsets: npt.NDArray[np.int64]
+    row_group_readers: List[Callable[[], pa.Table]]
 
-            with StepProfiler(method="rows.index", step="create the row group offsets"):
-                self.row_group_offsets = np.cumsum(
-                    [
-                        parquet_file.metadata.row_group(group_id).num_rows
-                        for parquet_file in parquet_files
-                        for group_id in range(parquet_file.metadata.num_row_groups)
-                    ]
-                )
-            with StepProfiler(method="rows.index", step="create the row group readers"):
-                self.row_group_readers: List[Callable[[], pa.Table]] = [
-                    partial(parquet_file.read_row_group, i=group_id, columns=self.supported_columns)
-                    for parquet_file in parquet_files
-                    for group_id in range(parquet_file.metadata.num_row_groups)
-                ]
-
-    # note that this cache size is global for the class, not per instance
-    @lru_cache(maxsize=1024)
     def query(self, offset: int, length: int) -> pa.Table:
         """Query the parquet files
 
@@ -224,15 +170,287 @@ class RowsIndex:
         first_row_in_pa_table = self.row_group_offsets[first_row_group_id - 1] if first_row_group_id > 0 else 0
         return pa_table.slice(offset - first_row_in_pa_table, length)
 
+    @staticmethod
+    def from_parquet_file_items(
+        parquet_file_items: List[ParquetFileItem], dataset: str, config: str, split: str, hf_token: Optional[str]
+    ) -> "ParquetIndexWithoutMetadata":
+        try:
+            sources = sorted(f"{config}/{parquet_file['filename']}" for parquet_file in parquet_file_items)
+        except Exception as e:
+            raise ParquetResponseFormatError(f"Could not parse the list of parquet files: {e}") from e
+        logging.debug(
+            f"Found {len(sources)} parquet files for dataset={dataset}, config={config}, split={split}: {sources}"
+        )
+        if not sources:
+            raise ParquetResponseEmptyError("No parquet files found.")
+        with StepProfiler(method="rows.index.without_metadata", step="get the Hub's dataset filesystem"):
+            fs = get_hf_fs(hf_token=hf_token)
+        with StepProfiler(method="rows.index.without_metadata", step="get the source URIs"):
+            source_uris = get_hf_parquet_uris(sources, dataset=dataset)
+        with StepProfiler(method="rows.index.without_metadata", step="get one parquet reader per parquet file"):
+            desc = f"{dataset}/{config}/{split}"
+            try:
+                parquet_files: List[pq.ParquetFile] = thread_map(
+                    partial(pq.ParquetFile, filesystem=fs), source_uris, desc=desc, unit="pq", disable=True
+                )
+            except Exception as e:
+                raise FileSystemError(f"Could not read the parquet files: {e}") from e
+        with StepProfiler(method="rows.index.without_metadata", step="get the dataset's features"):
+            features = Features.from_arrow_schema(parquet_files[0].schema.to_arrow_schema())
+            supported_columns, unsupported_columns = get_supported_unsupported_columns(features)
+
+        with StepProfiler(method="rows.index.without_metadata", step="create the row group offsets"):
+            row_group_offsets = np.cumsum(
+                [
+                    parquet_file.metadata.row_group(group_id).num_rows
+                    for parquet_file in parquet_files
+                    for group_id in range(parquet_file.metadata.num_row_groups)
+                ]
+            )
+        with StepProfiler(method="rows.index.without_metadata", step="create the row group readers"):
+            row_group_readers: List[Callable[[], pa.Table]] = [
+                partial(parquet_file.read_row_group, i=group_id, columns=supported_columns)
+                for parquet_file in parquet_files
+                for group_id in range(parquet_file.metadata.num_row_groups)
+            ]
+        return ParquetIndexWithoutMetadata(
+            features=features,
+            supported_columns=supported_columns,
+            unsupported_columns=unsupported_columns,
+            row_group_offsets=row_group_offsets,
+            row_group_readers=row_group_readers,
+        )
+
+
+@dataclass
+class ParquetIndexWithMetadata:
+    features: Features
+    supported_columns: List[str]
+    unsupported_columns: List[str]
+    parquet_files_urls: List[str]
+    metadata_paths: List[str]
+    num_bytes: List[int]
+    num_rows: List[int]
+    hf_token: Optional[str]
+
+    def query(self, offset: int, length: int) -> pa.Table:
+        """Query the parquet files
+
+        Note that this implementation will always read at least one row group, to get the list of columns and always
+        have the same schema, even if the requested rows are invalid (out of range).
+
+        Args:
+            offset (int): The first row to read.
+            length (int): The number of rows to read.
+
+        Returns:
+            pa.Table: The requested rows.
+        """
+        with StepProfiler(
+            method="rows.query.with_metadata", step="get the parquet files than contain the requested rows"
+        ):
+            parquet_file_offsets = np.cumsum(self.num_rows)
+
+            last_row_in_parquet = parquet_file_offsets[-1] - 1
+            first_row = min(offset, last_row_in_parquet)
+            last_row = min(offset + length - 1, last_row_in_parquet)
+            first_parquet_file_id, last_parquet_file_id = np.searchsorted(
+                parquet_file_offsets, [first_row, last_row], side="right"
+            )
+            parquet_offset = (
+                offset - parquet_file_offsets[first_parquet_file_id - 1] if first_parquet_file_id > 0 else offset
+            )
+            urls = self.parquet_files_urls[first_parquet_file_id : last_parquet_file_id + 1]
+            metadata_paths = self.metadata_paths[first_parquet_file_id : last_parquet_file_id + 1]
+            num_bytes = self.num_bytes[first_parquet_file_id : last_parquet_file_id + 1]
+
+        with StepProfiler(
+            method="rows.query.with_metadata", step="load the remote parquet files using metadata from disk"
+        ):
+            parquet_files = [
+                pq.ParquetFile(
+                    HTTPFile(httpfs, url, session=session, size=size, loop=httpfs.loop, cache_type=None),
+                    metadata=pq.read_metadata(metadata_path),
+                    pre_buffer=True,
+                )
+                for url, metadata_path, size in zip(urls, metadata_paths, num_bytes)
+            ]
+
+        with StepProfiler(
+            method="rows.query.with_metadata", step="get the row groups than contain the requested rows"
+        ):
+            row_group_offsets = np.cumsum(
+                [
+                    parquet_file.metadata.row_group(group_id).num_rows
+                    for parquet_file in parquet_files
+                    for group_id in range(parquet_file.metadata.num_row_groups)
+                ]
+            )
+            row_group_readers: List[Callable[[], pa.Table]] = [
+                partial(parquet_file.read_row_group, i=group_id, columns=self.supported_columns)
+                for parquet_file in parquet_files
+                for group_id in range(parquet_file.metadata.num_row_groups)
+            ]
+
+            last_row_in_parquet = row_group_offsets[-1] - 1
+            first_row = min(parquet_offset, last_row_in_parquet)
+            last_row = min(parquet_offset + length - 1, last_row_in_parquet)
+
+            first_row_group_id, last_row_group_id = np.searchsorted(
+                row_group_offsets, [first_row, last_row], side="right"
+            )
+
+        with StepProfiler(method="rows.query.with_metadata", step="read the row groups"):
+            pa_table = pa.concat_tables(
+                [row_group_readers[i]() for i in range(first_row_group_id, last_row_group_id + 1)]
+            )
+            first_row_in_pa_table = row_group_offsets[first_row_group_id - 1] if first_row_group_id > 0 else 0
+            return pa_table.slice(parquet_offset - first_row_in_pa_table, length)
+
+    @staticmethod
+    def from_parquet_metadata_items(
+        parquet_file_metadata_items: List[ParquetFileMetadataItem],
+        parquet_metadata_directory: StrPath,
+        hf_token: Optional[str],
+    ) -> "ParquetIndexWithMetadata":
+        if not parquet_file_metadata_items:
+            raise ParquetResponseEmptyError("No parquet files found.")
+
+        with StepProfiler(method="rows.index", step="get the index from parquet metadata"):
+            try:
+                parquet_files_metadata = sorted(
+                    parquet_file_metadata_items, key=lambda parquet_file_metadata: parquet_file_metadata["filename"]
+                )
+                parquet_files_urls = [parquet_file_metadata["url"] for parquet_file_metadata in parquet_files_metadata]
+                metadata_paths = [
+                    os.path.join(parquet_metadata_directory, parquet_file_metadata["parquet_metadata_subpath"])
+                    for parquet_file_metadata in parquet_files_metadata
+                ]
+                num_bytes = [parquet_file_metadata["size"] for parquet_file_metadata in parquet_files_metadata]
+                num_rows = [parquet_file_metadata["num_rows"] for parquet_file_metadata in parquet_files_metadata]
+            except Exception as e:
+                raise ParquetResponseFormatError(f"Could not parse the list of parquet files: {e}") from e
+
+        with StepProfiler(method="rows.index.with_metadata", step="get the dataset's features"):
+            features = Features.from_arrow_schema(pq.read_schema(metadata_paths[0]))
+            supported_columns, unsupported_columns = get_supported_unsupported_columns(features)
+        return ParquetIndexWithMetadata(
+            features=features,
+            supported_columns=supported_columns,
+            unsupported_columns=unsupported_columns,
+            parquet_files_urls=parquet_files_urls,
+            metadata_paths=metadata_paths,
+            num_bytes=num_bytes,
+            num_rows=num_rows,
+            hf_token=hf_token,
+        )
+
+
+class RowsIndex:
+    def __init__(
+        self,
+        dataset: str,
+        config: str,
+        split: str,
+        processing_graph: ProcessingGraph,
+        hf_endpoint: str,
+        hf_token: Optional[str],
+        parquet_metadata_directory: StrPath,
+    ):
+        self.dataset = dataset
+        self.revision: Optional[str] = None
+        self.config = config
+        self.split = split
+        self.processing_graph = processing_graph
+        self.parquet_index = self._init_parquet_index(
+            hf_endpoint=hf_endpoint,
+            hf_token=hf_token,
+            parquet_metadata_directory=parquet_metadata_directory,
+        )
+
+    def _init_parquet_index(
+        self,
+        hf_endpoint: str,
+        hf_token: Optional[str],
+        parquet_metadata_directory: StrPath,
+    ) -> Union[ParquetIndexWithMetadata, ParquetIndexWithoutMetadata]:
+        with StepProfiler(method="rows.index", step="all"):
+            # get the list of parquet files
+            with StepProfiler(method="rows.index", step="get list of parquet files for split"):
+                config_parquet_processing_steps = self.processing_graph.get_config_parquet_processing_steps()
+                config_parquet_metadata_processing_steps = (
+                    self.processing_graph.get_config_parquet_metadata_processing_steps()
+                )
+                if not config_parquet_processing_steps:
+                    raise RuntimeError("No processing steps are configured to provide a config's parquet response.")
+                try:
+                    result = get_cache_entry_from_steps(
+                        processing_steps=config_parquet_metadata_processing_steps + config_parquet_processing_steps,
+                        dataset=self.dataset,
+                        config=self.config,
+                        split=None,
+                        processing_graph=self.processing_graph,
+                        hf_endpoint=hf_endpoint,
+                        hf_token=hf_token,
+                    )
+                    self.revision = result["dataset_git_revision"]
+                    content = result["content"]
+                except ApiCustomError as e:
+                    raise e
+                except Exception as e:
+                    raise UnexpectedError("Could not get the list of parquet files to fetch the rows from.") from e
+                    # ^ TODO: improve the error, depending on the case
+            if content and "parquet_files" in content:
+                return ParquetIndexWithoutMetadata.from_parquet_file_items(
+                    [
+                        parquet_item
+                        for parquet_item in content["parquet_files"]
+                        if parquet_item["split"] == self.split and parquet_item["config"] == self.config
+                    ],
+                    dataset=self.dataset,
+                    config=self.config,
+                    split=self.split,
+                    hf_token=hf_token,
+                )
+            else:
+                return ParquetIndexWithMetadata.from_parquet_metadata_items(
+                    [
+                        parquet_item
+                        for parquet_item in content["parquet_files_metadata"]
+                        if parquet_item["split"] == self.split and parquet_item["config"] == self.config
+                    ],
+                    parquet_metadata_directory=parquet_metadata_directory,
+                    hf_token=hf_token,
+                )
+
+    # note that this cache size is global for the class, not per instance
+    @lru_cache(maxsize=1024)
+    def query(self, offset: int, length: int) -> pa.Table:
+        """Query the parquet files
+
+        Note that this implementation will always read at least one row group, to get the list of columns and always
+        have the same schema, even if the requested rows are invalid (out of range).
+
+        Args:
+            offset (int): The first row to read.
+            length (int): The number of rows to read.
+
+        Returns:
+            pa.Table: The requested rows.
+        """
+        return self.parquet_index.query(offset=offset, length=length)
+
 
 class Indexer:
     def __init__(
         self,
         processing_graph: ProcessingGraph,
+        parquet_metadata_directory: StrPath,
         hf_endpoint: str,
         hf_token: Optional[str] = None,
     ):
         self.processing_graph = processing_graph
+        self.parquet_metadata_directory = parquet_metadata_directory
         self.hf_endpoint = hf_endpoint
         self.hf_token = hf_token
 
@@ -250,6 +468,7 @@ class Indexer:
             processing_graph=self.processing_graph,
             hf_endpoint=self.hf_endpoint,
             hf_token=self.hf_token,
+            parquet_metadata_directory=self.parquet_metadata_directory,
         )
 
 
@@ -455,6 +674,7 @@ def create_rows_endpoint(
     processing_graph: ProcessingGraph,
     cached_assets_base_url: str,
     cached_assets_directory: StrPath,
+    parquet_metadata_directory: StrPath,
     hf_endpoint: str,
     hf_token: Optional[str] = None,
     hf_jwt_public_key: Optional[str] = None,
@@ -472,6 +692,7 @@ def create_rows_endpoint(
         processing_graph=processing_graph,
         hf_endpoint=hf_endpoint,
         hf_token=hf_token,
+        parquet_metadata_directory=parquet_metadata_directory,
     )
 
     async def rows_endpoint(request: Request) -> Response:
@@ -539,8 +760,8 @@ def create_rows_endpoint(
                         cached_assets_directory=cached_assets_directory,
                         pa_table=pa_table,
                         offset=offset,
-                        features=rows_index.features,
-                        unsupported_columns=rows_index.unsupported_columns,
+                        features=rows_index.parquet_index.features,
+                        unsupported_columns=rows_index.parquet_index.unsupported_columns,
                     )
                 with StepProfiler(method="rows_endpoint", step="update last modified time of rows in asset dir"):
                     update_last_modified_date_of_rows_in_assets_dir(

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -8,7 +8,7 @@ from libcommon.processing_graph import ProcessingGraph
 from libcommon.queue import _clean_queue_database
 from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.simple_cache import _clean_cache_database
-from libcommon.storage import StrPath, init_cached_assets_dir
+from libcommon.storage import StrPath, init_cached_assets_dir, init_parquet_metadata_dir
 from pytest import MonkeyPatch, fixture
 
 from api.config import AppConfig, EndpointConfig, UvicornConfig
@@ -133,6 +133,11 @@ def hf_auth_path(app_config: AppConfig) -> str:
 @fixture
 def cached_assets_directory(app_config: AppConfig) -> StrPath:
     return init_cached_assets_dir(app_config.cached_assets.storage_directory)
+
+
+@fixture
+def parquet_metadata_directory(app_config: AppConfig) -> StrPath:
+    return init_parquet_metadata_dir(app_config.parquet_metadata.storage_directory)
 
 
 @fixture

--- a/services/api/tests/fixtures/fsspec.py
+++ b/services/api/tests/fixtures/fsspec.py
@@ -1,5 +1,6 @@
 # type: ignore
 import posixpath
+import shutil
 from pathlib import Path
 from unittest.mock import patch
 
@@ -115,3 +116,4 @@ def tmpfs(tmp_path_factory, mock_fsspec):
     tmp_fs_dir = tmp_path_factory.mktemp("tmpfs")
     with patch.object(TmpDirFileSystem, "tmp_dir", tmp_fs_dir):
         yield TmpDirFileSystem()
+    shutil.rmtree(tmp_fs_dir)

--- a/services/api/tests/routes/test_rows.py
+++ b/services/api/tests/routes/test_rows.py
@@ -141,11 +141,12 @@ def dataset_image_with_config_parquet() -> dict[str, Any]:
 
 
 @pytest.fixture
-def indexer(app_config: AppConfig, processing_graph: ProcessingGraph) -> Indexer:
+def indexer(app_config: AppConfig, processing_graph: ProcessingGraph, parquet_metadata_directory: StrPath) -> Indexer:
     return Indexer(
         processing_graph=processing_graph,
         hf_endpoint=app_config.common.hf_endpoint,
         hf_token=app_config.common.hf_token,
+        parquet_metadata_directory=parquet_metadata_directory,
     )
 
 

--- a/services/api/tests/routes/test_rows.py
+++ b/services/api/tests/routes/test_rows.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import time
 from http import HTTPStatus
 from pathlib import Path
@@ -6,6 +7,7 @@ from typing import Any, Generator, List
 from unittest.mock import patch
 
 import numpy as np
+import pyarrow.parquet as pq
 import pytest
 from datasets import Dataset, Image, concatenate_datasets
 from datasets.table import embed_table_storage
@@ -18,6 +20,8 @@ from libcommon.viewer_utils.asset import update_last_modified_date_of_rows_in_as
 from api.config import AppConfig
 from api.routes.rows import (
     Indexer,
+    ParquetFileMetadataItem,
+    ParquetIndexWithMetadata,
     ParquetIndexWithoutMetadata,
     RowsIndex,
     clean_cached_assets,
@@ -70,6 +74,21 @@ def ds_image_fs(ds_image: Dataset, tmpfs: AbstractFileSystem) -> Generator[Abstr
 
 
 @pytest.fixture
+def ds_parquet_metadata_dir(
+    ds_fs: AbstractFileSystem, parquet_metadata_directory: StrPath
+) -> Generator[StrPath, None, None]:
+    parquet_shard_paths = ds_fs.glob("**.parquet")
+    for parquet_shard_path in parquet_shard_paths:
+        parquet_file_metadata_path = Path(parquet_metadata_directory) / "ds" / "--" / parquet_shard_path
+        parquet_file_metadata_path.parent.mkdir(parents=True, exist_ok=True)
+        with ds_fs.open(parquet_shard_path) as parquet_shard_f:
+            with open(parquet_file_metadata_path, "wb") as parquet_file_metadata_f:
+                pq.read_metadata(parquet_shard_f).write_metadata_file(parquet_file_metadata_f)
+    yield parquet_metadata_directory
+    shutil.rmtree(Path(parquet_metadata_directory) / "ds")
+
+
+@pytest.fixture
 def dataset_with_config_parquet() -> dict[str, Any]:
     config_parquet_content = {
         "parquet_files": [
@@ -92,6 +111,50 @@ def dataset_with_config_parquet() -> dict[str, Any]:
         progress=1.0,
     )
     return config_parquet_content
+
+
+@pytest.fixture
+def dataset_with_config_parquet_metadata(
+    ds_fs: AbstractFileSystem, ds_parquet_metadata_dir: StrPath
+) -> dict[str, Any]:
+    config_parquet_content = {
+        "parquet_files_metadata": [
+            {
+                "dataset": "ds",
+                "config": "plain_text",
+                "split": "train",
+                "url": "https://fake.huggingface.co/datasets/ds/resolve/refs%2Fconvert%2Fparquet/plain_text/ds-train.parquet",  # noqa: E501
+                "filename": "ds-train.parquet",
+                "size": ds_fs.info("plain_text/ds-train.parquet")["size"],
+                "num_rows": pq.read_metadata(ds_fs.open("plain_text/ds-train.parquet")).num_rows,
+                "parquet_metadata_subpath": f"ds/--/plain_text/ds-train.parquet",
+            }
+        ]
+    }
+    upsert_response(
+        kind="config-parquet-metadata",
+        dataset="ds",
+        config="plain_text",
+        content=config_parquet_content,
+        http_status=HTTPStatus.OK,
+        progress=1.0,
+    )
+    return config_parquet_content
+
+
+@pytest.fixture
+def ds_sharded_parquet_metadata_dir(
+    ds_sharded_fs: AbstractFileSystem, parquet_metadata_directory: StrPath
+) -> Generator[StrPath, None, None]:
+    parquet_shard_paths = ds_sharded_fs.glob("**.parquet")
+    for parquet_shard_path in parquet_shard_paths:
+        parquet_file_metadata_path = Path(parquet_metadata_directory) / "ds_sharded" / "--" / parquet_shard_path
+        parquet_file_metadata_path.parent.mkdir(parents=True, exist_ok=True)
+        with ds_sharded_fs.open(parquet_shard_path) as parquet_shard_f:
+            with open(parquet_file_metadata_path, "wb") as parquet_file_metadata_f:
+                pq.read_metadata(parquet_shard_f).write_metadata_file(parquet_file_metadata_f)
+    yield parquet_metadata_directory
+    shutil.rmtree(Path(parquet_metadata_directory) / "ds_sharded")
 
 
 @pytest.fixture
@@ -119,6 +182,36 @@ def dataset_sharded_with_config_parquet() -> dict[str, Any]:
         progress=1.0,
     )
     return config_parquet_content
+
+
+@pytest.fixture
+def dataset_sharded_with_config_parquet_metadata(
+    ds_sharded_fs: AbstractFileSystem, ds_sharded_parquet_metadata_dir: StrPath
+) -> dict[str, Any]:
+    config_parquet_metadata_content = {
+        "parquet_files_metadata": [
+            {
+                "dataset": "ds_sharded",
+                "config": "plain_text",
+                "split": "train",
+                "url": f"https://fake.huggingface.co/datasets/ds/resolve/refs%2Fconvert%2Fparquet/{parquet_file_path}",  # noqa: E501
+                "filename": os.path.basename(parquet_file_path),
+                "size": ds_sharded_fs.info(parquet_file_path)["size"],
+                "num_rows": pq.read_metadata(ds_sharded_fs.open(parquet_file_path)).num_rows,
+                "parquet_metadata_subpath": f"ds_sharded/--/{parquet_file_path}",
+            }
+            for parquet_file_path in ds_sharded_fs.glob("plain_text/*.parquet")
+        ]
+    }
+    upsert_response(
+        kind="config-parquet-metadata",
+        dataset="ds_sharded",
+        config="plain_text",
+        content=config_parquet_metadata_content,
+        http_status=HTTPStatus.OK,
+        progress=1.0,
+    )
+    return config_parquet_metadata_content
 
 
 @pytest.fixture
@@ -214,6 +307,69 @@ def test_rows_index_query(rows_index: RowsIndex, ds_sharded: Dataset) -> None:
     assert rows_index.query(offset=1, length=99999999).to_pydict() == ds_sharded[1:]
     with pytest.raises(IndexError):
         rows_index.query(offset=-1, length=2)
+
+
+@pytest.fixture
+def rows_index_with_parquet_metadata(
+    indexer: Indexer,
+    ds_sharded: Dataset,
+    ds_sharded_fs: AbstractFileSystem,
+    dataset_sharded_with_config_parquet_metadata: dict[str, Any],
+) -> Generator[RowsIndex, None, None]:
+    with ds_sharded_fs.open("plain_text/ds_sharded-train-00000-of-00004.parquet") as f:
+        with patch("api.routes.rows.HTTPFile", return_value=f):
+            yield indexer.get_rows_index("ds_sharded", "plain_text", "train")
+
+
+def test_indexer_get_rows_index_with_parquet_metadata(
+    indexer: Indexer, ds: Dataset, ds_fs: AbstractFileSystem, dataset_with_config_parquet_metadata: dict[str, Any]
+) -> None:
+    with ds_fs.open("plain_text/ds-train.parquet") as f:
+        with patch("api.routes.rows.HTTPFile", return_value=f):
+            index = indexer.get_rows_index("ds", "plain_text", "train")
+    assert isinstance(index.parquet_index, ParquetIndexWithMetadata)
+    assert index.parquet_index.features == ds.features
+    assert index.parquet_index.num_rows == [len(ds)]
+    assert index.parquet_index.parquet_files_urls == [
+        parquet_file_metadata_item["url"]
+        for parquet_file_metadata_item in dataset_with_config_parquet_metadata["parquet_files_metadata"]
+    ]
+    assert len(index.parquet_index.metadata_paths) == 1
+    assert os.path.exists(index.parquet_index.metadata_paths[0])
+
+
+def test_indexer_get_rows_index_sharded_with_parquet_metadata(
+    indexer: Indexer,
+    ds: Dataset,
+    ds_sharded: Dataset,
+    ds_sharded_fs: AbstractFileSystem,
+    dataset_sharded_with_config_parquet_metadata: dict[str, Any],
+) -> None:
+    with ds_sharded_fs.open("plain_text/ds_sharded-train-00000-of-00004.parquet") as f:
+        with patch("api.routes.rows.HTTPFile", return_value=f):
+            index = indexer.get_rows_index("ds_sharded", "plain_text", "train")
+    assert isinstance(index.parquet_index, ParquetIndexWithMetadata)
+    assert index.parquet_index.features == ds_sharded.features
+    assert index.parquet_index.num_rows == [len(ds)] * 4
+    assert index.parquet_index.parquet_files_urls == [
+        parquet_file_metadata_item["url"]
+        for parquet_file_metadata_item in dataset_sharded_with_config_parquet_metadata["parquet_files_metadata"]
+    ]
+    assert len(index.parquet_index.metadata_paths) == 4
+    assert all(os.path.exists(index.parquet_index.metadata_paths[i]) for i in range(4))
+
+
+def test_rows_index_query_with_parquet_metadata(
+    rows_index_with_parquet_metadata: RowsIndex, ds_sharded: Dataset
+) -> None:
+    assert isinstance(rows_index_with_parquet_metadata.parquet_index, ParquetIndexWithMetadata)
+    assert rows_index_with_parquet_metadata.query(offset=1, length=3).to_pydict() == ds_sharded[1:4]
+    assert rows_index_with_parquet_metadata.query(offset=1, length=-1).to_pydict() == ds_sharded[:0]
+    assert rows_index_with_parquet_metadata.query(offset=1, length=0).to_pydict() == ds_sharded[:0]
+    assert rows_index_with_parquet_metadata.query(offset=999999, length=1).to_pydict() == ds_sharded[:0]
+    assert rows_index_with_parquet_metadata.query(offset=1, length=99999999).to_pydict() == ds_sharded[1:]
+    with pytest.raises(IndexError):
+        rows_index_with_parquet_metadata.query(offset=-1, length=2)
 
 
 def test_create_response(ds: Dataset, app_config: AppConfig, cached_assets_directory: StrPath) -> None:

--- a/services/api/tests/routes/test_rows.py
+++ b/services/api/tests/routes/test_rows.py
@@ -33,6 +33,12 @@ def clean_mongo_databases(app_config: AppConfig) -> None:
     _clean_cache_database()
 
 
+@pytest.fixture(autouse=True)
+def enable_parquet_metadata_on_all_datasets() -> Generator[None, None, None]:
+    with patch("api.routes.rows.PARQUET_METADATA_DATASETS_ALLOW_LIST", "all"):
+        yield
+
+
 @pytest.fixture
 def ds() -> Dataset:
     return Dataset.from_dict({"text": ["Hello there", "General Kenobi"]})

--- a/services/api/tests/routes/test_rows.py
+++ b/services/api/tests/routes/test_rows.py
@@ -20,7 +20,6 @@ from libcommon.viewer_utils.asset import update_last_modified_date_of_rows_in_as
 from api.config import AppConfig
 from api.routes.rows import (
     Indexer,
-    ParquetFileMetadataItem,
     ParquetIndexWithMetadata,
     ParquetIndexWithoutMetadata,
     RowsIndex,
@@ -127,7 +126,7 @@ def dataset_with_config_parquet_metadata(
                 "filename": "ds-train.parquet",
                 "size": ds_fs.info("plain_text/ds-train.parquet")["size"],
                 "num_rows": pq.read_metadata(ds_fs.open("plain_text/ds-train.parquet")).num_rows,
-                "parquet_metadata_subpath": f"ds/--/plain_text/ds-train.parquet",
+                "parquet_metadata_subpath": "ds/--/plain_text/ds-train.parquet",
             }
         ]
     }

--- a/services/worker/tests/conftest.py
+++ b/services/worker/tests/conftest.py
@@ -8,7 +8,7 @@ from libcommon.processing_graph import ProcessingGraph, ProcessingStep
 from libcommon.queue import _clean_queue_database
 from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.simple_cache import _clean_cache_database
-from libcommon.storage import StrPath, init_assets_dir
+from libcommon.storage import StrPath, init_assets_dir, init_parquet_metadata_dir
 from pytest import MonkeyPatch, fixture
 
 from worker.config import AppConfig
@@ -111,7 +111,7 @@ def assets_directory(app_config: AppConfig) -> StrPath:
 
 @fixture
 def parquet_metadata_directory(app_config: AppConfig) -> StrPath:
-    return init_assets_dir(app_config.parquet_metadata.storage_directory)
+    return init_parquet_metadata_dir(app_config.parquet_metadata.storage_directory)
 
 
 @fixture

--- a/tools/docker-compose-datasets-server.yml
+++ b/tools/docker-compose-datasets-server.yml
@@ -55,6 +55,7 @@ services:
       service: common
     volumes:
       - cached-assets:${CACHED_ASSETS_STORAGE_DIRECTORY-/cached-assets}
+      - parquet-metadata:${PARQUET_METADATA_STORAGE_DIRECTORY-/parquet_metadata}
     environment:
       CACHED_ASSETS_BASE_URL: "http://localhost:${PORT_REVERSE_PROXY-8000}/cached-assets" # hard-coded to work with the reverse-proxy
       CACHED_ASSETS_STORAGE_DIRECTORY: ${CACHED_ASSETS_STORAGE_DIRECTORY-/cached-assets}
@@ -62,6 +63,7 @@ services:
       CACHED_ASSETS_KEEP_FIRST_ROWS_NUMBER: ${CACHED_ASSETS_KEEP_FIRST_ROWS_NUMBER-100}
       CACHED_ASSETS_KEEP_MOST_RECENT_ROWS_NUMBER: ${CACHED_ASSETS_KEEP_MOST_RECENT_ROWS_NUMBER-200}
       CACHED_ASSETS_MAX_CLEANED_ROWS_NUMBER: ${CACHED_ASSETS_MAX_CLEANED_ROWS_NUMBER-10000}
+      PARQUET_METADATA_STORAGE_DIRECTORY: ${PARQUET_METADATA_STORAGE_DIRECTORY-/parquet_metadata}
       # service
       API_HF_AUTH_PATH: ${API_HF_AUTH_PATH-/api/datasets/%s/auth-check}
       API_HF_JWT_PUBLIC_KEY_URL: ${API_HF_JWT_PUBLIC_KEY_URL-https://huggingface.co/api/keys/jwt}
@@ -87,6 +89,7 @@ services:
       dockerfile: services/worker/Dockerfile
     volumes:
       - assets:${ASSETS_STORAGE_DIRECTORY-/assets}:rw
+      - parquet-metadata:${PARQUET_METADATA_STORAGE_DIRECTORY-/parquet_metadata}:rw
     extends:
       file: docker-compose-base.yml
       service: datasets-worker
@@ -139,3 +142,4 @@ volumes:
   parquet-datasets-cache:
   parquet-modules-cache:
   parquet-numba-cache:
+  parquet-metadata:

--- a/tools/docker-compose-dev-datasets-server.yml
+++ b/tools/docker-compose-dev-datasets-server.yml
@@ -57,6 +57,7 @@ services:
       service: api
     volumes:
       - cached-assets:${CACHED_ASSETS_STORAGE_DIRECTORY-/cached-assets}
+      - parquet-metadata:${PARQUET_METADATA_STORAGE_DIRECTORY-/parquet_metadata}
     environment:
       CACHED_ASSETS_BASE_URL: "http://localhost:${PORT_REVERSE_PROXY-8000}/cached-assets" # hard-coded to work with the reverse-proxy
       CACHED_ASSETS_STORAGE_DIRECTORY: ${CACHED_ASSETS_STORAGE_DIRECTORY-/cached-assets}
@@ -64,6 +65,7 @@ services:
       CACHED_ASSETS_KEEP_FIRST_ROWS_NUMBER: ${CACHED_ASSETS_KEEP_FIRST_ROWS_NUMBER-100}
       CACHED_ASSETS_KEEP_MOST_RECENT_ROWS_NUMBER: ${CACHED_ASSETS_KEEP_MOST_RECENT_ROWS_NUMBER-200}
       CACHED_ASSETS_MAX_CLEANED_ROWS_NUMBER: ${CACHED_ASSETS_MAX_CLEANED_ROWS_NUMBER-10000}
+      PARQUET_METADATA_STORAGE_DIRECTORY: ${PARQUET_METADATA_STORAGE_DIRECTORY-/parquet_metadata}
       # service
       API_HF_AUTH_PATH: ${API_HF_AUTH_PATH-/api/datasets/%s/auth-check}
       API_HF_JWT_PUBLIC_KEY_URL: ${API_HF_JWT_PUBLIC_KEY_URL-https://hub-ci.huggingface.co/api/keys/jwt}
@@ -91,6 +93,7 @@ services:
       replicas: ${DEV_WORKER_REPLICAS-4}
     volumes:
       - assets:${ASSETS_STORAGE_DIRECTORY-/assets}:rw
+      - parquet-metadata:${PARQUET_METADATA_STORAGE_DIRECTORY-/parquet_metadata}:rw
     extends:
       file: docker-compose-dev-base.yml
       service: datasets-worker
@@ -141,3 +144,4 @@ volumes:
   parquet-datasets-cache:
   parquet-modules-cache:
   parquet-numba-cache:
+  parquet-metadata:


### PR DESCRIPTION
Step 2 of https://github.com/huggingface/datasets-server/issues/1186

## Implementation details

I implemented ParquetIndexWithMetadata (new) and ParquetIndexWithoutMetadata (from the existing code).:

- ParquetIndexWithMetadata is used when `config-parquet-metadata` is cached and is fast
- ParquetIndexWithoutMetadata is the old code, that runs when `config-parquet-metadata` is not available yet

I think in the long run we should remove ParquetIndexWithoutMetadata. I just kept it so that the UI doesn't show an error when `config-parquet-metadata` is not available.

I re-added support for image and audio for the ParquetIndexWithMetadata