### PR TITLE
Test concurrency in parquet and info

### DIFF
--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -1004,7 +1004,10 @@ def compute_config_parquet_and_info_response(
 
     # check if the repo exists and get the list of refs
     try:
-        refs = hf_api.list_repo_refs(repo_id=dataset, repo_type=DATASET_TYPE)
+        sleeps = [1, 1, 1, 10, 10]
+        refs = retry(on=[requests.exceptions.ConnectionError], sleeps=sleeps)(hf_api.list_repo_refs)(
+            repo_id=dataset, repo_type=DATASET_TYPE
+        )
     except RepositoryNotFoundError as err:
         raise DatasetNotFoundError("The dataset does not exist on the Hub.") from err
 

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -1036,6 +1036,7 @@ def compute_config_parquet_and_info_response(
 
     try:
         sleeps = [1, 1, 1, 1, 1, 10, 10, 10, 10, 100] * 3
+        # ^ timeouts after ~7 minutes
         with lock.git_branch(dataset=dataset, branch=target_revision, job_id=job_id, sleeps=sleeps):
             # create the target revision if we managed to get the parquet files and it does not exist yet
             # (clone from initial commit to avoid cloning all repo's files)

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -1035,7 +1035,7 @@ def compute_config_parquet_and_info_response(
         parquet_operations = convert_to_parquet(builder)
 
     try:
-        sleeps = [1, 1, 1, 10, 10, 100, 100, 100, 300]
+        sleeps = [1, 1, 1, 1, 1, 10, 10, 10, 10, 100] * 3
         with lock.git_branch(dataset=dataset, branch=target_revision, job_id=job_id, sleeps=sleeps):
             # create the target revision if we managed to get the parquet files and it does not exist yet
             # (clone from initial commit to avoid cloning all repo's files)

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -1035,7 +1035,7 @@ def compute_config_parquet_and_info_response(
         parquet_operations = convert_to_parquet(builder)
 
     try:
-        sleeps = [1, 1, 1, 10, 10]  # , 100, 100, 100, 300]
+        sleeps = [1, 1, 1, 10, 10, 100, 100, 100, 300]
         with lock.git_branch(dataset=dataset, branch=target_revision, job_id=job_id, sleeps=sleeps):
             # create the target revision if we managed to get the parquet files and it does not exist yet
             # (clone from initial commit to avoid cloning all repo's files)

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -1002,15 +1002,6 @@ def compute_config_parquet_and_info_response(
     hf_api = HfApi(endpoint=hf_endpoint, token=hf_token)
     committer_hf_api = HfApi(endpoint=hf_endpoint, token=committer_hf_token)
 
-    # check if the repo exists and get the list of refs
-    try:
-        sleeps = [1, 1, 1, 10, 10]
-        refs = retry(on=[requests.exceptions.ConnectionError], sleeps=sleeps)(hf_api.list_repo_refs)(
-            repo_id=dataset, repo_type=DATASET_TYPE
-        )
-    except RepositoryNotFoundError as err:
-        raise DatasetNotFoundError("The dataset does not exist on the Hub.") from err
-
     download_config = DownloadConfig(delete_extracted=True)
     try:
         builder = load_dataset_builder(
@@ -1022,6 +1013,8 @@ def compute_config_parquet_and_info_response(
         )
     except _EmptyDatasetError as err:
         raise EmptyDatasetError(f"{dataset=} is empty.", cause=err) from err
+    except FileNotFoundError as err:
+        raise DatasetNotFoundError("The dataset, or the revision, does not exist on the Hub.") from err
 
     if is_parquet_builder_with_hub_files(builder, hf_endpoint=hf_endpoint):
         parquet_operations = copy_parquet_files(builder)
@@ -1041,20 +1034,25 @@ def compute_config_parquet_and_info_response(
             )
         parquet_operations = convert_to_parquet(builder)
 
-    # create the target revision if we managed to get the parquet files and it does not exist yet
-    # (clone from initial commit to avoid cloning all repo's files)
     try:
-        if all(ref.ref != target_revision for ref in refs.converts):
-            initial_commit = hf_api.list_repo_commits(repo_id=dataset, repo_type=DATASET_TYPE)[-1].commit_id
-            committer_hf_api.create_branch(
-                repo_id=dataset, branch=target_revision, repo_type=DATASET_TYPE, revision=initial_commit, exist_ok=True
-            )
-    except RepositoryNotFoundError as err:
-        raise DatasetNotFoundError("The dataset does not exist on the Hub (was deleted during job).") from err
-
-    try:
-        sleeps = [1, 1, 1, 10, 10, 100, 100, 100, 300]
+        sleeps = [1, 1, 1, 10, 10]  # , 100, 100, 100, 300]
         with lock.git_branch(dataset=dataset, branch=target_revision, job_id=job_id, sleeps=sleeps):
+            # create the target revision if we managed to get the parquet files and it does not exist yet
+            # (clone from initial commit to avoid cloning all repo's files)
+            print(f"working on {dataset=} {config=}")
+            refs = retry(on=[requests.exceptions.ConnectionError], sleeps=[1, 1, 1, 10, 10])(hf_api.list_repo_refs)(
+                repo_id=dataset, repo_type=DATASET_TYPE
+            )
+            if all(ref.ref != target_revision for ref in refs.converts):
+                initial_commit = hf_api.list_repo_commits(repo_id=dataset, repo_type=DATASET_TYPE)[-1].commit_id
+                committer_hf_api.create_branch(
+                    repo_id=dataset,
+                    branch=target_revision,
+                    repo_type=DATASET_TYPE,
+                    revision=initial_commit,
+                    exist_ok=True,
+                )
+            # commit the parquet files
             commit_parquet_conversion(
                 hf_api=hf_api,
                 committer_hf_api=committer_hf_api,
@@ -1065,11 +1063,13 @@ def compute_config_parquet_and_info_response(
                 target_revision=target_revision,
                 commit_message=commit_message,
             )
+            # call the API again to get the list of parquet files
+            target_dataset_info = hf_api.dataset_info(repo_id=dataset, revision=target_revision, files_metadata=True)
     except TimeoutError as err:
         raise LockedDatasetTimeoutError("the dataset is currently locked, please try again later.") from err
+    except RepositoryNotFoundError as err:
+        raise DatasetNotFoundError("The dataset does not exist on the Hub (was deleted during job).") from err
 
-    # call the API again to get the list of parquet files
-    target_dataset_info = hf_api.dataset_info(repo_id=dataset, revision=target_revision, files_metadata=True)
     repo_files = [
         repo_file
         for repo_file in target_dataset_info.siblings

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -1039,7 +1039,6 @@ def compute_config_parquet_and_info_response(
         with lock.git_branch(dataset=dataset, branch=target_revision, job_id=job_id, sleeps=sleeps):
             # create the target revision if we managed to get the parquet files and it does not exist yet
             # (clone from initial commit to avoid cloning all repo's files)
-            print(f"working on {dataset=} {config=}")
             refs = retry(on=[requests.exceptions.ConnectionError], sleeps=[1, 1, 1, 10, 10])(hf_api.list_repo_refs)(
                 repo_id=dataset, repo_type=DATASET_TYPE
             )

--- a/services/worker/tests/fixtures/files.py
+++ b/services/worker/tests/fixtures/files.py
@@ -149,6 +149,40 @@ def dataset_script_with_two_configs_path(tmp_path_factory: pytest.TempPathFactor
     return path
 
 
+# N = 15
+DATASET_SCRIPT_WITH_N_CONFIGS = """
+import os
+
+import datasets
+from datasets import DatasetInfo, BuilderConfig, Features, Split, SplitGenerator, Value
+
+
+class DummyDataset(datasets.GeneratorBasedBuilder):
+
+    BUILDER_CONFIGS = [BuilderConfig(name="config"+str(i)) for i in range(15)]
+
+    def _info(self) -> DatasetInfo:
+        return DatasetInfo(features=Features({"text": Value("string")}))
+
+    def _split_generators(self, dl_manager):
+        return [
+            SplitGenerator(Split.TRAIN, gen_kwargs={"text": self.config.name}),
+        ]
+
+    def _generate_examples(self, text, **kwargs):
+        for i in range(1000):
+            yield i, {"text": text}
+"""
+
+
+@pytest.fixture(scope="session")
+def dataset_script_with_n_configs_path(tmp_path_factory: pytest.TempPathFactory) -> str:
+    path = str(tmp_path_factory.mktemp("data") / "{dataset_name}.py")
+    with open(path, "w", newline="") as f:
+        f.write(DATASET_SCRIPT_WITH_N_CONFIGS)
+    return path
+
+
 DATASET_SCRIPT_WITH_MANUAL_DOWNLOAD = """
 import os
 

--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -261,6 +261,13 @@ def hub_public_legacy_configs(dataset_script_with_two_configs_path: str) -> Iter
 
 
 @pytest.fixture(scope="session")
+def hub_public_n_configs(dataset_script_with_n_configs_path: str) -> Iterator[str]:
+    repo_id = create_hub_dataset_repo(prefix="n_configs", file_paths=[dataset_script_with_n_configs_path])
+    yield repo_id
+    delete_hub_dataset_repo(repo_id=repo_id)
+
+
+@pytest.fixture(scope="session")
 def hub_public_manual_download(dataset_script_with_manual_download_path: str) -> Iterator[str]:
     repo_id = create_hub_dataset_repo(prefix="manual_download", file_paths=[dataset_script_with_manual_download_path])
     yield repo_id

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -6,7 +6,9 @@ from contextlib import contextmanager
 from dataclasses import replace
 from fnmatch import fnmatch
 from http import HTTPStatus
-from typing import Any, Callable, Iterator, List, Optional
+from multiprocessing import Pool
+from pathlib import Path
+from typing import Any, Callable, Iterator, List, Optional, TypedDict
 
 import datasets.builder
 import datasets.info
@@ -25,12 +27,14 @@ from libcommon.exceptions import (
     DatasetWithTooBigExternalFilesError,
     DatasetWithTooManyExternalFilesError,
 )
-from libcommon.processing_graph import ProcessingGraph
+from libcommon.processing_graph import ProcessingGraph, ProcessingStep
+from libcommon.queue import Queue
 from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.simple_cache import CachedArtifactError, upsert_response
-from libcommon.utils import Priority
+from libcommon.utils import JobInfo, JobParams, Priority
 
 from worker.config import AppConfig
+from worker.job_manager import JobManager
 from worker.job_runners.config.parquet_and_info import (
     ConfigParquetAndInfoJobRunner,
     create_commits,
@@ -42,7 +46,9 @@ from worker.job_runners.config.parquet_and_info import (
     raise_if_too_big_from_external_data_files,
     raise_if_too_big_from_hub,
 )
+from worker.job_runners.dataset.config_names import DatasetConfigNamesJobRunner
 from worker.resources import LibrariesResource
+from worker.utils import CompleteJobResult
 
 from ...constants import CI_HUB_ENDPOINT, CI_USER_TOKEN
 from ...fixtures.hub import HubDatasetTest
@@ -649,3 +655,142 @@ def test_create_commits(
     filenames = hf_api.list_repo_files(repo_id=repo_id, repo_type="dataset")
     for i in range(NUM_FILES):
         assert f"{directory}/file{i}.txt" in filenames
+
+
+GetDatasetConfigNamesJobRunner = Callable[[str, AppConfig], DatasetConfigNamesJobRunner]
+
+
+@pytest.fixture
+def get_dataset_config_names_job_runner(
+    libraries_resource: LibrariesResource,
+    cache_mongo_resource: CacheMongoResource,
+    queue_mongo_resource: QueueMongoResource,
+) -> GetDatasetConfigNamesJobRunner:
+    def _get_job_runner(
+        dataset: str,
+        app_config: AppConfig,
+    ) -> DatasetConfigNamesJobRunner:
+        processing_step_name = DatasetConfigNamesJobRunner.get_job_type()
+        processing_graph = ProcessingGraph(
+            {
+                processing_step_name: {
+                    "input_type": "dataset",
+                    "job_runner_version": DatasetConfigNamesJobRunner.get_job_runner_version(),
+                }
+            }
+        )
+        return DatasetConfigNamesJobRunner(
+            job_info={
+                "type": DatasetConfigNamesJobRunner.get_job_type(),
+                "params": {
+                    "dataset": dataset,
+                    "revision": "revision",
+                    "config": None,
+                    "split": None,
+                },
+                "job_id": "job_id",
+                "priority": Priority.NORMAL,
+            },
+            app_config=app_config,
+            processing_step=processing_graph.get_processing_step(processing_step_name),
+            hf_datasets_cache=libraries_resource.hf_datasets_cache,
+        )
+
+    return _get_job_runner
+
+
+class JobRunnerArgs(TypedDict):
+    dataset: str
+    revision: str
+    config: str
+    app_config: AppConfig
+    tmp_path: Path
+
+
+def launch_job_runner(job_runner_args: JobRunnerArgs) -> CompleteJobResult:
+    config = job_runner_args["config"]
+    dataset = job_runner_args["dataset"]
+    revision = job_runner_args["revision"]
+    app_config = job_runner_args["app_config"]
+    tmp_path = job_runner_args["tmp_path"]
+    job_runner = ConfigParquetAndInfoJobRunner(
+        job_info=JobInfo(
+            job_id=f"job_{config}",
+            type="config-parquet-and-info",
+            params=JobParams(dataset=dataset, revision=revision, config=config, split=None),
+            priority=Priority.NORMAL,
+        ),
+        app_config=app_config,
+        processing_step=ProcessingStep(
+            name="config-parquet-and-info",
+            input_type="config",
+            job_runner_version=ConfigParquetAndInfoJobRunner.get_job_runner_version(),
+        ),
+        hf_datasets_cache=tmp_path,
+    )
+    return job_runner.compute()
+
+
+def test_concurrency(
+    hub_public_n_configs: str,
+    app_config: AppConfig,
+    tmp_path: Path,
+    get_dataset_config_names_job_runner: GetDatasetConfigNamesJobRunner,
+    queue_mongo_resource: QueueMongoResource,
+    cache_mongo_resource: CacheMongoResource,
+) -> None:
+    """
+    Test that multiple job runners (to compute config-parquet-and-info) can run in parallel,
+    without having conflicts when sending commits to the Hub.
+    For this test, we need a lot of configs for the same dataset (say 20) and one job runner for each.
+    Ideally we would try for both quick and slow jobs.
+    """
+    repo_id = hub_public_n_configs
+    hf_api = HfApi(endpoint=CI_HUB_ENDPOINT, token=CI_USER_TOKEN)
+    revision = hf_api.dataset_info(repo_id=repo_id, files_metadata=False).sha
+    if revision is None:
+        raise ValueError(f"Could not find revision for dataset {repo_id}")
+
+    # fill the cache for the step dataset-config-names, required by the job_runner
+    # it's a lot of code 😅
+    job_info = JobInfo(
+        job_id="not_used",
+        type="dataset-config-names",
+        params=JobParams(dataset=repo_id, revision=revision, config=None, split=None),
+        priority=Priority.NORMAL,
+    )
+    queue = Queue()
+    queue.create_jobs([job_info])
+    job_info = queue.start_job(job_types_only=["dataset-config-names"])
+    job_manager = JobManager(
+        job_info=job_info,
+        app_config=app_config,
+        processing_graph=ProcessingGraph(
+            {
+                "dataset-config-names": {
+                    "input_type": "dataset",
+                    "provides_dataset_config_names": True,
+                    "job_runner_version": DatasetConfigNamesJobRunner.get_job_runner_version(),
+                }
+            }
+        ),
+        job_runner=get_dataset_config_names_job_runner(repo_id, app_config),
+    )
+    job_result = job_manager.run_job()
+    job_manager.finish(job_result=job_result)
+    if not job_result["output"]:
+        raise ValueError("Could not get config names")
+    configs = [str(config_name["config"]) for config_name in job_result["output"]["content"]["config_names"]]
+
+    # launch the job runners
+    NUM_JOB_RUNNERS = 10
+    with Pool(NUM_JOB_RUNNERS) as pool:
+        pool.map(
+            launch_job_runner,
+            [
+                JobRunnerArgs(
+                    dataset=repo_id, revision=revision, config=config, app_config=app_config, tmp_path=tmp_path
+                )
+                for config in configs
+            ],
+        )


### PR DESCRIPTION
It adds a test on the concurrency of job runners on the step `config-parquet-and-info`(which creates `refs/convert/parquet` and uploads parquet files), to detect when the lock is not respected, leading to `CreateCommitError`.

Also:
- group all the code that accesses the Hub inside the lock (create the "branch", send the commit, get the list of files)
- retry "hf_api.list_repo_refs" on connection error (I saw it during the tests)
- adapt the sleep intervals

---

First: tests should fail (https://github.com/huggingface/datasets-server/actions/runs/5335283399/jobs/9668277338)
```
FAILED tests/job_runners/config/test_parquet_and_info.py::test_concurrency - huggingface_hub.utils._errors.HfHubHTTPError: 500 Server Error: Internal Server Error for url: https://hub-ci.huggingface.co/api/datasets/__DUMMY_DATASETS_SERVER_USER__/n_configs-16873575569236/branch/refs%2Fconvert%2Fparquet (Request ID: Root=1-64930878-4a2840cd4fc36b1752b0eac0)
```

Then, after rebasing after merging https://github.com/huggingface/datasets-server/pull/1414 into main, the test should pass (https://github.com/huggingface/datasets-server/actions/runs/5335527787/jobs/9669124731)
