### PR TITLE
Modify TTL index condition

### DIFF
--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -222,4 +222,11 @@ class MigrationsCollector:
                 ),
                 field_name="finished_at",
             ),
+            MigrationQueueDeleteTTLIndex(
+                version="202306201100",
+                description=(
+                    "delete the TTL index on the 'finished_at' field in the queue database to update its TTL condition"
+                ),
+                field_name="finished_at",
+            ),
         ]

--- a/jobs/mongodb_migration/tests/test_deletion_migrations.py
+++ b/jobs/mongodb_migration/tests/test_deletion_migrations.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The HuggingFace Authors.
 
-import pytest
 from libcommon.constants import (
     CACHE_COLLECTION_RESPONSES,
     CACHE_MONGOENGINE_ALIAS,
@@ -117,7 +116,6 @@ def test_metrics_deletion_migration(mongo_host: str) -> None:
         db[METRICS_COLLECTION_CACHE_TOTAL_METRIC].drop()
 
 
-@pytest.mark.skip(reason="temporaly disabled because of index removal")
 def test_queue_delete_ttl_index(mongo_host: str) -> None:
     with MongoResource(database="test_queue_delete_ttl_index", host=mongo_host, mongoengine_alias="queue"):
         Job(

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -24,6 +24,7 @@ from libcommon.constants import (
     QUEUE_COLLECTION_JOBS,
     QUEUE_COLLECTION_LOCKS,
     QUEUE_MONGOENGINE_ALIAS,
+    QUEUE_TTL_SECONDS,
 )
 from libcommon.utils import (
     FlatJobInfo,
@@ -135,6 +136,11 @@ class Job(Document):
             ("status", "namespace", "priority", "type", "created_at"),
             ("status", "namespace", "unicity_id", "priority", "type", "created_at"),
             "-created_at",
+            {
+                "fields": ["finished_at"],
+                "expireAfterSeconds": QUEUE_TTL_SECONDS,
+                "partialFilterExpression": {"status": {"$in": [Status.SUCCESS, Status.ERROR, Status.CANCELLED]}},
+            },
         ],
     }
     type = StringField(required=True)

--- a/libs/libcommon/tests/test_queue.py
+++ b/libs/libcommon/tests/test_queue.py
@@ -376,7 +376,6 @@ def test_queue_get_zombies() -> None:
     assert queue.get_zombies(max_seconds_without_heartbeat=9999999) == []
 
 
-@pytest.mark.skip(reason="temporaly disabled because of index removal")
 def test_has_ttl_index_on_finished_at_field() -> None:
     ttl_index_names = [
         name


### PR DESCRIPTION
Adding a condition TTL index in  Job document.
It will only delete those records with a final state of SUCCESS, ERROR or CANCELLED
