### PR TITLE
Reduce requests to mongo (deleteMany)

### DIFF
--- a/libs/libcommon/src/libcommon/state.py
+++ b/libs/libcommon/src/libcommon/state.py
@@ -434,101 +434,107 @@ class DatasetState:
     def __post_init__(self) -> None:
         with StepProfiler(
             method="DatasetState.__post_init__",
-            step="get_pending_jobs_df",
+            step="all",
             context=f"dataset={self.dataset}",
         ):
-            self.pending_jobs_df = Queue().get_pending_jobs_df(dataset=self.dataset, revision=self.revision)
-            self.pending_jobs_df = self.pending_jobs_df[
-                (self.pending_jobs_df["dataset"] == self.dataset) & (self.pending_jobs_df["revision"] == self.revision)
-            ]
-            # ^ safety check
-        with StepProfiler(
-            method="DatasetState.__post_init__", step="get_cache_entries_df", context=f"dataset={self.dataset}"
-        ):
-            self.cache_entries_df = get_cache_entries_df(dataset=self.dataset)
-            self.cache_entries_df = self.cache_entries_df[self.cache_entries_df["dataset"] == self.dataset]
-            # ^ safety check
+            with StepProfiler(
+                method="DatasetState.__post_init__",
+                step="get_pending_jobs_df",
+                context=f"dataset={self.dataset}",
+            ):
+                self.pending_jobs_df = Queue().get_pending_jobs_df(dataset=self.dataset, revision=self.revision)
+                self.pending_jobs_df = self.pending_jobs_df[
+                    (self.pending_jobs_df["dataset"] == self.dataset)
+                    & (self.pending_jobs_df["revision"] == self.revision)
+                ]
+                # ^ safety check
+            with StepProfiler(
+                method="DatasetState.__post_init__", step="get_cache_entries_df", context=f"dataset={self.dataset}"
+            ):
+                self.cache_entries_df = get_cache_entries_df(dataset=self.dataset)
+                self.cache_entries_df = self.cache_entries_df[self.cache_entries_df["dataset"] == self.dataset]
+                # ^ safety check
 
-        with StepProfiler(
-            method="DatasetState.__post_init__",
-            step="get_dataset_level_artifact_states",
-            context=f"dataset={self.dataset}",
-        ):
-            self.artifact_state_by_step = {
-                processing_step.name: ArtifactState(
-                    processing_step=processing_step,
-                    dataset=self.dataset,
-                    revision=self.revision,
-                    config=None,
-                    split=None,
-                    error_codes_to_retry=self.error_codes_to_retry,
-                    has_pending_job=(
-                        (self.pending_jobs_df["config"].isnull())
-                        & (self.pending_jobs_df["split"].isnull())
-                        & (self.pending_jobs_df["type"] == processing_step.job_type)
-                    ).any(),
-                    cache_entries_df=self.cache_entries_df[
-                        (self.cache_entries_df["kind"] == processing_step.cache_kind)
-                        & (self.cache_entries_df["config"].isnull())
-                        & (self.cache_entries_df["split"].isnull())
-                    ],
-                )
-                for processing_step in self.processing_graph.get_input_type_processing_steps(input_type="dataset")
-            }
-        with StepProfiler(
-            method="DatasetState.__post_init__",
-            step="get_config_names",
-            context=f"dataset={self.dataset}",
-        ):
-            try:
-                self.config_names = fetch_names(
-                    dataset=self.dataset,
-                    config=None,
-                    cache_kinds=[
-                        processing_step.cache_kind
-                        for processing_step in self.processing_graph.get_dataset_config_names_processing_steps()
-                    ],
-                    names_field="config_names",
-                    name_field="config",
-                )  # Note that we use the cached content even the revision is different (ie. maybe obsolete)
-            except Exception:
-                self.config_names = []
-        with StepProfiler(
-            method="DatasetState.__post_init__",
-            step="get_config_states",
-            context=f"dataset={self.dataset}",
-        ):
-            self.config_states = [
-                ConfigState(
-                    dataset=self.dataset,
-                    revision=self.revision,
-                    config=config_name,
-                    processing_graph=self.processing_graph,
-                    error_codes_to_retry=self.error_codes_to_retry,
-                    pending_jobs_df=self.pending_jobs_df[self.pending_jobs_df["config"] == config_name],
-                    cache_entries_df=self.cache_entries_df[self.cache_entries_df["config"] == config_name],
-                )
-                for config_name in self.config_names
-            ]
-        with StepProfiler(
-            method="DatasetState.__post_init__",
-            step="_get_cache_status",
-            context=f"dataset={self.dataset}",
-        ):
-            self.cache_status = self._get_cache_status()
-        with StepProfiler(
-            method="DatasetState.__post_init__",
-            step="_get_queue_status",
-            context=f"dataset={self.dataset}",
-        ):
-            self.queue_status = self._get_queue_status()
-        with StepProfiler(
-            method="DatasetState.__post_init__",
-            step="_create_plan",
-            context=f"dataset={self.dataset}",
-        ):
-            self.plan = self._create_plan()
-        self.should_be_backfilled = len(self.plan.tasks) > 0
+            with StepProfiler(
+                method="DatasetState.__post_init__",
+                step="get_dataset_level_artifact_states",
+                context=f"dataset={self.dataset}",
+            ):
+                self.artifact_state_by_step = {
+                    processing_step.name: ArtifactState(
+                        processing_step=processing_step,
+                        dataset=self.dataset,
+                        revision=self.revision,
+                        config=None,
+                        split=None,
+                        error_codes_to_retry=self.error_codes_to_retry,
+                        has_pending_job=(
+                            (self.pending_jobs_df["config"].isnull())
+                            & (self.pending_jobs_df["split"].isnull())
+                            & (self.pending_jobs_df["type"] == processing_step.job_type)
+                        ).any(),
+                        cache_entries_df=self.cache_entries_df[
+                            (self.cache_entries_df["kind"] == processing_step.cache_kind)
+                            & (self.cache_entries_df["config"].isnull())
+                            & (self.cache_entries_df["split"].isnull())
+                        ],
+                    )
+                    for processing_step in self.processing_graph.get_input_type_processing_steps(input_type="dataset")
+                }
+            with StepProfiler(
+                method="DatasetState.__post_init__",
+                step="get_config_names",
+                context=f"dataset={self.dataset}",
+            ):
+                try:
+                    self.config_names = fetch_names(
+                        dataset=self.dataset,
+                        config=None,
+                        cache_kinds=[
+                            processing_step.cache_kind
+                            for processing_step in self.processing_graph.get_dataset_config_names_processing_steps()
+                        ],
+                        names_field="config_names",
+                        name_field="config",
+                    )  # Note that we use the cached content even the revision is different (ie. maybe obsolete)
+                except Exception:
+                    self.config_names = []
+            with StepProfiler(
+                method="DatasetState.__post_init__",
+                step="get_config_states",
+                context=f"dataset={self.dataset}",
+            ):
+                self.config_states = [
+                    ConfigState(
+                        dataset=self.dataset,
+                        revision=self.revision,
+                        config=config_name,
+                        processing_graph=self.processing_graph,
+                        error_codes_to_retry=self.error_codes_to_retry,
+                        pending_jobs_df=self.pending_jobs_df[self.pending_jobs_df["config"] == config_name],
+                        cache_entries_df=self.cache_entries_df[self.cache_entries_df["config"] == config_name],
+                    )
+                    for config_name in self.config_names
+                ]
+            with StepProfiler(
+                method="DatasetState.__post_init__",
+                step="_get_cache_status",
+                context=f"dataset={self.dataset}",
+            ):
+                self.cache_status = self._get_cache_status()
+            with StepProfiler(
+                method="DatasetState.__post_init__",
+                step="_get_queue_status",
+                context=f"dataset={self.dataset}",
+            ):
+                self.queue_status = self._get_queue_status()
+            with StepProfiler(
+                method="DatasetState.__post_init__",
+                step="_create_plan",
+                context=f"dataset={self.dataset}",
+            ):
+                self.plan = self._create_plan()
+            self.should_be_backfilled = len(self.plan.tasks) > 0
 
     def _get_artifact_states_for_step(
         self, processing_step: ProcessingStep, config: Optional[str] = None, split: Optional[str] = None

--- a/libs/libcommon/src/libcommon/state.py
+++ b/libs/libcommon/src/libcommon/state.py
@@ -454,10 +454,11 @@ class DeleteJobsTask(Task):
             step="all",
             context=f"num_jobs_to_delete={len(self.jobs_df)}",
         ):
-            if Queue().cancel_jobs_by_job_id(job_ids=self.jobs_df["job_id"].tolist()) != len(self.jobs_df):
+            cancelled_jobs_count = Queue().cancel_jobs_by_job_id(job_ids=self.jobs_df["job_id"].tolist())
+            if cancelled_jobs_count != len(self.jobs_df):
                 raise ValueError(
                     f"Something went wrong when cancelling jobs: {len(self.jobs_df)} jobs were supposed to be"
-                    f" cancelled, but {len(self.jobs_df)} were cancelled."
+                    f" cancelled, but {cancelled_jobs_count} were cancelled."
                 )
 
 

--- a/libs/libcommon/src/libcommon/state.py
+++ b/libs/libcommon/src/libcommon/state.py
@@ -42,9 +42,6 @@ def fetch_names(
     return names
 
 
-DFIndex = Union[pd.Index, pd.MultiIndex]
-
-
 @dataclass
 class JobState:
     """The state of a job for a given input."""

--- a/libs/libcommon/src/libcommon/utils.py
+++ b/libs/libcommon/src/libcommon/utils.py
@@ -44,6 +44,8 @@ class FlatJobInfo(TypedDict):
     config: Optional[str]
     split: Optional[str]
     priority: str
+    status: str
+    created_at: datetime
 
 
 # orjson is used to get rid of errors with datetime (see allenai/c4)

--- a/libs/libcommon/tests/state/test_objects.py
+++ b/libs/libcommon/tests/state/test_objects.py
@@ -210,14 +210,7 @@ def test_cache_state_is_success(dataset: str, config: Optional[str], split: Opti
     ).is_success
 
 
-@pytest.mark.parametrize(
-    "has_pending_job,expected_is_in_process",
-    [
-        (False, False),
-        (True, True),
-    ],
-)
-def test_artifact_state(has_pending_job: bool, expected_is_in_process: bool) -> None:
+def test_artifact_state() -> None:
     dataset = DATASET_NAME
     revision = REVISION_NAME
     config = None
@@ -230,13 +223,13 @@ def test_artifact_state(has_pending_job: bool, expected_is_in_process: bool) -> 
         config=config,
         split=split,
         processing_step=processing_step,
-        has_pending_job=has_pending_job,
+        pending_jobs_df=Queue().get_pending_jobs_df(dataset=dataset, revision=revision),
         cache_entries_df=get_cache_entries_df(dataset=dataset),
     )
     assert artifact_state.id == f"{processing_step_name},{dataset},{revision}"
     assert not artifact_state.cache_state.exists
     assert not artifact_state.cache_state.is_success
-    assert artifact_state.job_state.is_in_process is expected_is_in_process
+    assert not artifact_state.job_state.is_in_process
 
 
 def test_split_state() -> None:

--- a/libs/libcommon/tests/state/test_plan.py
+++ b/libs/libcommon/tests/state/test_plan.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The HuggingFace Authors.
 
-from typing import List, Set
+from datetime import datetime
+from typing import List, Optional, Set, Tuple
 
 import pytest
 
 from libcommon.processing_graph import ProcessingGraph
+from libcommon.queue import Queue
 from libcommon.resources import CacheMongoResource, QueueMongoResource
+from libcommon.utils import Priority, Status
 
 from .utils import (
     DATASET_NAME,
@@ -69,6 +72,18 @@ ARTIFACT_SA_1_2 = f"{STEP_SA},{DATASET_NAME},{REVISION_NAME},{CONFIG_NAME_1},{SP
 ARTIFACT_SA_2_1 = f"{STEP_SA},{DATASET_NAME},{REVISION_NAME},{CONFIG_NAME_2},{SPLIT_NAME_1}"
 ARTIFACT_SA_2_2 = f"{STEP_SA},{DATASET_NAME},{REVISION_NAME},{CONFIG_NAME_2},{SPLIT_NAME_2}"
 
+
+# Graph to test only one step
+#
+#    +-------+
+#    | DA    |
+#    +-------+
+#
+PROCESSING_GRAPH_ONE_STEP = ProcessingGraph(
+    processing_graph_specification={
+        STEP_DA: {"input_type": "dataset"},
+    }
+)
 
 # Graph to test siblings, children, grand-children, multiple parents
 #
@@ -772,3 +787,173 @@ def test_plan_incoherent_state(
         queue_status={"in_process": []},
         tasks=[],
     )
+
+
+# df = pd.DataFrame(
+#     {
+#         "priority": pd.Categorical(
+#             ["low", "low", "low", "normal", "normal"],
+#             ordered=True,
+#             # categories=[Priority.LOW.value, Priority.NORMAL.value],
+#             categories=["low", "normal"],
+#         ),
+#         "status": pd.Categorical(
+#             ["waiting", "waiting", "started", "waiting", "started"],
+#             ordered=True,
+#             categories=[
+#                 "waiting",
+#                 "started",
+#                 "success",
+#                 "error",
+#                 "cancelled"
+#                 # Status.WAITING.value,
+#                 # Status.STARTED.value,
+#                 # Status.SUCCESS.value,
+#                 # Status.ERROR.value,
+#                 # Status.CANCELLED.value,
+#             ],
+#         ),
+#         "created_at": [
+#             pd.Timestamp("20130101"),
+#             pd.Timestamp("20130102"),
+#             pd.Timestamp("20130103"),
+#             pd.Timestamp("20130104"),
+#             pd.Timestamp("20130105"),
+#         ],
+#     }
+# )
+
+JobSpec = Tuple[Priority, Status, Optional[datetime]]
+
+OLD = datetime.strptime("20000101", "%Y%m%d")
+NEW = datetime.strptime("20000102", "%Y%m%d")
+LOW_WAITING_OLD = (Priority.LOW, Status.WAITING, OLD)
+LOW_WAITING_NEW = (Priority.LOW, Status.WAITING, NEW)
+LOW_STARTED_OLD = (Priority.LOW, Status.STARTED, OLD)
+LOW_STARTED_NEW = (Priority.LOW, Status.STARTED, NEW)
+NORMAL_WAITING_OLD = (Priority.NORMAL, Status.WAITING, OLD)
+NORMAL_WAITING_NEW = (Priority.NORMAL, Status.WAITING, NEW)
+NORMAL_STARTED_OLD = (Priority.NORMAL, Status.STARTED, OLD)
+NORMAL_STARTED_NEW = (Priority.NORMAL, Status.STARTED, NEW)
+
+
+@pytest.mark.parametrize(
+    "existing_jobs,expected_create_job,expected_delete_jobs,expected_jobs_after_backfill",
+    [
+        ([], True, False, [(Priority.LOW, Status.WAITING, None)]),
+        (
+            [
+                LOW_WAITING_OLD,
+                LOW_WAITING_NEW,
+                LOW_STARTED_OLD,
+                LOW_STARTED_NEW,
+                NORMAL_WAITING_OLD,
+                NORMAL_WAITING_NEW,
+                NORMAL_STARTED_OLD,
+                NORMAL_STARTED_NEW,
+            ],
+            False,
+            True,
+            [NORMAL_STARTED_OLD],
+        ),
+        (
+            [
+                LOW_WAITING_OLD,
+                LOW_WAITING_NEW,
+                LOW_STARTED_OLD,
+                LOW_STARTED_NEW,
+                NORMAL_WAITING_OLD,
+                NORMAL_WAITING_NEW,
+                NORMAL_STARTED_NEW,
+            ],
+            False,
+            True,
+            [NORMAL_STARTED_NEW],
+        ),
+        (
+            [
+                LOW_WAITING_OLD,
+                LOW_WAITING_NEW,
+                LOW_STARTED_OLD,
+                LOW_STARTED_NEW,
+                NORMAL_WAITING_OLD,
+                NORMAL_WAITING_NEW,
+            ],
+            False,
+            True,
+            [LOW_STARTED_OLD],
+        ),
+        (
+            [LOW_WAITING_OLD, LOW_WAITING_NEW, LOW_STARTED_NEW, NORMAL_WAITING_OLD, NORMAL_WAITING_NEW],
+            False,
+            True,
+            [LOW_STARTED_NEW],
+        ),
+        (
+            [LOW_WAITING_OLD, LOW_WAITING_NEW, NORMAL_WAITING_OLD, NORMAL_WAITING_NEW],
+            False,
+            True,
+            [NORMAL_WAITING_OLD],
+        ),
+        ([LOW_WAITING_OLD, LOW_WAITING_NEW, NORMAL_WAITING_NEW], False, True, [NORMAL_WAITING_NEW]),
+        ([LOW_WAITING_OLD, LOW_WAITING_NEW], False, True, [LOW_WAITING_OLD]),
+        ([LOW_WAITING_NEW], False, False, [LOW_WAITING_NEW]),
+        ([LOW_WAITING_NEW] * 5, False, True, [LOW_WAITING_NEW]),
+    ],
+)
+def test_delete_jobs(
+    existing_jobs: List[JobSpec],
+    expected_create_job: bool,
+    expected_delete_jobs: bool,
+    expected_jobs_after_backfill: List[JobSpec],
+) -> None:
+    processing_graph = PROCESSING_GRAPH_ONE_STEP
+
+    queue = Queue()
+    for job_spec in existing_jobs:
+        (priority, status, created_at) = job_spec
+        job = queue._add_job(job_type=STEP_DA, dataset="dataset", revision="revision", priority=priority)
+        if created_at is not None:
+            job.created_at = created_at
+            job.save()
+        if status is Status.STARTED:
+            queue._start_job(job)
+
+    dataset_state = get_dataset_state(processing_graph=processing_graph)
+    expected_in_process = [ARTIFACT_DA] if existing_jobs else []
+    if expected_create_job:
+        if expected_delete_jobs:
+            raise NotImplementedError()
+        expected_tasks = [f"CreateJob,{ARTIFACT_DA}"]
+    elif expected_delete_jobs:
+        artifact_ids = ",".join([ARTIFACT_DA] * (len(existing_jobs) - 1))
+        expected_tasks = [f"DeleteJobs,{artifact_ids}"]
+    else:
+        expected_tasks = []
+
+    assert_dataset_state(
+        dataset_state=dataset_state,
+        config_names=[],
+        split_names_in_first_config=[],
+        cache_status={
+            "cache_has_different_git_revision": [],
+            "cache_is_outdated_by_parent": [],
+            "cache_is_empty": [ARTIFACT_DA],
+            "cache_is_error_to_retry": [],
+            "cache_is_job_runner_obsolete": [],
+            "up_to_date": [],
+        },
+        queue_status={"in_process": expected_in_process},
+        tasks=expected_tasks,
+    )
+
+    dataset_state.backfill()
+
+    job_dicts = queue.get_dataset_pending_jobs_for_type(dataset=DATASET_NAME, job_type=STEP_DA)
+    assert len(job_dicts) == len(expected_jobs_after_backfill)
+    for job_dict, expected_job_spec in zip(job_dicts, expected_jobs_after_backfill):
+        (priority, status, created_at) = expected_job_spec
+        assert job_dict["priority"] == priority.value
+        assert job_dict["status"] == status.value
+        if created_at is not None:
+            assert job_dict["created_at"] == created_at

--- a/libs/libcommon/tests/state/test_plan.py
+++ b/libs/libcommon/tests/state/test_plan.py
@@ -789,40 +789,6 @@ def test_plan_incoherent_state(
     )
 
 
-# df = pd.DataFrame(
-#     {
-#         "priority": pd.Categorical(
-#             ["low", "low", "low", "normal", "normal"],
-#             ordered=True,
-#             # categories=[Priority.LOW.value, Priority.NORMAL.value],
-#             categories=["low", "normal"],
-#         ),
-#         "status": pd.Categorical(
-#             ["waiting", "waiting", "started", "waiting", "started"],
-#             ordered=True,
-#             categories=[
-#                 "waiting",
-#                 "started",
-#                 "success",
-#                 "error",
-#                 "cancelled"
-#                 # Status.WAITING.value,
-#                 # Status.STARTED.value,
-#                 # Status.SUCCESS.value,
-#                 # Status.ERROR.value,
-#                 # Status.CANCELLED.value,
-#             ],
-#         ),
-#         "created_at": [
-#             pd.Timestamp("20130101"),
-#             pd.Timestamp("20130102"),
-#             pd.Timestamp("20130103"),
-#             pd.Timestamp("20130104"),
-#             pd.Timestamp("20130105"),
-#         ],
-#     }
-# )
-
 JobSpec = Tuple[Priority, Status, Optional[datetime]]
 
 OLD = datetime.strptime("20000101", "%Y%m%d")

--- a/libs/libcommon/tests/state/utils.py
+++ b/libs/libcommon/tests/state/utils.py
@@ -71,7 +71,7 @@ def assert_dataset_state(
     for key, value in cache_status.items():
         assert_equality(computed_cache_status[key], sorted(value), key)
     assert_equality(
-        dataset_state.queue_status.as_response(),
+        dataset_state.get_queue_status().as_response(),
         {key: sorted(value) for key, value in queue_status.items()},
         context="queue_status",
     )

--- a/services/api/src/api/routes/endpoint.py
+++ b/services/api/src/api/routes/endpoint.py
@@ -108,7 +108,6 @@ def get_cache_entry_from_steps(
             revision=revision,
             error_codes_to_retry=ERROR_CODES_TO_RETRY,
             priority=Priority.NORMAL,
-            # TODO: move Priority outside from queue.py (to remove dependency to this file)
         )
         artifact_ids = [
             Artifact(
@@ -117,7 +116,7 @@ def get_cache_entry_from_steps(
             for processing_step in processing_steps
         ]
         should_exist = any(
-            artifact_id in dataset_state.queue_status.in_process for artifact_id in artifact_ids
+            artifact_id in dataset_state.get_queue_status().in_process for artifact_id in artifact_ids
         ) or any(
             f"CreateJob,{artifact_id}" in task.id for task in dataset_state.plan.tasks for artifact_id in artifact_ids
         )


### PR DESCRIPTION
Do only one request to mongo to delete multiple jobs, instead of one per job deletion.