### PR TITLE
Generate random cache subdirectory for dataset job runner

### DIFF
--- a/services/worker/src/worker/job_runners/_datasets_based_job_runner.py
+++ b/services/worker/src/worker/job_runners/_datasets_based_job_runner.py
@@ -3,8 +3,8 @@
 
 import json
 import logging
+import random
 import re
-from datetime import datetime
 from hashlib import sha1
 from pathlib import Path
 from typing import Optional
@@ -44,18 +44,18 @@ class DatasetsBasedJobRunner(JobRunner):
         self.datasets_based_config = app_config.datasets_based
         self.base_datasets_cache = hf_datasets_cache
 
-    def get_cache_subdirectory(self, date: datetime) -> str:
-        date_str = date.strftime("%Y-%m-%d-%H-%M-%S")
+    def get_cache_subdirectory(self, digits: int = 14) -> str:
+        random_str = f"{random.randrange(10**(digits - 1), 10**digits)}"
         # TODO: Refactor, need a way to generate payload based only on provided params
         payload = (
-            date_str,
+            random_str,
             self.get_job_type(),
             self.job_info["params"]["dataset"],
             self.job_info["params"]["config"],
             self.job_info["params"]["split"],
         )
         hash_suffix = sha1(json.dumps(payload, sort_keys=True).encode(), usedforsecurity=False).hexdigest()[:8]
-        prefix = f"{date_str}-{self.get_job_type()}-{self.job_info['params']['dataset']}"[:64]
+        prefix = f"{random_str}-{self.get_job_type()}-{self.job_info['params']['dataset']}"[:64]
         subdirectory = f"{prefix}-{hash_suffix}"
         return "".join([c if re.match(r"[\w-]", c) else "-" for c in subdirectory])
 
@@ -79,7 +79,7 @@ class DatasetsBasedJobRunner(JobRunner):
         self.datasets_cache = None
 
     def set_cache(self) -> None:
-        cache_subdirectory = self.get_cache_subdirectory(date=datetime.now())
+        cache_subdirectory = self.get_cache_subdirectory()
         self.set_datasets_cache(self.base_datasets_cache / cache_subdirectory)
 
     def unset_cache(self) -> None:

--- a/services/worker/src/worker/job_runners/_datasets_based_job_runner.py
+++ b/services/worker/src/worker/job_runners/_datasets_based_job_runner.py
@@ -45,7 +45,7 @@ class DatasetsBasedJobRunner(JobRunner):
         self.base_datasets_cache = hf_datasets_cache
 
     def get_cache_subdirectory(self, digits: int = 14) -> str:
-        random_str = f"{random.randrange(10**(digits - 1), 10**digits)}"
+        random_str = f"{random.randrange(10**(digits - 1), 10**digits)}"  # nosec B311
         # TODO: Refactor, need a way to generate payload based only on provided params
         payload = (
             random_str,

--- a/services/worker/tests/job_runners/test__datasets_based_worker.py
+++ b/services/worker/tests/job_runners/test__datasets_based_worker.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
 
-from datetime import datetime
+import random
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -81,18 +81,18 @@ def get_job_runner(
 @pytest.mark.parametrize(
     "dataset,config,split,expected",
     [
-        ("user/dataset", "config", "split", "2022-11-07-12-34-56-dummy-job-runner-user-dataset-93f0f1a3"),
+        ("user/dataset", "config", "split", "64218998941645-dummy-job-runner-user-dataset-da67625f"),
         # Every parameter variation changes the hash, hence the subdirectory
-        ("user/dataset", None, "split", "2022-11-07-12-34-56-dummy-job-runner-user-dataset-0083afc6"),
-        ("user/dataset", "config2", "split", "2022-11-07-12-34-56-dummy-job-runner-user-dataset-a180e0a8"),
-        ("user/dataset", "config", None, "2022-11-07-12-34-56-dummy-job-runner-user-dataset-77f9f489"),
-        ("user/dataset", "config", "split2", "2022-11-07-12-34-56-dummy-job-runner-user-dataset-6ab6a389"),
+        ("user/dataset", None, "split", "64218998941645-dummy-job-runner-user-dataset-498c21fa"),
+        ("user/dataset", "config2", "split", "64218998941645-dummy-job-runner-user-dataset-1c4f24f2"),
+        ("user/dataset", "config", None, "64218998941645-dummy-job-runner-user-dataset-a87e8dc2"),
+        ("user/dataset", "config", "split2", "64218998941645-dummy-job-runner-user-dataset-f169bd48"),
         # The subdirectory length is truncated, and it always finishes with the hash
         (
             "very_long_dataset_name_0123456789012345678901234567890123456789012345678901234567890123456789",
             "config",
             "split",
-            "2022-11-07-12-34-56-dummy-job-runner-very_long_dataset_name_0123-d9070011",
+            "64218998941645-dummy-job-runner-very_long_dataset_name_012345678-25cb8442",
         ),
     ],
 )
@@ -104,9 +104,9 @@ def test_get_cache_subdirectory(
     split: Optional[str],
     expected: str,
 ) -> None:
-    date = datetime(2022, 11, 7, 12, 34, 56)
     job_runner = get_job_runner(dataset, config, split, app_config)
-    assert job_runner.get_cache_subdirectory(date=date) == expected
+    random.seed(0)
+    assert job_runner.get_cache_subdirectory() == expected
 
 
 def test_set_and_unset_datasets_cache(app_config: AppConfig, get_job_runner: GetJobRunner) -> None:


### PR DESCRIPTION
Generate random cache subdirectory for dataset job runner.

This might fix the stale file handle error:
```
OSError: [Errno 116] Stale file handle
```

See: https://huggingface.co/datasets/tapaco/discussions/4