### PR TITLE
Add Docker internal to extra_hosts

### DIFF
--- a/tools/docker-compose-dev-base.yml
+++ b/tools/docker-compose-dev-base.yml
@@ -25,6 +25,8 @@ services:
       WORKER_MAX_LOAD_PCT: ${WORKER_MAX_LOAD_PCT-70}
       WORKER_MAX_MEMORY_PCT: ${WORKER_MAX_MEMORY_PCT-80}
       WORKER_SLEEP_SECONDS: ${WORKER_SLEEP_SECONDS-15}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     # volumes to local source directory for development
     volumes:
       - ../libs/libcommon/src:/src/libs/libcommon/src


### PR DESCRIPTION
This is required to connect to the local DB instance on Linux; it is already added to `tools/docker-compose-dev-datasets-server.yml`