### PR TITLE
fix: 🐛 delete pending jobs for other revisions

### DIFF
--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -719,12 +719,9 @@ class Queue:
         )
         # ^ does not seem optimal at all, but I get the types right
 
-    def get_pending_jobs_df(self, dataset: str, revision: str) -> pd.DataFrame:
+    def get_pending_jobs_df(self, dataset: str) -> pd.DataFrame:
         return self._get_df(
-            [
-                job.flat_info()
-                for job in Job.objects(dataset=dataset, revision=revision, status__in=[Status.WAITING, Status.STARTED])
-            ]
+            [job.flat_info() for job in Job.objects(dataset=dataset, status__in=[Status.WAITING, Status.STARTED])]
         )
 
     # special reports

--- a/libs/libcommon/tests/state/test_objects.py
+++ b/libs/libcommon/tests/state/test_objects.py
@@ -223,7 +223,7 @@ def test_artifact_state() -> None:
         config=config,
         split=split,
         processing_step=processing_step,
-        pending_jobs_df=Queue().get_pending_jobs_df(dataset=dataset, revision=revision),
+        pending_jobs_df=Queue().get_pending_jobs_df(dataset=dataset),
         cache_entries_df=get_cache_entries_df(dataset=dataset),
     )
     assert artifact_state.id == f"{processing_step_name},{dataset},{revision}"


### PR DESCRIPTION
when backfilling a new revision, all pending jobs for other revisions (be it started or waiting) are canceled.