### PR TITLE
fix: Parallel job runner for split-first-rows-from-parquet

### DIFF
--- a/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
@@ -245,7 +245,7 @@ class SplitFirstRowsFromParquetJobRunner(SplitJobRunner):
     def get_parallel_job_runner() -> JobRunnerInfo:
         return JobRunnerInfo(
             job_runner_version=PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_STREAMING_VERSION,
-            job_type="config-split-names-from-info",
+            job_type="split-first-rows-from-streaming",
         )
 
     def __init__(


### PR DESCRIPTION
It must be split-first-rows-from-streaming, not config-split-names-from-info