### PR TITLE
feat: 🎸 disable the limit per namespace

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -256,7 +256,7 @@ api:
 workers:
   -
     deployName: "all"
-    maxJobsPerNamespace: 20
+    maxJobsPerNamespace: 1000
     workerJobTypesBlocked: ""
     workerJobTypesOnly: ""
     nodeSelector:
@@ -272,7 +272,7 @@ workers:
     tolerations: []
   -
     deployName: "light"
-    maxJobsPerNamespace: 2
+    maxJobsPerNamespace: 1000
     workerJobTypesBlocked: "dataset-config-names,config-split-names-from-streaming,config-parquet-and-info,split-first-rows-from-parquet,split-first-rows-from-streaming,split-opt-in-out-urls-scan"
     workerJobTypesOnly: ""
     nodeSelector:


### PR DESCRIPTION
(only increased to 1000, which is a lot more than the max number of started jobs). I think that we don't need this restriction anymore, because the jobs are limited in time, and the datasets with less started job are already prioritized. I think that the code could be removed at one point (let's first see how it goes), which would simplify the queries to mongo