### PR TITLE
feat: 🎸 write cache + backfill only if job finished as expected

### DIFF
--- a/libs/libcommon/src/libcommon/state.py
+++ b/libs/libcommon/src/libcommon/state.py
@@ -362,8 +362,6 @@ class DeleteJobTask(Task):
         self.id = f"DeleteJob,{self.artifact_state.id}"
 
     def run(self) -> None:
-        # TODO: the started jobs are also canceled: we need to ensure the job runners will
-        # not try to update the cache when they finish
         Queue().cancel_jobs(
             job_type=self.artifact_state.processing_step.job_type,
             dataset=self.artifact_state.dataset,

--- a/services/worker/src/worker/job_manager.py
+++ b/services/worker/src/worker/job_manager.py
@@ -3,7 +3,7 @@
 
 import logging
 from http import HTTPStatus
-from typing import Optional
+from typing import Any, Mapping, Optional, TypedDict
 
 from libcommon.config import CommonConfig
 from libcommon.exceptions import (
@@ -16,6 +16,7 @@ from libcommon.exceptions import (
     UnexpectedError,
 )
 from libcommon.processing_graph import ProcessingGraph, ProcessingStep
+from libcommon.queue import Queue
 from libcommon.simple_cache import (
     CachedArtifactError,
     DoesNotExist,
@@ -30,6 +31,19 @@ from worker.job_runner import JobRunner
 
 # List of error codes that should trigger a retry.
 ERROR_CODES_TO_RETRY: list[str] = ["ClientConnectionError"]
+
+
+class JobOutput(TypedDict):
+    content: Mapping[str, Any]
+    http_status: HTTPStatus
+    error_code: Optional[str]
+    details: Optional[Mapping[str, Any]]
+    progress: Optional[float]
+
+
+class JobResult(TypedDict):
+    is_success: bool
+    output: Optional[JobOutput]
 
 
 class JobManager:
@@ -107,14 +121,32 @@ class JobManager:
     def critical(self, msg: str) -> None:
         self.log(level=logging.CRITICAL, msg=msg)
 
-    def run(self) -> bool:
+    def run_job(self) -> JobResult:
         try:
-            self.info(f"compute {self}")
-            result = self.process()
+            job_result: JobResult = self.process()
         except Exception:
-            self.exception(f"error while computing {self}")
-            result = False
-        return result
+            job_result = {
+                "is_success": False,
+                "output": None,
+            }
+        result_str = "SUCCESS" if job_result["is_success"] else "ERROR"
+        self.debug(f"job output with {result_str} - {self}")
+        return job_result
+
+    def finish(self, job_result: JobResult) -> None:
+        # check if the job is still in started status
+        # if not, it means that the job was cancelled, and we don't want to update the cache
+        job_was_valid = Queue().finish_job(
+            job_id=self.job_id,
+            is_success=job_result["is_success"],
+        )
+        if job_was_valid and job_result["output"]:
+            self.set_cache(job_result["output"])
+            logging.debug("the job output has been written to the cache.")
+            self.backfill()
+            logging.debug("the dataset has been backfilled.")
+        else:
+            logging.debug("the job output has not been written to the cache, and the dataset has not been backfilled.")
 
     def raise_if_parallel_response_exists(self, parallel_cache_kind: str, parallel_job_version: int) -> None:
         try:
@@ -138,7 +170,8 @@ class JobManager:
 
     def process(
         self,
-    ) -> bool:
+    ) -> JobResult:
+        self.info(f"compute {self}")
         try:
             try:
                 self.job_runner.pre_compute()
@@ -161,57 +194,53 @@ class JobManager:
             finally:
                 # ensure the post_compute hook is called even if the compute raises an exception
                 self.job_runner.post_compute()
-            upsert_response_params(
-                kind=self.processing_step.cache_kind,
-                job_params=self.job_params,
-                content=content,
-                http_status=HTTPStatus.OK,
-                job_runner_version=self.job_runner.get_job_runner_version(),
-                dataset_git_revision=self.job_params["revision"],
-                progress=job_result.progress,
-            )
             self.debug(
                 f"dataset={self.job_params['dataset']} revision={self.job_params['revision']} job_info={self.job_info}"
-                " is valid, cache updated"
+                " is valid"
             )
-            return True
+            return {
+                "is_success": True,
+                "output": {
+                    "content": content,
+                    "http_status": HTTPStatus.OK,
+                    "error_code": None,
+                    "details": None,
+                    "progress": job_result.progress,
+                },
+            }
         except DatasetNotFoundError:
             # To avoid filling the cache, we don't save this error. Otherwise, DoS is possible.
             self.debug(f"the dataset={self.job_params['dataset']} could not be found, don't update the cache")
-            return False
+            return {"is_success": False, "output": None}
         except CachedArtifactError as err:
             # A previous step (cached artifact required by the job runner) is an error. We copy the cached entry,
             # so that users can see the underlying error (they are not interested in the internals of the graph).
             # We add an entry to details: "copied_from_artifact", with its identification details, to have a chance
             # to debug if needed.
-            upsert_response_params(
-                kind=self.processing_step.cache_kind,
-                job_params=self.job_params,
-                job_runner_version=self.job_runner.get_job_runner_version(),
-                dataset_git_revision=self.job_params["revision"],
-                # TODO: should we manage differently arguments above ^ and below v?
-                content=err.cache_entry_with_details["content"],
-                http_status=err.cache_entry_with_details["http_status"],
-                error_code=err.cache_entry_with_details["error_code"],
-                details=err.enhanced_details,
-            )
-            self.debug(f"response for job_info={self.job_info} had an error from a previous step, cache updated")
-            return False
+            self.debug(f"response for job_info={self.job_info} had an error from a previous step")
+            return {
+                "is_success": False,
+                "output": {
+                    "content": err.cache_entry_with_details["content"],
+                    "http_status": err.cache_entry_with_details["http_status"],
+                    "error_code": err.cache_entry_with_details["error_code"],
+                    "details": err.enhanced_details,
+                    "progress": None,
+                },
+            }
         except Exception as err:
             e = err if isinstance(err, CustomError) else UnexpectedError(str(err), err)
-            upsert_response_params(
-                kind=self.processing_step.cache_kind,
-                job_params=self.job_params,
-                job_runner_version=self.job_runner.get_job_runner_version(),
-                dataset_git_revision=self.job_params["revision"],
-                # TODO: should we manage differently arguments above ^ and below v?
-                content=dict(e.as_response()),
-                http_status=e.status_code,
-                error_code=e.code,
-                details=dict(e.as_response_with_cause()),
-            )
-            self.debug(f"response for job_info={self.job_info} had an error, cache updated")
-            return False
+            self.debug(f"response for job_info={self.job_info} had an error")
+            return {
+                "is_success": False,
+                "output": {
+                    "content": dict(e.as_response()),
+                    "http_status": e.status_code,
+                    "error_code": e.code,
+                    "details": dict(e.as_response_with_cause()),
+                    "progress": None,
+                },
+            }
 
     def backfill(self) -> None:
         """Evaluate the state of the dataset and backfill the cache if necessary."""
@@ -223,38 +252,56 @@ class JobManager:
             priority=self.priority,
         ).backfill()
 
-    def set_crashed(self, message: str, cause: Optional[BaseException] = None) -> None:
-        error = JobManagerCrashedError(message=message, cause=cause)
+    def set_cache(self, output: JobOutput) -> None:
         upsert_response_params(
+            # inputs
             kind=self.processing_step.cache_kind,
             job_params=self.job_params,
-            content=dict(error.as_response()),
-            http_status=error.status_code,
-            error_code=error.code,
-            details=dict(error.as_response_with_cause()),
             job_runner_version=self.job_runner.get_job_runner_version(),
-            dataset_git_revision=self.job_params["revision"],
+            # output
+            content=output["content"],
+            http_status=output["http_status"],
+            error_code=output["error_code"],
+            details=output["details"],
+            progress=output["progress"],
         )
-        logging.debug(
+
+    def set_crashed(self, message: str, cause: Optional[BaseException] = None) -> None:
+        self.debug(
             "response for"
             f" dataset={self.job_params['dataset']} revision={self.job_params['revision']} job_info={self.job_info}"
-            " had an error (crashed), cache updated"
+            " had an error (crashed)"
+        )
+        error = JobManagerCrashedError(message=message, cause=cause)
+        self.finish(
+            job_result={
+                "is_success": False,
+                "output": {
+                    "content": dict(error.as_response()),
+                    "http_status": error.status_code,
+                    "error_code": error.code,
+                    "details": dict(error.as_response_with_cause()),
+                    "progress": None,
+                },
+            }
         )
 
     def set_exceeded_maximum_duration(self, message: str, cause: Optional[BaseException] = None) -> None:
-        error = JobManagerExceededMaximumDurationError(message=message, cause=cause)
-        upsert_response_params(
-            kind=self.processing_step.cache_kind,
-            job_params=self.job_params,
-            content=dict(error.as_response()),
-            http_status=error.status_code,
-            error_code=error.code,
-            details=dict(error.as_response_with_cause()),
-            job_runner_version=self.job_runner.get_job_runner_version(),
-            dataset_git_revision=self.job_params["revision"],
-        )
-        logging.debug(
+        self.debug(
             "response for"
             f" dataset={self.job_params['dataset']} revision={self.job_params['revision']} job_info={self.job_info}"
-            " had an error (exceeded maximum duration), cache updated"
+            " had an error (exceeded maximum duration)"
+        )
+        error = JobManagerExceededMaximumDurationError(message=message, cause=cause)
+        self.finish(
+            job_result={
+                "is_success": False,
+                "output": {
+                    "content": dict(error.as_response()),
+                    "http_status": error.status_code,
+                    "error_code": error.code,
+                    "details": dict(error.as_response_with_cause()),
+                    "progress": None,
+                },
+            }
         )

--- a/services/worker/src/worker/loop.py
+++ b/services/worker/src/worker/loop.py
@@ -142,12 +142,9 @@ class Loop:
             job_runner=job_runner,
             processing_graph=self.processing_graph,
         )
-        is_success = job_manager.run()
-        self.queue.finish_job(job_id=job_manager.job_id, is_success=is_success)
-        job_manager.backfill()
+        job_result = job_manager.run_job()
+        job_manager.finish(job_result=job_result)
         self.set_worker_state(current_job_info=None)
-        finished_status = "success" if is_success else "error"
-        logging.debug(f"job finished with {finished_status}: {job_manager}")
         return True
 
     def set_worker_state(self, current_job_info: Optional[JobInfo]) -> None:

--- a/services/worker/tests/test_job_manager.py
+++ b/services/worker/tests/test_job_manager.py
@@ -5,7 +5,7 @@ from typing import Optional
 import pytest
 from libcommon.exceptions import CustomError
 from libcommon.processing_graph import ProcessingGraph, ProcessingStep
-from libcommon.queue import Queue
+from libcommon.queue import Job, Queue
 from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.simple_cache import CachedResponse, get_response, upsert_response
 from libcommon.utils import JobInfo, Priority, Status
@@ -123,17 +123,18 @@ def test_backfill(priority: Priority, app_config: AppConfig) -> None:
         }
     )
     root_step = graph.get_processing_step("dummy")
-    job_info = JobInfo(
-        job_id="job_id",
-        type=root_step.job_type,
-        params={
-            "dataset": "dataset",
-            "revision": "revision",
-            "config": None,
-            "split": None,
-        },
+    queue = Queue()
+    assert Job.objects().count() == 0
+    queue.upsert_job(
+        job_type=root_step.job_type,
+        dataset="dataset",
+        revision="revision",
+        config=None,
+        split=None,
         priority=priority,
     )
+    job_info = queue.start_job()
+    assert job_info["priority"] == priority
 
     job_runner = DummyJobRunner(
         job_info=job_info,
@@ -142,12 +143,29 @@ def test_backfill(priority: Priority, app_config: AppConfig) -> None:
     )
 
     job_manager = JobManager(job_info=job_info, app_config=app_config, job_runner=job_runner, processing_graph=graph)
+    assert job_manager.priority == priority
 
-    # we add an entry to the cache
-    job_manager.run()
-    job_manager.backfill()
-    # check that the missing cache entries have been created
-    queue = Queue()
+    job_result = job_manager.run_job()
+    assert job_result["is_success"]
+    assert job_result["output"] is not None
+    assert job_result["output"]["content"] == {"key": "value"}
+
+    job_manager.finish(job_result=job_result)
+    # check that the job has been finished with success
+    job = queue.get_job_with_id(job_id=job_info["job_id"])
+    assert job.status == Status.SUCCESS
+    assert job.priority == priority
+
+    # check that the cache entry has have been created
+    cached_response = get_response(kind=root_step.cache_kind, dataset="dataset", config=None, split=None)
+    assert cached_response is not None
+    assert cached_response["http_status"] == HTTPStatus.OK
+    assert cached_response["error_code"] is None
+    assert cached_response["content"] == {"key": "value"}
+    assert cached_response["dataset_git_revision"] == "revision"
+    assert cached_response["job_runner_version"] == 1
+    assert cached_response["progress"] == 1.0
+
     dataset_child_jobs = queue.get_dump_with_status(job_type="dataset-child", status=Status.WAITING)
     assert len(dataset_child_jobs) == 1
     assert dataset_child_jobs[0]["dataset"] == "dataset"
@@ -172,24 +190,24 @@ def test_job_runner_set_crashed(
     test_processing_step: ProcessingStep,
     app_config: AppConfig,
 ) -> None:
-    job_id = "job_id"
     dataset = "dataset"
     revision = "revision"
     config = "config"
     split = "split"
     message = "I'm crashed :("
 
-    job_info = JobInfo(
-        job_id=job_id,
-        type=test_processing_step.job_type,
-        params={
-            "dataset": dataset,
-            "revision": revision,
-            "config": config,
-            "split": split,
-        },
+    queue = Queue()
+    assert Job.objects().count() == 0
+    queue.upsert_job(
+        job_type=test_processing_step.job_type,
+        dataset=dataset,
+        revision=revision,
+        config=config,
+        split=split,
         priority=Priority.NORMAL,
     )
+    job_info = queue.start_job()
+
     job_runner = DummyJobRunner(
         job_info=job_info,
         processing_step=test_processing_step,
@@ -300,7 +318,7 @@ def test_doesnotexist(app_config: AppConfig) -> None:
         job_info=job_info, app_config=app_config, job_runner=job_runner, processing_graph=processing_graph
     )
 
-    assert job_manager.process()
+    job_result = job_manager.process()
     # ^ the job is processed, since we don't contact the Hub to check if the dataset exists
-    response = get_response(kind=job_manager.processing_step.cache_kind, dataset=dataset, config=config, split=split)
-    assert response["content"] == {"key": "value"}
+    assert job_result["output"] is not None
+    assert job_result["output"]["content"] == {"key": "value"}


### PR DESCRIPTION
ie: if it has been cancelled, we ignore it. See previous work at https://github.com/huggingface/datasets-server/pull/1188. Note that after #1222, the number of warnings "...has a non-empty finished_at field..." has fallen to 26 logs among 20,000, while it was like 20% bof the logs before!