### PR TITLE
[docs] Improvements

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -4,6 +4,8 @@
     title: 🤗 Datasets server
   - local: quick_start
     title: Quickstart
+  - local: analyze_data
+    title: Analyze a dataset on the Hub
 - title: Guides
   sections:
   - local: valid

--- a/docs/source/analyze_data.mdx
+++ b/docs/source/analyze_data.mdx
@@ -1,0 +1,63 @@
+# Analyze a dataset on the Hub
+
+[[open-in-colab]]
+
+In the Quickstart, you were introduced to various endpoints for interacting with datasets on the Hub. One of the most useful ones is the `/parquet` endpoint, which allows you to get a dataset stored on the Hub and analyze it. This is a great way to explore the dataset, and get a better understanding of it's contents.
+
+To demonstrate, this guide will show you an end-to-end example of how to retrieve a dataset from the Hub and do some basic data analysis with the Pandas library.
+
+## Get a dataset
+
+The [Hub](https://huggingface.co/datasets) is home to more than 40,000 datasets across a wide variety of tasks, sizes, and languages. For this example, you'll use the [`codeparrot/codecomplex`](https://huggingface.co/datasets/codeparrot/codecomplex) dataset, but feel free to explore and find another dataset that interests you! The dataset contains Java code from programming competitions, and the time complexity of the code is labeled by a group of algorithm experts. 
+
+Let's say you're interested in the average length of the submitted code as it relates to the time complexity. Here's how you can get started. 
+
+Use the `/parquet` endpoint to convert the dataset to a Parquet file and return the URL to it:
+
+```py
+import requests
+API_URL = "https://datasets-server.huggingface.co/parquet?dataset=codeparrot/codecomplex"
+def query():
+    response = requests.get(API_URL)
+    return response.json()
+data = query()
+print(data)
+{'parquet_files': 
+    [
+        {'dataset': 'codeparrot/codecomplex', 'config': 'codeparrot--codecomplex', 'split': 'train', 'url': 'https://huggingface.co/datasets/codeparrot/codecomplex/resolve/refs%2Fconvert%2Fparquet/codeparrot--codecomplex/json-train.parquet', 'filename': 'json-train.parquet', 'size': 4115908}
+    ], 
+ 'pending': [], 'failed': []
+}
+```
+
+## Read dataset with Pandas
+
+With the URL, you can read the Parquet file into a Pandas DataFrame:
+
+```py
+import pandas as pd
+
+url = "https://huggingface.co/datasets/codeparrot/codecomplex/resolve/refs%2Fconvert%2Fparquet/codeparrot--codecomplex/json-train.parquet"
+df = pd.read_parquet(url)
+df.head(5)
+```
+
+|                                               src | complexity |                         problem |       from |
+|--------------------------------------------------:|-----------:|--------------------------------:|-----------:|
+| import java.io.*;\nimport java.math.BigInteger... |  quadratic |     1179_B. Tolik and His Uncle | CODEFORCES |
+| import java.util.Scanner;\n \npublic class pil... |     linear |                 1197_B. Pillars | CODEFORCES |
+| import java.io.BufferedReader;\nimport java.io... |     linear | 1059_C. Sequence Transformation | CODEFORCES |
+| import java.util.*;\n\nimport java.io.*;\npubl... |     linear |                  1011_A. Stages | CODEFORCES |
+| import java.io.OutputStream;\nimport java.io.I... |     linear |    1190_C. Tokitsukaze and Duel | CODEFORCES |
+
+## Calculate mean code length by time complexity
+
+Pandas is a powerful library for data analysis; group the dataset by time complexity, apply a function to calculate the average length of the code snippet, and plot the results:
+
+```py
+df.groupby('complexity')['src'].apply(lambda x: x.str.len().mean()).sort_values(ascending=False).plot.barh(color="orange")
+```
+
+<div class="flex justify-center">
+    <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets-server/codecomplex.png"/>
+</div>

--- a/docs/source/quick_start.mdx
+++ b/docs/source/quick_start.mdx
@@ -1,5 +1,7 @@
 # Quickstart
 
+[[open-in-colab]]
+
 In this quickstart, you'll learn how to use the Datasets Server's REST API to:
 
 - Check whether a dataset on the Hub is functional.
@@ -87,6 +89,13 @@ curl https://datasets-server.huggingface.co/is-valid?dataset=rotten_tomatoes \
 </curl>
 </inferencesnippet>
 
+You;ll see the following error if you're trying to access a gated dataset without providing your user token:
+
+```py
+print(data)
+{'error': 'The dataset does not exist, or is not accessible without authentication (private or gated). Please check the spelling of the dataset name or retry with authentication.'}
+```
+
 ## Check dataset validity
 
 The `/valid` endpoint returns a JSON list of datasets stored on the Hub that load without any errors:
@@ -128,6 +137,22 @@ curl https://datasets-server.huggingface.co/valid \
 </curl>
 </inferencesnippet>
 
+This returns a list of all the datasets that load without an error:
+
+```py
+print(data)
+{
+  "valid": [
+    "0n1xus/codexglue",
+    "0n1xus/pytorrent-standalone",
+    "0x7194633/rupile",
+    "51la5/keyword-extraction",
+    ...,
+    ...,
+  ]
+}
+```
+
 To check whether a specific dataset is valid, for example, [Rotten Tomatoes](https://huggingface.co/datasets/rotten_tomatoes), use the `/is-valid` endpoint instead:
 
 <inferencesnippet>
@@ -166,6 +191,13 @@ curl https://datasets-server.huggingface.co/is-valid?dataset=rotten_tomatoes \
 ```
 </curl>
 </inferencesnippet>
+
+This returns whether the `valid` key is `true` or `false`:
+
+```py
+print(data)
+{'valid': True}
+```
 
 ## List configurations and splits
 
@@ -208,6 +240,21 @@ curl https://datasets-server.huggingface.co/splits?dataset=rotten_tomatoes \
 </curl>
 </inferencesnippet>
 
+This returns the available configuration and splits in the dataset:
+
+```py
+print(data)
+{'splits': 
+    [
+        {'dataset': 'rotten_tomatoes', 'config': 'default', 'split': 'train'}, 
+        {'dataset': 'rotten_tomatoes', 'config': 'default', 'split': 'validation'}, 
+        {'dataset': 'rotten_tomatoes', 'config': 'default', 'split': 'test'}
+    ], 
+ 'pending': [], 
+ 'failed': []
+}
+```
+
 ## Preview a dataset
 
 The `/first-rows` endpoint returns a JSON list of the first 100 rows of a dataset. It also returns the types of data features ("columns" data types). You should specify the dataset name, configuration name (you can find out the configuration name from the `/splits` endpoint), and split name of the dataset you'd like to preview:
@@ -248,6 +295,26 @@ curl https://datasets-server.huggingface.co/first-rows?dataset=rotten_tomatoes&c
 ```
 </curl>
 </inferencesnippet>
+
+This returns the first 100 rows of the dataset:
+
+```py
+print(data)
+{'dataset': 'rotten_tomatoes', 'config': 'default', 'split': 'train', 
+ 'features': 
+    [
+        {'feature_idx': 0, 'name': 'text', 'type': {'dtype': 'string', '_type': 'Value'}}, 
+        {'feature_idx': 1, 'name': 'label', 'type': {'names': ['neg', 'pos'], '_type': 'ClassLabel'}}
+    ], 
+ 'rows': 
+    [
+        {'row_idx': 0, 'row': {'text': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .', 'label': 1}, 'truncated_cells': []}, 
+        {'row_idx': 1, 'row': {'text': 'the gorgeously elaborate continuation of " the lord of the rings " trilogy is so huge that a column of words cannot adequately describe co-writer/director peter jackson\'s expanded vision of j . r . r . tolkien\'s middle-earth .', 'label': 1}, 'truncated_cells': []}
+        ...,
+        ...,
+    ],
+}
+```
 
 ## Download slices of a dataset
 
@@ -294,6 +361,27 @@ curl https://datasets-server.huggingface.co/rows?dataset=rotten_tomatoes&config=
 
 You can download slices of 100 rows maximum at a time.
 
+The response looks like:
+
+```py
+print(data)
+{'features': 
+    [
+        {'feature_idx': 0, 'name': 'text', 'type': {'dtype': 'string', '_type': 'Value'}}, 
+        {'feature_idx': 1, 'name': 'label', 'type': {'names': ['neg', 'pos'], '_type': 'ClassLabel'}}], 
+ 'rows': 
+    [
+        {'row_idx': 150, 'row': {'text': 'enormously likable , partly because it is aware of its own grasp of the absurd .', 'label': 1}, 'truncated_cells': []}, 
+        {'row_idx': 151, 'row': {'text': "here's a british flick gleefully unconcerned with plausibility , yet just as determined to entertain you .", 'label': 1}, 'truncated_cells': []}, 
+        {'row_idx': 152, 'row': {'text': "it's an old story , but a lively script , sharp acting and partially animated interludes make just a kiss seem minty fresh .", 'label': 1}, 'truncated_cells': []}, 
+        {'row_idx': 153, 'row': {'text': 'must be seen to be believed .', 'label': 1}, 'truncated_cells': []}, 
+        {'row_idx': 154, 'row': {'text': "ray liotta and jason patric do some of their best work in their underwritten roles , but don't be fooled : nobody deserves any prizes here .", 'label': 1}, 'truncated_cells': []}, 
+        ...,
+        ...,
+    ]
+}
+```
+
 ## Access Parquet files
 
 Datasets Server converts every public dataset on the Hub to the [Parquet](https://parquet.apache.org/) format. The `/parquet` endpoint returns a JSON list of the Parquet URLs for a dataset:
@@ -334,3 +422,18 @@ curl https://datasets-server.huggingface.co/parquet?dataset=rotten_tomatoes \
 ```
 </curl>
 </inferencesnippet>
+
+This returns a URL to the Parquet file:
+
+```py
+print(data)
+{'parquet_files': 
+    [
+        {'dataset': 'rotten_tomatoes', 'config': 'default', 'split': 'test', 'url': 'https://huggingface.co/datasets/rotten_tomatoes/resolve/refs%2Fconvert%2Fparquet/default/rotten_tomatoes-test.parquet', 'filename': 'rotten_tomatoes-test.parquet', 'size': 92206}, 
+        {'dataset': 'rotten_tomatoes', 'config': 'default', 'split': 'train', 'url': 'https://huggingface.co/datasets/rotten_tomatoes/resolve/refs%2Fconvert%2Fparquet/default/rotten_tomatoes-train.parquet', 'filename': 'rotten_tomatoes-train.parquet', 'size': 698845}, 
+        {'dataset': 'rotten_tomatoes', 'config': 'default', 'split': 'validation', 'url': 'https://huggingface.co/datasets/rotten_tomatoes/resolve/refs%2Fconvert%2Fparquet/default/rotten_tomatoes-validation.parquet', 'filename': 'rotten_tomatoes-validation.parquet', 'size': 90001}
+    ], 
+ 'pending': [], 
+ 'failed': []
+}
+```

--- a/docs/source/quick_start.mdx
+++ b/docs/source/quick_start.mdx
@@ -89,7 +89,7 @@ curl https://datasets-server.huggingface.co/is-valid?dataset=rotten_tomatoes \
 </curl>
 </inferencesnippet>
 
-You;ll see the following error if you're trying to access a gated dataset without providing your user token:
+You'll see the following error if you're trying to access a gated dataset without providing your user token:
 
 ```py
 print(data)
@@ -423,7 +423,7 @@ curl https://datasets-server.huggingface.co/parquet?dataset=rotten_tomatoes \
 </curl>
 </inferencesnippet>
 
-This returns a URL to the Parquet file:
+This returns a URL to the Parquet file for each split:
 
 ```py
 print(data)


### PR DESCRIPTION
Based on @mishig25's [feedback](https://huggingface.slack.com/archives/C0311GZ7R6K/p1684484245379859), this adds:
- a response to the code snippets in the Quickstart
- an end-to-end example of using `/parquet` to get a dataset, analyze it, and plot the results
- button to open in a Colab notebook to run examples right away