### PR TITLE
fix: 🐛 dataset viewer is valid if any of first-rows work

### DIFF
--- a/libs/libcommon/src/libcommon/config.py
+++ b/libs/libcommon/src/libcommon/config.py
@@ -240,6 +240,7 @@ class ProcessingGraphConfig:
             "split-first-rows-from-parquet": {
                 "input_type": "split",
                 "triggered_by": "config-parquet",
+                "required_by_dataset_viewer": True,
                 "job_runner_version": PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_PARQUET_VERSION,
             },
             "dataset-parquet": {

--- a/libs/libcommon/tests/test_processing_graph.py
+++ b/libs/libcommon/tests/test_processing_graph.py
@@ -301,7 +301,7 @@ def test_default_graph_first_steps(graph: ProcessingGraph) -> None:
 
 
 def test_default_graph_required_by_dataset_viewer(graph: ProcessingGraph) -> None:
-    required_by_dataset_viewer = ["split-first-rows-from-streaming"]
+    required_by_dataset_viewer = ["split-first-rows-from-streaming", "split-first-rows-from-parquet"]
     assert_lists_are_equal(graph.get_processing_steps_required_by_dataset_viewer(), required_by_dataset_viewer)
 
 


### PR DESCRIPTION
we were only considering a dataset supports the dataset viewer when the first-rows were generated with the "streaming" mode.