### PR TITLE
Ensure only one job is started for the same unicity_id

### DIFF
--- a/jobs/cache_maintenance/tests/test_collect_metrics.py
+++ b/jobs/cache_maintenance/tests/test_collect_metrics.py
@@ -24,7 +24,7 @@ def test_collect_metrics() -> None:
     )
     processing_step = processing_graph.get_processing_step(processing_step_name)
     queue = Queue()
-    queue.upsert_job(
+    queue.add_job(
         job_type=processing_step.job_type, dataset="dataset", revision="revision", config="config", split="split"
     )
     upsert_response(

--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -44,6 +44,9 @@ from mongodb_migration.migrations._20230516101500_queue_job_add_revision import 
 from mongodb_migration.migrations._20230516101600_queue_delete_index_without_revision import (
     MigrationQueueDeleteIndexWithoutRevision,
 )
+from mongodb_migration.migrations._20230622131500_lock_add_owner import (
+    MigrationAddOwnerToQueueLock,
+)
 from mongodb_migration.renaming_migrations import (
     CacheRenamingMigration,
     QueueRenamingMigration,
@@ -228,5 +231,8 @@ class MigrationsCollector:
                     "delete the TTL index on the 'finished_at' field in the queue database to update its TTL condition"
                 ),
                 field_name="finished_at",
+            ),
+            MigrationAddOwnerToQueueLock(
+                version="20230622131800", description="add 'owner' field copying the job_id value"
             ),
         ]

--- a/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230622131500_lock_add_owner.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230622131500_lock_add_owner.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+import logging
+
+from libcommon.constants import QUEUE_COLLECTION_LOCKS, QUEUE_MONGOENGINE_ALIAS
+from libcommon.queue import Lock
+from mongoengine.connection import get_db
+
+from mongodb_migration.check import check_documents
+from mongodb_migration.migration import Migration
+
+
+# connection already occurred in the main.py (caveat: we use globals)
+class MigrationAddOwnerToQueueLock(Migration):
+    def up(self) -> None:
+        # See https://docs.mongoengine.org/guide/migration.html#example-1-addition-of-a-field
+        logging.info("If missing, add the owner field with the same value as the field job_id to the locks")
+        db = get_db(QUEUE_MONGOENGINE_ALIAS)
+        db[QUEUE_COLLECTION_LOCKS].update_many(
+            {"owner": {"$exists": False}}, [{"$set": {"owner": "$job_id"}}]  # type: ignore
+        )
+
+    def down(self) -> None:
+        logging.info("Remove the owner field from all the locks")
+        db = get_db(QUEUE_MONGOENGINE_ALIAS)
+        db[QUEUE_COLLECTION_LOCKS].update_many({}, {"$unset": {"owner": ""}})
+
+    def validate(self) -> None:
+        logging.info("Ensure that a random selection of locks have the 'owner' field")
+
+        check_documents(DocCls=Lock, sample_size=10)

--- a/jobs/mongodb_migration/tests/migrations/test_20230622131500_lock_add_owner.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230622131500_lock_add_owner.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+import pytest
+from typing import Optional
+
+from libcommon.constants import QUEUE_COLLECTION_LOCKS, QUEUE_MONGOENGINE_ALIAS
+from libcommon.resources import MongoResource
+from mongoengine.connection import get_db
+
+from mongodb_migration.migrations._20230622131500_lock_add_owner import (
+    MigrationAddOwnerToQueueLock,
+)
+
+
+def assert_owner(key: str, owner: Optional[str]) -> None:
+    db = get_db(QUEUE_MONGOENGINE_ALIAS)
+    entry = db[QUEUE_COLLECTION_LOCKS].find_one({"key": key})
+    assert entry is not None
+    if owner is None:
+        assert "owner" not in entry or entry["owner"] is None
+    else:
+        assert entry["owner"] == owner
+
+
+def test_lock_add_owner(mongo_host: str) -> None:
+    with MongoResource(database="test_lock_add_owner", host=mongo_host, mongoengine_alias="queue"):
+        db = get_db(QUEUE_MONGOENGINE_ALIAS)
+        db[QUEUE_COLLECTION_LOCKS].insert_many(
+            [
+                {
+                    "key": "key1",
+                    "job_id": "job_id1",
+                    "created_at": "2022-01-01T00:00:00.000000Z",
+                },
+                {
+                    "key": "key2",
+                    "job_id": None,
+                    "created_at": "2022-01-01T00:00:00.000000Z",
+                },
+                {
+                    "key": "key3",
+                    "job_id": "job_id3",
+                    "owner": "owner3",
+                    "created_at": "2022-01-01T00:00:00.000000Z",
+                },
+            ]
+        )
+
+        migration = MigrationAddOwnerToQueueLock(
+            version="20230622131500",
+            description="add owner field to locks",
+        )
+        migration.up()
+
+        assert_owner("key1", "job_id1")
+        assert_owner("key2", None)
+        assert_owner("key3", "owner3")
+
+        migration.down()
+        assert_owner("key1", None)
+        assert_owner("key2", None)
+        assert_owner("key3", None)
+
+        db[QUEUE_COLLECTION_LOCKS].drop()

--- a/jobs/mongodb_migration/tests/migrations/test_20230622131500_lock_add_owner.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230622131500_lock_add_owner.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
 
-import pytest
 from typing import Optional
 
 from libcommon.constants import QUEUE_COLLECTION_LOCKS, QUEUE_MONGOENGINE_ALIAS

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -408,45 +408,6 @@ class Queue:
         except Exception:
             return 0
 
-    def cancel_jobs(
-        self,
-        job_type: str,
-        dataset: str,
-        config: Optional[str] = None,
-        split: Optional[str] = None,
-        statuses_to_cancel: Optional[List[Status]] = None,
-    ) -> List[JobDict]:
-        """Cancel jobs from the queue.
-
-        Note that the jobs for all the revisions are canceled.
-
-        Returns the list of canceled jobs (as JobDict, before they are canceled, to be able to know their previous
-        status)
-
-        Args:
-            job_type (`str`): The type of the job
-            dataset (`str`): The dataset on which to apply the job.
-            config (`str`, optional): The config on which to apply the job.
-            split (`str`, optional): The config on which to apply the job.
-            statuses_to_cancel (`list[Status]`, optional): The list of statuses to cancel. Defaults to
-                [Status.WAITING, Status.STARTED].
-
-        Returns:
-            `list[JobDict]`: The list of canceled jobs
-        """
-        if statuses_to_cancel is None:
-            statuses_to_cancel = [Status.WAITING, Status.STARTED]
-        existing = Job.objects(
-            type=job_type,
-            dataset=dataset,
-            config=config,
-            split=split,
-            status__in=statuses_to_cancel,
-        )
-        job_dicts = [job.to_dict() for job in existing]
-        existing.update(finished_at=get_datetime(), status=Status.CANCELLED)
-        return job_dicts
-
     def cancel_jobs_by_job_id(self, job_ids: List[str]) -> int:
         """Cancel jobs from the queue.
 

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -96,7 +96,7 @@ class JobDoesNotExistError(DoesNotExist):
     pass
 
 
-class AlreadyStartedError(Exception):
+class AlreadyStartedJobError(Exception):
     pass
 
 
@@ -559,7 +559,7 @@ class Queue:
             the started job
 
         Raises:
-            AlreadyStartedError: if the job is already started by another worker.
+            AlreadyStartedJobError: if a started job already exist for the same unicity_id.
             LockTimeoutError: if the lock could not be acquired after 20 retries.
         """
         # could be a method of Job
@@ -577,7 +577,7 @@ class Queue:
                 if num_started_jobs > 0:
                     if num_started_jobs > 1:
                         logging.critical(f"job {job.unicity_id} has been started {num_started_jobs} times. Max is 1.")
-                    raise AlreadyStartedError(f"job {job.unicity_id} has been started by another worker")
+                    raise AlreadyStartedJobError(f"job {job.unicity_id} has been started by another worker")
                 # get the most recent one
                 first_job = waiting_jobs.first()
                 if not first_job:
@@ -619,7 +619,7 @@ class Queue:
         Raises:
             EmptyQueueError: if there is no job in the queue, within the limit of the maximum number of started jobs
             for a dataset
-            AlreadyStartedError: if the job is locked
+            AlreadyStartedJobError: if a started job already exist for the same unicity_id
             LockTimeoutError: if the lock cannot be acquired
 
         Returns: the job id, the type, the input arguments: dataset, revision, config and split

--- a/libs/libcommon/tests/test_backfill.py
+++ b/libs/libcommon/tests/test_backfill.py
@@ -772,7 +772,9 @@ def test_delete_jobs(
             job.created_at = created_at
             job.save()
         if status is Status.STARTED:
-            queue._start_job(job)
+            job.status = Status.STARTED
+            job.started_at = datetime.now()
+            job.save()
 
     dataset_backfill_plan = get_dataset_backfill_plan(processing_graph=processing_graph)
     expected_in_process = [ARTIFACT_DA] if existing_jobs else []

--- a/libs/libcommon/tests/test_backfill.py
+++ b/libs/libcommon/tests/test_backfill.py
@@ -767,7 +767,7 @@ def test_delete_jobs(
     queue = Queue()
     for job_spec in existing_jobs:
         (priority, status, created_at) = job_spec
-        job = queue._add_job(job_type=STEP_DA, dataset="dataset", revision="revision", priority=priority)
+        job = queue.add_job(job_type=STEP_DA, dataset="dataset", revision="revision", priority=priority)
         if created_at is not None:
             job.created_at = created_at
             job.save()

--- a/libs/libcommon/tests/test_orchestrator.py
+++ b/libs/libcommon/tests/test_orchestrator.py
@@ -142,7 +142,7 @@ def test_finish_job(
     processing_graph: ProcessingGraph,
     artifacts_to_create: List[str],
 ) -> None:
-    Queue()._add_job(
+    Queue().add_job(
         dataset=DATASET_NAME,
         revision=REVISION_NAME,
         config=None,

--- a/libs/libcommon/tests/test_queue.py
+++ b/libs/libcommon/tests/test_queue.py
@@ -408,7 +408,7 @@ def increment(tmp_file: Path) -> None:
 
 def locked_increment(tmp_file: Path) -> None:
     sleeps = [0.05, 0.05, 0.05, 1, 1, 1, 1, 1, 1, 5, 5, 5, 5]
-    with lock(key="test_lock", job_id=str(os.getpid()), sleeps=sleeps):
+    with lock(key="test_lock", owner=str(os.getpid()), sleeps=sleeps):
         increment(tmp_file)
 
 
@@ -431,7 +431,7 @@ def git_branch_locked_increment(tmp_file: Path) -> None:
     sleeps = [0.05, 0.05, 0.05, 1, 1, 1, 1, 1, 1, 5, 5, 5, 5]
     dataset = "dataset"
     branch = "refs/convert/parquet"
-    with lock.git_branch(dataset=dataset, branch=branch, job_id=str(os.getpid()), sleeps=sleeps):
+    with lock.git_branch(dataset=dataset, branch=branch, owner=str(os.getpid()), sleeps=sleeps):
         increment(tmp_file)
 
 
@@ -449,5 +449,5 @@ def test_lock_git_branch(tmp_path_factory: pytest.TempPathFactory, queue_mongo_r
         assert int(f.read()) == expected
     assert Lock.objects().count() == 1
     assert Lock.objects().get().key == json.dumps({"dataset": "dataset", "branch": "refs/convert/parquet"})
-    assert Lock.objects().get().job_id is None
+    assert Lock.objects().get().owner is None
     Lock.objects().delete()

--- a/libs/libcommon/tests/test_queue.py
+++ b/libs/libcommon/tests/test_queue.py
@@ -76,42 +76,6 @@ def test_add_job() -> None:
 
 
 @pytest.mark.parametrize(
-    "statuses_to_cancel, expected_remaining_number",
-    [
-        (None, 0),
-        ([Status.WAITING], 1),
-        ([Status.WAITING, Status.STARTED], 0),
-        ([Status.STARTED], 1),
-        ([Status.SUCCESS], 2),
-    ],
-)
-def test_cancel_jobs(statuses_to_cancel: Optional[List[Status]], expected_remaining_number: int) -> None:
-    test_type = "test_type"
-    test_dataset = "test_dataset"
-    test_revision_1 = "test_revision_1"
-    test_revision_2 = "test_revision_2"
-    queue = Queue()
-    queue.add_job(job_type=test_type, dataset=test_dataset, revision=test_revision_1)
-    queue.add_job(job_type=test_type, dataset=test_dataset, revision=test_revision_2)
-    queue.start_job()
-
-    canceled_job_dicts = queue.cancel_jobs(
-        job_type=test_type, dataset=test_dataset, statuses_to_cancel=statuses_to_cancel
-    )
-    assert len(canceled_job_dicts) == 2 - expected_remaining_number
-
-    if expected_remaining_number == 0:
-        with pytest.raises(EmptyQueueError):
-            queue.start_job()
-    assert queue.is_job_in_process(job_type=test_type, dataset=test_dataset, revision=test_revision_1) == (
-        statuses_to_cancel is not None and Status.STARTED not in statuses_to_cancel
-    )
-    assert queue.is_job_in_process(job_type=test_type, dataset=test_dataset, revision=test_revision_2) == (
-        statuses_to_cancel is not None and Status.WAITING not in statuses_to_cancel
-    )
-
-
-@pytest.mark.parametrize(
     "jobs_ids,job_ids_to_cancel,expected_canceled_number",
     [
         (["a", "b"], ["a", "b"], 2),

--- a/services/admin/src/admin/routes/force_refresh.py
+++ b/services/admin/src/admin/routes/force_refresh.py
@@ -59,7 +59,7 @@ def create_force_refresh_endpoint(
                 hf_timeout_seconds=hf_timeout_seconds,
             )
             revision = get_dataset_git_revision(dataset=dataset, hf_endpoint=hf_endpoint, hf_token=hf_token)
-            Queue().upsert_job(job_type=job_type, dataset=dataset, revision=revision, config=config, split=split)
+            Queue().add_job(job_type=job_type, dataset=dataset, revision=revision, config=config, split=split)
             return get_json_ok_response(
                 {"status": "ok"},
                 max_age=0,

--- a/services/api/tests/routes/test_endpoint.py
+++ b/services/api/tests/routes/test_endpoint.py
@@ -151,7 +151,7 @@ def test_get_cache_entry_from_steps() -> None:
 
     # pending job throws exception
     queue = Queue()
-    queue.upsert_job(job_type="dataset-split-names", dataset=dataset, revision=revision, config=config)
+    queue.add_job(job_type="dataset-split-names", dataset=dataset, revision=revision, config=config)
     non_existent_step = processing_graph.get_processing_step("dataset-split-names")
     with patch("libcommon.dataset.get_dataset_git_revision", return_value=revision):
         # ^ the dataset does not exist on the Hub, we don't want to raise an issue here

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -1034,7 +1034,7 @@ def compute_config_parquet_and_info_response(
     try:
         sleeps = [1, 1, 1, 1, 1, 10, 10, 10, 10, 100] * 3
         # ^ timeouts after ~7 minutes
-        with lock.git_branch(dataset=dataset, branch=target_revision, job_id=job_id, sleeps=sleeps):
+        with lock.git_branch(dataset=dataset, branch=target_revision, owner=job_id, sleeps=sleeps):
             # create the target revision if we managed to get the parquet files and it does not exist yet
             # (clone from initial commit to avoid cloning all repo's files)
             refs = retry(on=[requests.exceptions.ConnectionError], sleeps=[1, 1, 1, 10, 10])(hf_api.list_repo_refs)(

--- a/services/worker/src/worker/loop.py
+++ b/services/worker/src/worker/loop.py
@@ -11,7 +11,12 @@ from typing import Optional, TypedDict
 import orjson
 from filelock import FileLock
 from libcommon.processing_graph import ProcessingGraph
-from libcommon.queue import EmptyQueueError, LockedJobError, Queue
+from libcommon.queue import (
+    AlreadyStartedError,
+    EmptyQueueError,
+    LockTimeoutError,
+    Queue,
+)
 from libcommon.utils import JobInfo, get_datetime
 from psutil import cpu_count, disk_usage, getloadavg, swap_memory, virtual_memory
 
@@ -126,7 +131,7 @@ class Loop:
             )
             self.set_worker_state(current_job_info=job_info)
             logging.debug(f"job assigned: {job_info}")
-        except (EmptyQueueError, LockedJobError) as e:
+        except (EmptyQueueError, AlreadyStartedError, LockTimeoutError) as e:
             self.set_worker_state(current_job_info=None)
             logging.debug(e)
             return False

--- a/services/worker/src/worker/loop.py
+++ b/services/worker/src/worker/loop.py
@@ -12,7 +12,7 @@ import orjson
 from filelock import FileLock
 from libcommon.processing_graph import ProcessingGraph
 from libcommon.queue import (
-    AlreadyStartedError,
+    AlreadyStartedJobError,
     EmptyQueueError,
     LockTimeoutError,
     NoWaitingJobError,
@@ -132,7 +132,7 @@ class Loop:
             )
             self.set_worker_state(current_job_info=job_info)
             logging.debug(f"job assigned: {job_info}")
-        except (EmptyQueueError, AlreadyStartedError, LockTimeoutError, NoWaitingJobError) as e:
+        except (EmptyQueueError, AlreadyStartedJobError, LockTimeoutError, NoWaitingJobError) as e:
             self.set_worker_state(current_job_info=None)
             logging.debug(e)
             return False

--- a/services/worker/src/worker/loop.py
+++ b/services/worker/src/worker/loop.py
@@ -11,7 +11,7 @@ from typing import Optional, TypedDict
 import orjson
 from filelock import FileLock
 from libcommon.processing_graph import ProcessingGraph
-from libcommon.queue import EmptyQueueError, Queue
+from libcommon.queue import EmptyQueueError, LockedJobError, Queue
 from libcommon.utils import JobInfo, get_datetime
 from psutil import cpu_count, disk_usage, getloadavg, swap_memory, virtual_memory
 
@@ -126,9 +126,9 @@ class Loop:
             )
             self.set_worker_state(current_job_info=job_info)
             logging.debug(f"job assigned: {job_info}")
-        except EmptyQueueError:
+        except (EmptyQueueError, LockedJobError) as e:
             self.set_worker_state(current_job_info=None)
-            logging.debug("no job in the queue")
+            logging.debug(e)
             return False
 
         job_runner = self.job_runner_factory.create_job_runner(job_info)

--- a/services/worker/src/worker/loop.py
+++ b/services/worker/src/worker/loop.py
@@ -15,6 +15,7 @@ from libcommon.queue import (
     AlreadyStartedError,
     EmptyQueueError,
     LockTimeoutError,
+    NoWaitingJobError,
     Queue,
 )
 from libcommon.utils import JobInfo, get_datetime
@@ -131,7 +132,7 @@ class Loop:
             )
             self.set_worker_state(current_job_info=job_info)
             logging.debug(f"job assigned: {job_info}")
-        except (EmptyQueueError, AlreadyStartedError, LockTimeoutError) as e:
+        except (EmptyQueueError, AlreadyStartedError, LockTimeoutError, NoWaitingJobError) as e:
             self.set_worker_state(current_job_info=None)
             logging.debug(e)
             return False

--- a/services/worker/tests/test_job_manager.py
+++ b/services/worker/tests/test_job_manager.py
@@ -125,7 +125,7 @@ def test_backfill(priority: Priority, app_config: AppConfig) -> None:
     root_step = graph.get_processing_step("dummy")
     queue = Queue()
     assert Job.objects().count() == 0
-    queue.upsert_job(
+    queue.add_job(
         job_type=root_step.job_type,
         dataset="dataset",
         revision="revision",
@@ -195,7 +195,7 @@ def test_job_runner_set_crashed(
 
     queue = Queue()
     assert Job.objects().count() == 0
-    queue.upsert_job(
+    queue.add_job(
         job_type=test_processing_step.job_type,
         dataset=dataset,
         revision=revision,

--- a/services/worker/tests/test_loop.py
+++ b/services/worker/tests/test_loop.py
@@ -69,7 +69,7 @@ def test_process_next_job(
     revision = "revision"
     config = "config"
     split = "split"
-    loop.queue.upsert_job(job_type=job_type, dataset=dataset, revision=revision, config=config, split=split)
+    loop.queue.add_job(job_type=job_type, dataset=dataset, revision=revision, config=config, split=split)
     assert loop.queue.is_job_in_process(
         job_type=job_type, dataset=dataset, revision=revision, config=config, split=split
     )


### PR DESCRIPTION
To avoid multiple job runners getting the same job at the same time, for a given unicity_id (identifies job type + parameters):
- a lock is used during the update of the selected job
- we ensure no other job is already started
- we select the newest (in date order) job from all the waiting jobs and start it (status, started_at)
- we cancel all the other waiting jobs

Should fix #1323.
