### PR TITLE
Fix missing slash in admin endpoints

### DIFF
--- a/services/admin/src/admin/app.py
+++ b/services/admin/src/admin/app.py
@@ -119,7 +119,7 @@ def create_app() -> Starlette:
         routes.extend(
             [
                 Route(
-                    f"/force-refresh{job_type}",
+                    f"/force-refresh/{job_type}",
                     endpoint=create_force_refresh_endpoint(
                         input_type=input_type,
                         job_type=job_type,
@@ -131,7 +131,7 @@ def create_app() -> Starlette:
                     methods=["POST"],
                 ),
                 Route(
-                    f"/cache-reports{cache_kind}",
+                    f"/cache-reports/{cache_kind}",
                     endpoint=create_cache_reports_endpoint(
                         cache_kind=cache_kind,
                         cache_reports_num_results=app_config.admin.cache_reports_num_results,
@@ -141,7 +141,7 @@ def create_app() -> Starlette:
                     ),
                 ),
                 Route(
-                    f"/cache-reports-with-content{cache_kind}",
+                    f"/cache-reports-with-content/{cache_kind}",
                     endpoint=create_cache_reports_with_content_endpoint(
                         cache_kind=cache_kind,
                         cache_reports_with_content_num_results=app_config.admin.cache_reports_with_content_num_results,
@@ -151,7 +151,7 @@ def create_app() -> Starlette:
                     ),
                 ),
                 Route(
-                    f"/cancel-jobs{job_type}",
+                    f"/cancel-jobs/{job_type}",
                     endpoint=create_cancel_jobs_endpoint(
                         job_type=job_type,
                         external_auth_url=app_config.admin.external_auth_url,

--- a/services/admin/src/admin/routes/cancel_jobs.py
+++ b/services/admin/src/admin/routes/cancel_jobs.py
@@ -25,7 +25,7 @@ def create_cancel_jobs_endpoint(
 ) -> Endpoint:
     async def cancel_jobs_endpoint(request: Request) -> Response:
         try:
-            logging.info(f"/cancel-jobs{job_type}")
+            logging.info(f"/cancel-jobs/{job_type}")
 
             # if auth_check fails, it will raise an exception that will be caught below
             auth_check(external_auth_url=external_auth_url, request=request, organization=organization)

--- a/services/admin/src/admin/routes/force_refresh.py
+++ b/services/admin/src/admin/routes/force_refresh.py
@@ -48,7 +48,7 @@ def create_force_refresh_endpoint(
                 split = request.query_params.get("split")
                 if not are_valid_parameters([config, split]):
                     raise MissingRequiredParameterError("Parameters 'config' and 'split' are required")
-            logging.info(f"/force-refresh{job_type}, dataset={dataset}, config={config}, split={split}")
+            logging.info(f"/force-refresh/{job_type}, dataset={dataset}, config={config}, split={split}")
 
             # if auth_check fails, it will raise an exception that will be caught below
             auth_check(external_auth_url=external_auth_url, request=request, organization=organization)

--- a/services/admin/tests/test_app.py
+++ b/services/admin/tests/test_app.py
@@ -100,7 +100,7 @@ def test_cache_reports(
     first_step = processing_graph.get_processing_steps()[0]
     path = first_step.cache_kind
     cursor_str = f"?cursor={cursor}" if cursor else ""
-    response = client.request("get", f"/cache-reports{path}{cursor_str}")
+    response = client.request("get", f"/cache-reports/{path}{cursor_str}")
     assert response.status_code == http_status
     if error_code:
         assert isinstance(response.json()["error"], str)
@@ -128,7 +128,7 @@ def test_cache_reports_with_content(
     first_step = processing_graph.get_processing_steps()[0]
     path = first_step.cache_kind
     cursor_str = f"?cursor={cursor}" if cursor else ""
-    response = client.request("get", f"/cache-reports-with-content{path}{cursor_str}")
+    response = client.request("get", f"/cache-reports-with-content/{path}{cursor_str}")
     assert response.status_code == http_status
     if error_code:
         assert isinstance(response.json()["error"], str)

--- a/services/admin/tests/test_app_real.py
+++ b/services/admin/tests/test_app_real.py
@@ -47,5 +47,5 @@ def test_force_refresh(
     processing_graph = ProcessingGraph(real_app_config.processing_graph.specification)
     first_step = processing_graph.get_processing_steps(order="topological")[0]
     path = first_step.job_type
-    response = real_client.request("post", f"/force-refresh{path}?dataset={dataset}")
+    response = real_client.request("post", f"/force-refresh/{path}?dataset={dataset}")
     assert response.status_code == 200, response.text


### PR DESCRIPTION
As discussed with @severo, this PR fixes the missing slash in some admin endpoints, e.g.: 
- https://datasets-server.huggingface.co/admin/force-refreshdataset-config-names

After this PR, it will be:
- https://datasets-server.huggingface.co/admin/force-refresh/dataset-config-names

Related to:
- #1246