### PR TITLE
Add numba cache to api

### DIFF
--- a/chart/templates/_envNumba.tpl
+++ b/chart/templates/_envNumba.tpl
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+{{- define "envNumba" -}}
+# the size should remain so small that we don't need to worry about putting it on an external storage
+# note that the /tmp directory is not shared among the pods
+# This is needed to use numba and packages that use numba like librosa
+- name: NUMBA_CACHE_DIR
+  value: "/tmp/numba-cache"
+{{- end -}}
+

--- a/chart/templates/services/api/_container.tpl
+++ b/chart/templates/services/api/_container.tpl
@@ -12,6 +12,7 @@
   {{ include "envQueue" . | nindent 2 }}
   {{ include "envCommon" . | nindent 2 }}
   {{ include "envLog" . | nindent 2 }}
+  {{ include "envNumba" . | nindent 2 }}
   # service
   - name: API_HF_AUTH_PATH
     value: {{ .Values.api.hfAuthPath | quote }}

--- a/tools/docker-compose-base.yml
+++ b/tools/docker-compose-base.yml
@@ -26,6 +26,11 @@ services:
       WORKER_MAX_LOAD_PCT: ${WORKER_MAX_LOAD_PCT-70}
       WORKER_MAX_MEMORY_PCT: ${WORKER_MAX_MEMORY_PCT-80}
       WORKER_SLEEP_SECONDS: ${WORKER_SLEEP_SECONDS-15}
+  api:
+    extends:
+      service: common
+    environment:
+      NUMBA_CACHE_DIR: ${NUMBA_CACHE_DIR-/numba-cache}
   datasets-worker:
     extends:
       service: common

--- a/tools/docker-compose-datasets-server.yml
+++ b/tools/docker-compose-datasets-server.yml
@@ -52,7 +52,7 @@ services:
       dockerfile: services/api/Dockerfile
     extends:
       file: docker-compose-base.yml
-      service: common
+      service: api
     volumes:
       - cached-assets:${CACHED_ASSETS_STORAGE_DIRECTORY-/cached-assets}
       - parquet-metadata:${PARQUET_METADATA_STORAGE_DIRECTORY-/parquet_metadata}

--- a/tools/docker-compose-dev-base.yml
+++ b/tools/docker-compose-dev-base.yml
@@ -39,6 +39,8 @@ services:
     extends:
       service: common
     # volumes to local source directory for development
+    environment:
+      NUMBA_CACHE_DIR: ${NUMBA_CACHE_DIR-/numba-cache}
     volumes:
       - ../services/api/src:/src/services/api/src
   datasets-worker:

--- a/tools/docker-compose-dev-base.yml
+++ b/tools/docker-compose-dev-base.yml
@@ -38,9 +38,9 @@ services:
   api:
     extends:
       service: common
-    # volumes to local source directory for development
     environment:
       NUMBA_CACHE_DIR: ${NUMBA_CACHE_DIR-/numba-cache}
+    # volumes to local source directory for development
     volumes:
       - ../services/api/src:/src/services/api/src
   datasets-worker:


### PR DESCRIPTION
this should fix issues when importing librosa in the API (it causes issues in /rows for audio datasets)