### PR TITLE
[docs] Fix quickstart

### DIFF
--- a/docs/source/quick_start.mdx
+++ b/docs/source/quick_start.mdx
@@ -294,11 +294,9 @@ curl https://datasets-server.huggingface.co/rows?dataset=rotten_tomatoes&config=
 
 You can download slices of 100 rows maximum at a time.
 
-## Access parquet files
+## Access Parquet files
 
-## Access parquet files
-
-The datasets-server converts every public dataset on the Hub to the [parquet](https://parquet.apache.org/) format. The `/parquet` endpoint returns a JSON list of the parquet URLs for a dataset:
+Datasets Server converts every public dataset on the Hub to the [Parquet](https://parquet.apache.org/) format. The `/parquet` endpoint returns a JSON list of the Parquet URLs for a dataset:
 
 <inferencesnippet>
 <python>


### PR DESCRIPTION
Removes the extra "Access parquet files" section in the quickstart.