### PR TITLE
Fix typo in error message

### DIFF
--- a/services/worker/src/worker/job_runners/dataset/config_names.py
+++ b/services/worker/src/worker/job_runners/dataset/config_names.py
@@ -74,7 +74,7 @@ def compute_config_names_response(
     number_of_configs = len(config_name_items)
     if number_of_configs > max_number:
         raise DatasetWithTooManyConfigsError(
-            f"The maximun number of configs allowed is {max_number}, dataset has {number_of_configs} configs."
+            f"The maximum number of configs allowed is {max_number}, dataset has {number_of_configs} configs."
         )
 
     return DatasetConfigNamesResponse(config_names=config_name_items)


### PR DESCRIPTION
I already suggested this typo fix:
- https://github.com/huggingface/datasets-server/pull/1371/files#r1230650727

while reviewing PR:
- #1371

And normally it was taken into account with commit:
- https://github.com/huggingface/datasets-server/pull/1371/commits/1c55c9e6d55e178062eb6b85c33e7c6e71dc13ec

However a subsequent force-push removed this commit:
- https://github.com/huggingface/datasets-server/compare/1c55c9e6d55e178062eb6b85c33e7c6e71dc13ec..d29012b12274ea9d58d3a6c3cdbb2dd64097f202