### PR TITLE
Adding temporal hardcoded data for opt in/out: laion/laion2B-en and kakaobrain/coyo-700m

### DIFF
--- a/services/api/src/api/routes/endpoint.py
+++ b/services/api/src/api/routes/endpoint.py
@@ -152,7 +152,7 @@ HARD_CODED_OPT_IN_OUT_URLS = {
         num_opt_in_urls=5,
         num_opt_out_urls=42785281,
         num_urls=2322161807,
-        num_scanned_rows=0, # It is unknown but leaving with 0 for now since UI validates non null
+        num_scanned_rows=0,  # It is unknown but leaving with 0 for now since UI validates non null
         has_urls_columns=True,
         full_scan=True,
     ),
@@ -161,7 +161,7 @@ HARD_CODED_OPT_IN_OUT_URLS = {
         num_opt_in_urls=2,
         num_opt_out_urls=4691511,
         num_urls=746972269,
-        num_scanned_rows=0, # It is unknown but leaving with 0 for now since UI validates non null
+        num_scanned_rows=0,  # It is unknown but leaving with 0 for now since UI validates non null
         has_urls_columns=True,
         full_scan=True,
     ),


### PR DESCRIPTION
As per discussion in https://github.com/huggingface/moon-landing/pull/6332#discussion_r1202989143
Fake data will be hardcoded on the server side so that it is consistent with what API returns and what we show in the UI.
NOTE.- This is a temporal solution, once https://github.com/huggingface/datasets-server/issues/1087 is implemented, this code can be removed.
