### PR TITLE
Retry get_parquet_file_and_size

### DIFF
--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -637,7 +637,10 @@ def retry_get_parquet_file_and_size(
         pf, size = retry(on=[pa.ArrowInvalid], sleeps=sleeps)(get_parquet_file_and_size)(url, fs, hf_token)
         return pf, size
     except RuntimeError as err:
-        raise NotAParquetFileError(f"Not a parquet file: '{url}'") from err.__cause__
+        if err.__cause__ and isinstance(err.__cause__, pa.ArrowInvalid):
+            raise NotAParquetFileError(f"Not a parquet file: '{url}'") from err.__cause__
+        else:
+            raise err
 
 
 def fill_builder_info(builder: DatasetBuilder, hf_token: Optional[str]) -> None:

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -14,6 +14,7 @@ import datasets
 import datasets.config
 import datasets.info
 import numpy as np
+import pyarrow as pa
 import pyarrow.parquet as pq
 import requests
 from datasets import DownloadConfig, Features, load_dataset_builder
@@ -616,10 +617,12 @@ def copy_parquet_files(builder: DatasetBuilder) -> List[CommitOperationCopy]:
     return parquet_operations
 
 
+@retry(on=[pa.ArrowInvalid], sleeps=[1, 1, 1, 10, 10, 10])
 def get_parquet_file_and_size(url: str, fs: HTTPFileSystem, hf_token: Optional[str]) -> Tuple[pq.ParquetFile, int]:
     headers = get_authentication_headers_for_url(url, use_auth_token=hf_token)
     f = fs.open(url, headers=headers)
-    return pq.ParquetFile(f), f.size
+    pf = pq.ParquetFile(f)
+    return pf, f.size
 
 
 def fill_builder_info(builder: DatasetBuilder, hf_token: Optional[str]) -> None:


### PR DESCRIPTION
In prod I got an ArrowInvalid when instantiating a pq.ParquetFile for bigcode/the-stack-dedup even though all the parquet files are valid (I ran a script and checked I could get all the pq.ParquetFile objects)