### PR TITLE
feat: 🎸 delete metrics for /split-names-from-streaming

### DIFF
--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -209,4 +209,10 @@ class MigrationsCollector:
                     "to 'config-split-names-from-streaming'"
                 ),
             ),
+            MetricsDeletionMigration(
+                job_type="/split-names-from-streaming",
+                cache_kind="/split-names-from-streaming",
+                version="20230522094400",
+                description="delete the queue and cache metrics for step '/split-names-from-streaming'",
+            ),
         ]


### PR DESCRIPTION
we missed this migration, which leads to still having 5,000 pending jobs for this step in the Grafana charts, while these jobs don't exist now.