### PR TITLE
refactor: 💡 rename required_by_dataset_viewer: enables_preview

### DIFF
--- a/chart/static-files/openapi.json
+++ b/chart/static-files/openapi.json
@@ -290,10 +290,7 @@
         "description": "A string that identifies the underlying error for 500 on /first-rows.",
         "schema": {
           "type": "string",
-          "enum": [
-            "RowsPostProcessingError",
-            "UnexpectedError"
-          ]
+          "enum": ["RowsPostProcessingError", "UnexpectedError"]
         },
         "examples": {
           "RowsPostProcessingError": {
@@ -896,11 +893,20 @@
       },
       "ValidResponse": {
         "type": "object",
-        "required": ["valid"],
+        "required": ["preview", "viewer", "valid"],
         "properties": {
-          "valid": {
+          "preview": {
             "type": "array",
             "items": { "type": "string" }
+          },
+          "viewer": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "valid": {
+            "type": "array",
+            "items": { "type": "string" },
+            "deprecated": true
           }
         }
       },
@@ -2213,7 +2219,7 @@
             "description": "The length of the slice",
             "default": 100,
             "minimum": 0,
-            "maximum": 100, 
+            "maximum": 100,
             "schema": { "type": "integer" },
             "examples": {
               "100": {
@@ -3146,9 +3152,9 @@
     "/valid": {
       "get": {
         "summary": "Valid datasets",
-        "description": "The list of the Hub datasets that work without an error (for /splits and /first-rows).",
+        "description": "The lists of the Hub datasets that work without an error, by type. It lists the datasets that have a Dataset Viewer (i.e. have been converted to Parquet format, and can be paginated) and the datasets that only have the Dataset Preview (the first 100 rows).",
         "externalDocs": {
-          "description": "See  Valid datasets (Hub docs)",
+          "description": "See Valid datasets (Hub docs)",
           "url": "https://huggingface.co/docs/datasets-server/valid"
         },
         "operationId": "listValidDatasets",
@@ -3173,6 +3179,15 @@
                   "valid": {
                     "summary": "list of datasets",
                     "value": {
+                      "preview": [
+                        "0n1xus/codexglue",
+                        "0x7194633/rupile",
+                        "AHussain0418/day2_data"
+                      ],
+                      "viewer": [
+                        "0n1xus/pytorrent-standalone",
+                        "51la5/keyword-extraction"
+                      ],
                       "valid": [
                         "0n1xus/codexglue",
                         "0n1xus/pytorrent-standalone",

--- a/libs/libcommon/src/libcommon/config.py
+++ b/libs/libcommon/src/libcommon/config.py
@@ -264,6 +264,7 @@ class ProcessingGraphConfig:
             "config-size": {
                 "input_type": "config",
                 "triggered_by": "config-parquet-and-info",
+                "enables_viewer": True,
                 "job_runner_version": PROCESSING_STEP_CONFIG_SIZE_VERSION,
             },
             "dataset-size": {

--- a/libs/libcommon/src/libcommon/config.py
+++ b/libs/libcommon/src/libcommon/config.py
@@ -214,7 +214,7 @@ class ProcessingGraphConfig:
             "split-first-rows-from-streaming": {
                 "input_type": "split",
                 "triggered_by": ["config-split-names-from-streaming", "config-split-names-from-info"],
-                "required_by_dataset_viewer": True,
+                "enables_preview": True,
                 "job_runner_version": PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_STREAMING_VERSION,
             },
             "config-parquet-and-info": {
@@ -237,7 +237,7 @@ class ProcessingGraphConfig:
             "split-first-rows-from-parquet": {
                 "input_type": "split",
                 "triggered_by": "config-parquet",
-                "required_by_dataset_viewer": True,
+                "enables_preview": True,
                 "job_runner_version": PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_PARQUET_VERSION,
             },
             "dataset-parquet": {

--- a/libs/libcommon/src/libcommon/processing_graph.py
+++ b/libs/libcommon/src/libcommon/processing_graph.py
@@ -48,6 +48,7 @@ class ProcessingStepSpecification(TypedDict, total=False):
     input_type: InputType
     triggered_by: Union[List[str], str, None]
     enables_preview: Literal[True]
+    enables_viewer: Literal[True]
     job_runner_version: int
     provides_dataset_config_names: bool
     provides_config_split_names: bool
@@ -135,6 +136,7 @@ class ProcessingGraph:
     _processing_step_names_by_input_type: Mapping[InputType, List[str]] = field(init=False)
     _first_processing_steps: List[ProcessingStep] = field(init=False)
     _processing_steps_enables_preview: List[ProcessingStep] = field(init=False)
+    _processing_steps_enables_viewer: List[ProcessingStep] = field(init=False)
     _config_split_names_processing_steps: List[ProcessingStep] = field(init=False)
     _config_parquet_processing_steps: List[ProcessingStep] = field(init=False)
     _config_parquet_metadata_processing_steps: List[ProcessingStep] = field(init=False)
@@ -180,6 +182,7 @@ class ProcessingGraph:
             _nx_graph.add_node(
                 name,
                 enables_preview=specification.get("enables_preview", False),
+                enables_viewer=specification.get("enables_viewer", False),
                 provides_dataset_config_names=provides_dataset_config_names,
                 provides_config_split_names=provides_config_split_names,
                 provides_config_parquet=provides_config_parquet,
@@ -216,6 +219,11 @@ class ProcessingGraph:
         self._processing_steps_enables_preview = [
             self._processing_steps[processing_step_name]
             for (processing_step_name, required) in _nx_graph.nodes(data="enables_preview")
+            if required
+        ]
+        self._processing_steps_enables_viewer = [
+            self._processing_steps[processing_step_name]
+            for (processing_step_name, required) in _nx_graph.nodes(data="enables_viewer")
             if required
         ]
         self._config_parquet_processing_steps = [
@@ -381,6 +389,18 @@ class ProcessingGraph:
             List[ProcessingStep]: The list of processing steps that enable the dataset preview
         """
         return copy_processing_steps_list(self._processing_steps_enables_preview)
+
+    def get_processing_steps_enables_viewer(self) -> List[ProcessingStep]:
+        """
+        Get the processing steps that enable the dataset viewer (all rows).
+
+        The returned processing steps are copies of the original ones, so that they can be modified without affecting
+        the original ones.
+
+        Returns:
+            List[ProcessingStep]: The list of processing steps that enable the dataset viewer
+        """
+        return copy_processing_steps_list(self._processing_steps_enables_viewer)
 
     def get_config_parquet_processing_steps(self) -> List[ProcessingStep]:
         """

--- a/libs/libcommon/tests/test_processing_graph.py
+++ b/libs/libcommon/tests/test_processing_graph.py
@@ -300,9 +300,9 @@ def test_default_graph_first_steps(graph: ProcessingGraph) -> None:
     assert_lists_are_equal(graph.get_first_processing_steps(), roots)
 
 
-def test_default_graph_required_by_dataset_viewer(graph: ProcessingGraph) -> None:
-    required_by_dataset_viewer = ["split-first-rows-from-streaming", "split-first-rows-from-parquet"]
-    assert_lists_are_equal(graph.get_processing_steps_required_by_dataset_viewer(), required_by_dataset_viewer)
+def test_default_graph_enables_preview(graph: ProcessingGraph) -> None:
+    enables_preview = ["split-first-rows-from-streaming", "split-first-rows-from-parquet"]
+    assert_lists_are_equal(graph.get_processing_steps_enables_preview(), enables_preview)
 
 
 def test_default_graph_provide_dataset_config_names(graph: ProcessingGraph) -> None:

--- a/libs/libcommon/tests/test_processing_graph.py
+++ b/libs/libcommon/tests/test_processing_graph.py
@@ -305,6 +305,11 @@ def test_default_graph_enables_preview(graph: ProcessingGraph) -> None:
     assert_lists_are_equal(graph.get_processing_steps_enables_preview(), enables_preview)
 
 
+def test_default_graph_enables_viewer(graph: ProcessingGraph) -> None:
+    enables_viewer = ["config-size"]
+    assert_lists_are_equal(graph.get_processing_steps_enables_viewer(), enables_viewer)
+
+
 def test_default_graph_provide_dataset_config_names(graph: ProcessingGraph) -> None:
     assert_lists_are_equal(graph.get_dataset_config_names_processing_steps(), ["dataset-config-names"])
 

--- a/services/api/src/api/routes/valid.py
+++ b/services/api/src/api/routes/valid.py
@@ -20,8 +20,8 @@ from api.utils import (
 
 def get_valid(processing_graph: ProcessingGraph) -> List[str]:
     # a dataset is considered valid if at least one response of any of the
-    # "required_by_dataset_viewer" steps is valid.
-    processing_steps = processing_graph.get_processing_steps_required_by_dataset_viewer()
+    # "enables_preview" steps is valid.
+    processing_steps = processing_graph.get_processing_steps_enables_preview()
     if not processing_steps:
         return []
     datasets = set.union(

--- a/services/api/src/api/routes/valid.py
+++ b/services/api/src/api/routes/valid.py
@@ -2,9 +2,10 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
-from typing import List
+from dataclasses import dataclass, field
+from typing import List, Set, TypedDict
 
-from libcommon.processing_graph import ProcessingGraph
+from libcommon.processing_graph import ProcessingGraph, ProcessingStep
 from libcommon.prometheus import StepProfiler
 from libcommon.simple_cache import get_valid_datasets
 from starlette.requests import Request
@@ -18,17 +19,48 @@ from api.utils import (
 )
 
 
-def get_valid(processing_graph: ProcessingGraph) -> List[str]:
-    # a dataset is considered valid if at least one response of any of the
-    # "enables_preview" steps is valid.
-    processing_steps = processing_graph.get_processing_steps_enables_preview()
-    if not processing_steps:
-        return []
-    datasets = set.union(
-        *[get_valid_datasets(kind=processing_step.cache_kind) for processing_step in processing_steps]
-    )
-    # note that the list is sorted alphabetically for consistency
-    return sorted(datasets)
+class ValidContent(TypedDict):
+    valid: List[str]
+    preview: List[str]
+    viewer: List[str]
+
+
+@dataclass
+class ValidDatasets:
+    processing_graph: ProcessingGraph
+    content: ValidContent = field(init=False)
+
+    def __post_init__(self) -> None:
+        _viewer_set: Set[str] = self._get_valid_set(
+            processing_steps=self.processing_graph.get_processing_steps_enables_viewer()
+        )
+        _preview_set: Set[str] = self._get_valid_set(
+            processing_steps=self.processing_graph.get_processing_steps_enables_preview()
+        ).difference(_viewer_set)
+        _valid_set = set.union(_viewer_set, _preview_set)
+        self.content = ValidContent(
+            valid=sorted(_valid_set),
+            preview=sorted(_preview_set),
+            viewer=sorted(_viewer_set),
+        )
+
+    def _get_valid_set(self, processing_steps: List[ProcessingStep]) -> Set[str]:
+        """Returns the list of the valid datasets for the list of steps
+
+        A dataset is considered valid if at least one response of any of the artifacts for any of the
+        steps is valid.
+
+        Args:
+            processing_steps (List[ProcessingStep]): The list of processing steps
+
+        Returns:
+            List[str]: The list of valid datasets for the steps
+        """
+        if not processing_steps:
+            return set()
+        return set.union(
+            *[get_valid_datasets(kind=processing_step.cache_kind) for processing_step in processing_steps]
+        )
 
 
 def create_valid_endpoint(
@@ -42,7 +74,7 @@ def create_valid_endpoint(
             try:
                 logging.info("/valid")
                 with StepProfiler(method="valid_endpoint", step="prepare content"):
-                    content = {"valid": get_valid(processing_graph=processing_graph)}
+                    content = ValidDatasets(processing_graph=processing_graph).content
                 with StepProfiler(method="valid_endpoint", step="generate OK response"):
                     return get_json_ok_response(content, max_age=max_age_long)
             except Exception as e:

--- a/services/api/tests/routes/test_valid.py
+++ b/services/api/tests/routes/test_valid.py
@@ -26,7 +26,7 @@ def clean_mongo_databases(app_config: AppConfig) -> None:
     [
         {},
         {step_1: {}},
-        {step_1: {"required_by_dataset_viewer": True}},
+        {step_1: {"enables_preview": True}},
     ],
 )
 def test_empty(processing_graph_specification: ProcessingGraphSpecification) -> None:
@@ -38,9 +38,9 @@ def test_empty(processing_graph_specification: ProcessingGraphSpecification) -> 
     "processing_graph_specification,expected_valid",
     [
         ({step_1: {}}, []),
-        ({step_1: {"required_by_dataset_viewer": True}}, ["dataset"]),
-        ({step_1: {}, step_2: {"required_by_dataset_viewer": True}}, []),
-        ({step_1: {"required_by_dataset_viewer": True}, step_2: {"required_by_dataset_viewer": True}}, ["dataset"]),
+        ({step_1: {"enables_preview": True}}, ["dataset"]),
+        ({step_1: {}, step_2: {"enables_preview": True}}, []),
+        ({step_1: {"enables_preview": True}, step_2: {"enables_preview": True}}, ["dataset"]),
     ],
 )
 def test_one_dataset(processing_graph_specification: ProcessingGraphSpecification, expected_valid: List[str]) -> None:
@@ -55,10 +55,10 @@ def test_one_dataset(processing_graph_specification: ProcessingGraphSpecificatio
     "processing_graph_specification,expected_valid",
     [
         ({step_1: {}, step_2: {}}, []),
-        ({step_1: {"required_by_dataset_viewer": True}, step_2: {}}, ["dataset1"]),
-        ({step_1: {}, step_2: {"required_by_dataset_viewer": True}}, ["dataset2"]),
+        ({step_1: {"enables_preview": True}, step_2: {}}, ["dataset1"]),
+        ({step_1: {}, step_2: {"enables_preview": True}}, ["dataset2"]),
         (
-            {step_1: {"required_by_dataset_viewer": True}, step_2: {"required_by_dataset_viewer": True}},
+            {step_1: {"enables_preview": True}, step_2: {"enables_preview": True}},
             ["dataset1", "dataset2"],
         ),
     ],
@@ -93,7 +93,7 @@ def test_two_datasets(processing_graph_specification: ProcessingGraphSpecificati
         ),
         (
             {
-                dataset_step: {"required_by_dataset_viewer": True},
+                dataset_step: {"enables_preview": True},
                 config_step: {"input_type": "config", "triggered_by": dataset_step},
                 split_step: {"input_type": "split", "triggered_by": config_step},
             },
@@ -105,7 +105,7 @@ def test_two_datasets(processing_graph_specification: ProcessingGraphSpecificati
                 config_step: {
                     "input_type": "config",
                     "triggered_by": dataset_step,
-                    "required_by_dataset_viewer": True,
+                    "enables_preview": True,
                 },
                 split_step: {"input_type": "split", "triggered_by": config_step},
             },
@@ -115,19 +115,19 @@ def test_two_datasets(processing_graph_specification: ProcessingGraphSpecificati
             {
                 dataset_step: {},
                 config_step: {"input_type": "config", "triggered_by": dataset_step},
-                split_step: {"input_type": "split", "triggered_by": config_step, "required_by_dataset_viewer": True},
+                split_step: {"input_type": "split", "triggered_by": config_step, "enables_preview": True},
             },
             ["dataset"],
         ),
         (
             {
-                dataset_step: {"required_by_dataset_viewer": True},
+                dataset_step: {"enables_preview": True},
                 config_step: {
                     "input_type": "config",
                     "triggered_by": dataset_step,
-                    "required_by_dataset_viewer": True,
+                    "enables_preview": True,
                 },
-                split_step: {"input_type": "split", "triggered_by": config_step, "required_by_dataset_viewer": True},
+                split_step: {"input_type": "split", "triggered_by": config_step, "enables_preview": True},
             },
             ["dataset"],
         ),
@@ -163,7 +163,7 @@ def test_three_steps(processing_graph_specification: ProcessingGraphSpecificatio
 
 
 def test_errors() -> None:
-    processing_graph = ProcessingGraph({dataset_step: {"required_by_dataset_viewer": True}})
+    processing_graph = ProcessingGraph({dataset_step: {"enables_preview": True}})
     dataset_a = "dataset_a"
     dataset_b = "dataset_b"
     dataset_c = "dataset_c"

--- a/services/api/tests/test_app.py
+++ b/services/api/tests/test_app.py
@@ -49,6 +49,8 @@ def test_get_valid_datasets(client: TestClient) -> None:
     response = client.get("/valid")
     assert response.status_code == 200
     assert "valid" in response.json()
+    assert "preview" in response.json()
+    assert "viewer" in response.json()
 
 
 def test_get_healthcheck(client: TestClient) -> None:


### PR DESCRIPTION
Change the response of `/valid`, from:

```json
{
  "valid": ["datasets", "that", "have", "/first-rows"]
}
```

to

```json
{
  "preview": ["datasets", "that", "only", "have", "/first-rows"],
  "viewer": ["datasets", "that", "have", "/rows", "and", "/size"],
  "valid": ["preview", "and", "viewer"]
}
```

Note that `valid` is the same as before, and will be removed in a future PR, once the Hub has been updated to use "preview" and "viewer".

### Notes

I propose to first try this. If it works, we will remove the `valid` field, update the docs (https://huggingface.co/docs/datasets-server/valid) and do the same switch for `/is-valid`.
