### PR TITLE
Reduce number of concurrent jobs in namespace

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -256,7 +256,7 @@ api:
 workers:
   -
     deployName: "all"
-    maxJobsPerNamespace: 10
+    maxJobsPerNamespace: 1
     workerJobTypesBlocked: ""
     workerJobTypesOnly: ""
     nodeSelector:
@@ -272,7 +272,7 @@ workers:
     tolerations: []
   -
     deployName: "light"
-    maxJobsPerNamespace: 2
+    maxJobsPerNamespace: 1
     workerJobTypesBlocked: "/config-names,config-split-names-from-streaming,config-parquet-and-info,split-first-rows-from-parquet,split-first-rows-from-streaming,split-opt-in-out-urls-scan"
     workerJobTypesOnly: ""
     nodeSelector:
@@ -288,7 +288,7 @@ workers:
     tolerations: []
   -
     deployName: "temporal-opt-in-out"
-    maxJobsPerNamespace: 10
+    maxJobsPerNamespace: 1
     workerJobTypesBlocked: ""
     workerJobTypesOnly: "split-opt-in-out-urls-scan"
     nodeSelector:

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -158,7 +158,6 @@ def upsert_response_params(
     error_code: Optional[str] = None,
     details: Optional[Mapping[str, Any]] = None,
     job_runner_version: Optional[int] = None,
-    dataset_git_revision: Optional[str] = None,
     progress: Optional[float] = None,
     updated_at: Optional[datetime] = None,
 ) -> None:


### PR DESCRIPTION
the idea is to reduce the number of pending jobs, currently we have > 200,000 jobs, from a lot of different datasets.

And as it seems like a cause of the issues with the queue is that concurrent backfill processes run at the same time for the same dataset, we reduce the concurrency drastically to 1 job per namespace (we don't have a way to limit per dataset, for now)