### PR TITLE
Remove too restrictive __all__ definitions

### DIFF
--- a/jobs/mongodb_migration/src/mongodb_migration/database_migrations.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/database_migrations.py
@@ -5,7 +5,6 @@ import types
 from typing import Generic, Type, TypeVar
 
 from mongoengine import Document
-from mongoengine.errors import DoesNotExist
 from mongoengine.fields import StringField
 from mongoengine.queryset.queryset import QuerySet
 

--- a/jobs/mongodb_migration/src/mongodb_migration/database_migrations.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/database_migrations.py
@@ -4,7 +4,8 @@
 import types
 from typing import Generic, Type, TypeVar
 
-from mongoengine import Document, DoesNotExist
+from mongoengine import Document
+from mongoengine.errors import DoesNotExist
 from mongoengine.fields import StringField
 from mongoengine.queryset.queryset import QuerySet
 
@@ -55,7 +56,3 @@ class DatabaseMigration(Document):
 def _clean_maintenance_database() -> None:
     """Delete all the jobs in the database"""
     DatabaseMigration.drop_collection()  # type: ignore
-
-
-# explicit re-export
-__all__ = ["DoesNotExist"]

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -196,7 +196,7 @@ class Job(Document):
         )
 
     @staticmethod
-    def get(job_id: str):
+    def get(job_id: str) -> Job:
         try:
             Job.objects(pk=job_id).get()
         except DoesNotExist as e:

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -195,10 +195,10 @@ class Job(Document):
             }
         )
 
-    @staticmethod
-    def get(job_id: str) -> "Job":
+    @classmethod
+    def get(cls, job_id: str) -> "Job":
         try:
-            return Job.objects(pk=job_id).get()
+            return cls.objects(pk=job_id).get()
         except DoesNotExist as e:
             raise JobDoesNotExistError(f"Job does not exist: {job_id=}") from e
 

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -15,8 +15,8 @@ from typing import Generic, List, Literal, Optional, Sequence, Type, TypedDict, 
 
 import pandas as pd
 import pytz
-from mongoengine import Document, DoesNotExist
-from mongoengine.errors import NotUniqueError
+from mongoengine import Document
+from mongoengine.errors import DoesNotExist, NotUniqueError
 from mongoengine.fields import DateTimeField, EnumField, StringField
 from mongoengine.queryset.queryset import QuerySet
 
@@ -918,7 +918,3 @@ def _clean_queue_database() -> None:
     """Delete all the jobs in the database"""
     Job.drop_collection()  # type: ignore
     Lock.drop_collection()  # type: ignore
-
-
-# explicit re-export
-__all__ = ["DoesNotExist"]

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -196,9 +196,9 @@ class Job(Document):
         )
 
     @staticmethod
-    def get(job_id: str) -> Job:
+    def get(job_id: str) -> "Job":
         try:
-            Job.objects(pk=job_id).get()
+            return Job.objects(pk=job_id).get()
         except DoesNotExist as e:
             raise JobDoesNotExistError(f"Job does not exist: {job_id=}") from e
 

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -92,6 +92,10 @@ class EmptyQueueError(Exception):
     pass
 
 
+class JobDoesNotExistError(DoesNotExist):
+    pass
+
+
 # States:
 # - waiting: started_at is None and finished_at is None: waiting jobs
 # - started: started_at is not None and finished_at is None: started jobs
@@ -190,6 +194,13 @@ class Job(Document):
                 "priority": self.priority,
             }
         )
+
+    @staticmethod
+    def get(job_id: str):
+        try:
+            Job.objects(pk=job_id).get()
+        except DoesNotExist as e:
+            raise JobDoesNotExistError(f"Job does not exist: {job_id=}") from e
 
     def flat_info(self) -> FlatJobInfo:
         return FlatJobInfo(

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -124,6 +124,10 @@ CachedResponse.config.required = False  # type: ignore
 CachedResponse.split.required = False  # type: ignore
 
 
+class CacheEntryDoesNotExistError(DoesNotExist):
+    pass
+
+
 # Note: we let the exceptions throw (ie DocumentTooLarge): it's the responsibility of the caller to manage them
 def upsert_response(
     kind: str,
@@ -196,15 +200,18 @@ class CacheEntryWithoutContent(TypedDict):
     job_runner_version: Optional[int]
 
 
-# Note: we let the exceptions throw (ie DoesNotExist): it's the responsibility of the caller to manage them
+# Note: we let the exceptions throw: it's the responsibility of the caller to manage them
 def get_response_without_content(
     kind: str, dataset: str, config: Optional[str] = None, split: Optional[str] = None
 ) -> CacheEntryWithoutContent:
-    response = (
-        CachedResponse.objects(kind=kind, dataset=dataset, config=config, split=split)
-        .only("http_status", "error_code", "job_runner_version", "dataset_git_revision", "progress")
-        .get()
-    )
+    try:
+        response = (
+            CachedResponse.objects(kind=kind, dataset=dataset, config=config, split=split)
+            .only("http_status", "error_code", "job_runner_version", "dataset_git_revision", "progress")
+            .get()
+        )
+    except DoesNotExist as e:
+        raise CacheEntryDoesNotExistError(f"Cache entry does not exist: {kind=} {dataset=} {config=} {split=}") from e
     return {
         "http_status": response.http_status,
         "error_code": response.error_code,
@@ -224,15 +231,18 @@ class CacheEntryMetadata(CacheEntryWithoutContent):
     updated_at: datetime
 
 
-# Note: we let the exceptions throw (ie DoesNotExist): it's the responsibility of the caller to manage them
+# Note: we let the exceptions throw: it's the responsibility of the caller to manage them
 def get_response_metadata(
     kind: str, dataset: str, config: Optional[str] = None, split: Optional[str] = None
 ) -> CacheEntryMetadata:
-    response = (
-        CachedResponse.objects(kind=kind, dataset=dataset, config=config, split=split)
-        .only("http_status", "error_code", "job_runner_version", "dataset_git_revision", "progress", "updated_at")
-        .get()
-    )
+    try:
+        response = (
+            CachedResponse.objects(kind=kind, dataset=dataset, config=config, split=split)
+            .only("http_status", "error_code", "job_runner_version", "dataset_git_revision", "progress", "updated_at")
+            .get()
+        )
+    except DoesNotExist as e:
+        raise CacheEntryDoesNotExistError(f"Cache entry does not exist: {kind=} {dataset=} {config=} {split=}") from e
     return {
         "http_status": response.http_status,
         "error_code": response.error_code,
@@ -283,13 +293,16 @@ class CachedArtifactError(Exception):
         }
 
 
-# Note: we let the exceptions throw (ie DoesNotExist): it's the responsibility of the caller to manage them
+# Note: we let the exceptions throw: it's the responsibility of the caller to manage them
 def get_response(kind: str, dataset: str, config: Optional[str] = None, split: Optional[str] = None) -> CacheEntry:
-    response = (
-        CachedResponse.objects(kind=kind, dataset=dataset, config=config, split=split)
-        .only("content", "http_status", "error_code", "job_runner_version", "dataset_git_revision", "progress")
-        .get()
-    )
+    try:
+        response = (
+            CachedResponse.objects(kind=kind, dataset=dataset, config=config, split=split)
+            .only("content", "http_status", "error_code", "job_runner_version", "dataset_git_revision", "progress")
+            .get()
+        )
+    except DoesNotExist as e:
+        raise CacheEntryDoesNotExistError(f"Cache entry does not exist: {kind=} {dataset=} {config=} {split=}") from e
     return {
         "content": response.content,
         "http_status": response.http_status,
@@ -300,17 +313,26 @@ def get_response(kind: str, dataset: str, config: Optional[str] = None, split: O
     }
 
 
-# Note: we let the exceptions throw (ie DoesNotExist): it's the responsibility of the caller to manage them
+# Note: we let the exceptions throw: it's the responsibility of the caller to manage them
 def get_response_with_details(
     kind: str, dataset: str, config: Optional[str] = None, split: Optional[str] = None
 ) -> CacheEntryWithDetails:
-    response = (
-        CachedResponse.objects(kind=kind, dataset=dataset, config=config, split=split)
-        .only(
-            "content", "http_status", "error_code", "job_runner_version", "dataset_git_revision", "progress", "details"
+    try:
+        response = (
+            CachedResponse.objects(kind=kind, dataset=dataset, config=config, split=split)
+            .only(
+                "content",
+                "http_status",
+                "error_code",
+                "job_runner_version",
+                "dataset_git_revision",
+                "progress",
+                "details",
+            )
+            .get()
         )
-        .get()
-    )
+    except DoesNotExist as e:
+        raise CacheEntryDoesNotExistError(f"Cache entry does not exist: {kind=} {dataset=} {config=} {split=}") from e
     return {
         "content": response.content,
         "http_status": response.http_status,
@@ -330,7 +352,7 @@ def get_response_or_missing_error(
 ) -> CacheEntryWithDetails:
     try:
         response = get_response_with_details(kind=kind, dataset=dataset, config=config, split=split)
-    except DoesNotExist:
+    except CacheEntryDoesNotExistError:
         response = CacheEntryWithDetails(
             content={
                 "error": (

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -22,7 +22,8 @@ from typing import (
 import pandas as pd
 from bson import ObjectId
 from bson.errors import InvalidId
-from mongoengine import Document, DoesNotExist
+from mongoengine import Document
+from mongoengine.errors import DoesNotExist
 from mongoengine.fields import (
     DateTimeField,
     DictField,

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -744,7 +744,3 @@ def fetch_names(
 # only for the tests
 def _clean_cache_database() -> None:
     CachedResponse.drop_collection()  # type: ignore
-
-
-# explicit re-export
-__all__ = ["DoesNotExist"]

--- a/libs/libcommon/tests/test_simple_cache.py
+++ b/libs/libcommon/tests/test_simple_cache.py
@@ -7,6 +7,7 @@ from time import process_time
 from typing import Any, Dict, List, Mapping, Optional, TypedDict
 
 import pytest
+from mongoengine.errors import DoesNotExist
 from pymongo.errors import DocumentTooLarge
 
 from libcommon.resources import CacheMongoResource
@@ -15,7 +16,6 @@ from libcommon.simple_cache import (
     CachedResponse,
     CacheReportsPage,
     CacheReportsWithContentPage,
-    DoesNotExist,
     InvalidCursor,
     InvalidLimit,
     delete_dataset_responses,

--- a/libs/libcommon/tests/test_simple_cache.py
+++ b/libs/libcommon/tests/test_simple_cache.py
@@ -7,13 +7,13 @@ from time import process_time
 from typing import Any, Dict, List, Mapping, Optional, TypedDict
 
 import pytest
-from mongoengine.errors import DoesNotExist
 from pymongo.errors import DocumentTooLarge
 
 from libcommon.resources import CacheMongoResource
 from libcommon.simple_cache import (
     CachedArtifactError,
     CachedResponse,
+    CacheEntryDoesNotExistError,
     CacheReportsPage,
     CacheReportsWithContentPage,
     InvalidCursor,
@@ -138,7 +138,7 @@ def test_upsert_response(config: Optional[str], split: Optional[str]) -> None:
     get_response(kind=kind, dataset=dataset, config=config, split=split)
 
     delete_dataset_responses(dataset=dataset)
-    with pytest.raises(DoesNotExist):
+    with pytest.raises(CacheEntryDoesNotExistError):
         get_response(kind=kind, dataset=dataset, config=config, split=split)
 
     error_code = "error_code"
@@ -178,7 +178,7 @@ def test_delete_response() -> None:
     get_response(kind=kind, dataset=dataset_a, config=config, split=split)
     get_response(kind=kind, dataset=dataset_b, config=config, split=split)
     delete_response(kind=kind, dataset=dataset_a, config=config, split=split)
-    with pytest.raises(DoesNotExist):
+    with pytest.raises(CacheEntryDoesNotExistError):
         get_response(kind=kind, dataset=dataset_a, config=config, split=split)
     get_response(kind=kind, dataset=dataset_b, config=config, split=split)
 
@@ -197,9 +197,9 @@ def test_delete_dataset_responses() -> None:
     get_response(kind=kind_b, dataset=dataset_a, config=config, split=split)
     get_response(kind=kind_a, dataset=dataset_b)
     delete_dataset_responses(dataset=dataset_a)
-    with pytest.raises(DoesNotExist):
+    with pytest.raises(CacheEntryDoesNotExistError):
         get_response(kind=kind_a, dataset=dataset_a)
-    with pytest.raises(DoesNotExist):
+    with pytest.raises(CacheEntryDoesNotExistError):
         get_response(kind=kind_b, dataset=dataset_a, config=config, split=split)
     get_response(kind=kind_a, dataset=dataset_b)
 

--- a/services/worker/src/worker/job_manager.py
+++ b/services/worker/src/worker/job_manager.py
@@ -19,10 +19,10 @@ from libcommon.orchestrator import DatasetOrchestrator
 from libcommon.processing_graph import ProcessingGraph, ProcessingStep
 from libcommon.simple_cache import (
     CachedArtifactError,
-    DoesNotExist,
     get_response_without_content_params,
 )
 from libcommon.utils import JobInfo, JobParams, JobResult, Priority, orjson_dumps
+from mongoengine.errors import DoesNotExist
 
 from worker.config import AppConfig, WorkerConfig
 from worker.job_runner import JobRunner

--- a/services/worker/src/worker/job_manager.py
+++ b/services/worker/src/worker/job_manager.py
@@ -19,10 +19,10 @@ from libcommon.orchestrator import DatasetOrchestrator
 from libcommon.processing_graph import ProcessingGraph, ProcessingStep
 from libcommon.simple_cache import (
     CachedArtifactError,
+    CacheEntryDoesNotExistError,
     get_response_without_content_params,
 )
 from libcommon.utils import JobInfo, JobParams, JobResult, Priority, orjson_dumps
-from mongoengine.errors import DoesNotExist
 
 from worker.config import AppConfig, WorkerConfig
 from worker.job_runner import JobRunner
@@ -143,7 +143,7 @@ class JobManager:
                     f"Response has already been computed and stored in cache kind: {parallel_cache_kind}. Compute will"
                     " be skipped."
                 )
-        except DoesNotExist:
+        except CacheEntryDoesNotExistError:
             logging.debug(f"no cache found for {parallel_cache_kind}.")
 
     def process(

--- a/services/worker/src/worker/job_runners/config/opt_in_out_urls_count.py
+++ b/services/worker/src/worker/job_runners/config/opt_in_out_urls_count.py
@@ -7,8 +7,11 @@ from typing import Tuple
 
 from libcommon.constants import PROCESSING_STEP_CONFIG_OPT_IN_OUT_URLS_COUNT_VERSION
 from libcommon.exceptions import PreviousStepFormatError
-from libcommon.simple_cache import get_previous_step_or_raise, get_response
-from mongoengine.errors import DoesNotExist
+from libcommon.simple_cache import (
+    CacheEntryDoesNotExistError,
+    get_previous_step_or_raise,
+    get_response,
+)
 
 from worker.job_runners.config.config_job_runner import ConfigJobRunner
 from worker.utils import JobResult, OptInOutUrlsCountResponse
@@ -42,7 +45,7 @@ def compute_opt_in_out_urls_scan_response(dataset: str, config: str) -> Tuple[Op
                 response = get_response(
                     kind="split-opt-in-out-urls-count", dataset=dataset, config=config, split=split
                 )
-            except DoesNotExist:
+            except CacheEntryDoesNotExistError:
                 logging.debug("No response found in previous step for this dataset: 'split-opt-in-out-urls-count'.")
                 pending += 1
                 continue

--- a/services/worker/src/worker/job_runners/config/opt_in_out_urls_count.py
+++ b/services/worker/src/worker/job_runners/config/opt_in_out_urls_count.py
@@ -7,10 +7,7 @@ from typing import Tuple
 
 from libcommon.constants import PROCESSING_STEP_CONFIG_OPT_IN_OUT_URLS_COUNT_VERSION
 from libcommon.exceptions import PreviousStepFormatError
-from libcommon.simple_cache import (
-    get_previous_step_or_raise,
-    get_response,
-)
+from libcommon.simple_cache import get_previous_step_or_raise, get_response
 from mongoengine.errors import DoesNotExist
 
 from worker.job_runners.config.config_job_runner import ConfigJobRunner

--- a/services/worker/src/worker/job_runners/config/opt_in_out_urls_count.py
+++ b/services/worker/src/worker/job_runners/config/opt_in_out_urls_count.py
@@ -8,10 +8,10 @@ from typing import Tuple
 from libcommon.constants import PROCESSING_STEP_CONFIG_OPT_IN_OUT_URLS_COUNT_VERSION
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import (
-    DoesNotExist,
     get_previous_step_or_raise,
     get_response,
 )
+from mongoengine.errors import DoesNotExist
 
 from worker.job_runners.config.config_job_runner import ConfigJobRunner
 from worker.utils import JobResult, OptInOutUrlsCountResponse

--- a/services/worker/src/worker/job_runners/dataset/info.py
+++ b/services/worker/src/worker/job_runners/dataset/info.py
@@ -7,8 +7,11 @@ from typing import Any, Dict, List, Tuple, TypedDict
 
 from libcommon.constants import PROCESSING_STEP_DATASET_INFO_VERSION
 from libcommon.exceptions import PreviousStepFormatError
-from libcommon.simple_cache import get_previous_step_or_raise, get_response
-from mongoengine.errors import DoesNotExist
+from libcommon.simple_cache import (
+    CacheEntryDoesNotExistError,
+    get_previous_step_or_raise,
+    get_response,
+)
 
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 from worker.utils import JobResult, PreviousJob
@@ -54,7 +57,7 @@ def compute_dataset_info_response(dataset: str) -> Tuple[DatasetInfoResponse, fl
             total += 1
             try:
                 config_response = get_response(kind="config-info", dataset=dataset, config=config)
-            except DoesNotExist:
+            except CacheEntryDoesNotExistError:
                 logging.debug(f"No response found in previous step for {dataset=} {config=}: 'config-info'.")
                 pending.append(
                     PreviousJob(

--- a/services/worker/src/worker/job_runners/dataset/info.py
+++ b/services/worker/src/worker/job_runners/dataset/info.py
@@ -7,10 +7,7 @@ from typing import Any, Dict, List, Tuple, TypedDict
 
 from libcommon.constants import PROCESSING_STEP_DATASET_INFO_VERSION
 from libcommon.exceptions import PreviousStepFormatError
-from libcommon.simple_cache import (
-    get_previous_step_or_raise,
-    get_response,
-)
+from libcommon.simple_cache import get_previous_step_or_raise, get_response
 from mongoengine.errors import DoesNotExist
 
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner

--- a/services/worker/src/worker/job_runners/dataset/info.py
+++ b/services/worker/src/worker/job_runners/dataset/info.py
@@ -8,10 +8,10 @@ from typing import Any, Dict, List, Tuple, TypedDict
 from libcommon.constants import PROCESSING_STEP_DATASET_INFO_VERSION
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import (
-    DoesNotExist,
     get_previous_step_or_raise,
     get_response,
 )
+from mongoengine.errors import DoesNotExist
 
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 from worker.utils import JobResult, PreviousJob

--- a/services/worker/src/worker/job_runners/dataset/opt_in_out_urls_count.py
+++ b/services/worker/src/worker/job_runners/dataset/opt_in_out_urls_count.py
@@ -7,10 +7,7 @@ from typing import Tuple
 
 from libcommon.constants import PROCESSING_STEP_DATASET_OPT_IN_OUT_URLS_COUNT_VERSION
 from libcommon.exceptions import PreviousStepFormatError
-from libcommon.simple_cache import (
-    get_previous_step_or_raise,
-    get_response,
-)
+from libcommon.simple_cache import get_previous_step_or_raise, get_response
 from mongoengine.errors import DoesNotExist
 
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner

--- a/services/worker/src/worker/job_runners/dataset/opt_in_out_urls_count.py
+++ b/services/worker/src/worker/job_runners/dataset/opt_in_out_urls_count.py
@@ -8,10 +8,10 @@ from typing import Tuple
 from libcommon.constants import PROCESSING_STEP_DATASET_OPT_IN_OUT_URLS_COUNT_VERSION
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import (
-    DoesNotExist,
     get_previous_step_or_raise,
     get_response,
 )
+from mongoengine.errors import DoesNotExist
 
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 from worker.utils import JobResult, OptInOutUrlsCountResponse

--- a/services/worker/src/worker/job_runners/dataset/opt_in_out_urls_count.py
+++ b/services/worker/src/worker/job_runners/dataset/opt_in_out_urls_count.py
@@ -7,8 +7,11 @@ from typing import Tuple
 
 from libcommon.constants import PROCESSING_STEP_DATASET_OPT_IN_OUT_URLS_COUNT_VERSION
 from libcommon.exceptions import PreviousStepFormatError
-from libcommon.simple_cache import get_previous_step_or_raise, get_response
-from mongoengine.errors import DoesNotExist
+from libcommon.simple_cache import (
+    CacheEntryDoesNotExistError,
+    get_previous_step_or_raise,
+    get_response,
+)
 
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 from worker.utils import JobResult, OptInOutUrlsCountResponse
@@ -36,7 +39,7 @@ def compute_opt_in_out_urls_count_response(dataset: str) -> Tuple[OptInOutUrlsCo
             total += 1
             try:
                 response = get_response(kind="config-opt-in-out-urls-count", dataset=dataset, config=config)
-            except DoesNotExist:
+            except CacheEntryDoesNotExistError:
                 logging.debug("No response found in previous step for this dataset: 'config-opt-in-out-urls-count'.")
                 pending += 1
                 continue

--- a/services/worker/src/worker/job_runners/dataset/parquet.py
+++ b/services/worker/src/worker/job_runners/dataset/parquet.py
@@ -7,8 +7,11 @@ from typing import List, Tuple, TypedDict
 
 from libcommon.constants import PROCESSING_STEP_DATASET_PARQUET_VERSION
 from libcommon.exceptions import PreviousStepFormatError
-from libcommon.simple_cache import get_previous_step_or_raise, get_response
-from mongoengine.errors import DoesNotExist
+from libcommon.simple_cache import (
+    CacheEntryDoesNotExistError,
+    get_previous_step_or_raise,
+    get_response,
+)
 
 from worker.job_runners.config.parquet import ConfigParquetResponse
 from worker.job_runners.config.parquet_and_info import ParquetFileItem
@@ -54,7 +57,7 @@ def compute_sizes_response(dataset: str) -> Tuple[DatasetParquetResponse, float]
             total += 1
             try:
                 response = get_response(kind="config-parquet", dataset=dataset, config=config)
-            except DoesNotExist:
+            except CacheEntryDoesNotExistError:
                 logging.debug("No response found in previous step for this dataset: 'config-parquet' endpoint.")
                 pending.append(
                     PreviousJob(

--- a/services/worker/src/worker/job_runners/dataset/parquet.py
+++ b/services/worker/src/worker/job_runners/dataset/parquet.py
@@ -7,10 +7,7 @@ from typing import List, Tuple, TypedDict
 
 from libcommon.constants import PROCESSING_STEP_DATASET_PARQUET_VERSION
 from libcommon.exceptions import PreviousStepFormatError
-from libcommon.simple_cache import (
-    get_previous_step_or_raise,
-    get_response,
-)
+from libcommon.simple_cache import get_previous_step_or_raise, get_response
 from mongoengine.errors import DoesNotExist
 
 from worker.job_runners.config.parquet import ConfigParquetResponse

--- a/services/worker/src/worker/job_runners/dataset/parquet.py
+++ b/services/worker/src/worker/job_runners/dataset/parquet.py
@@ -8,10 +8,10 @@ from typing import List, Tuple, TypedDict
 from libcommon.constants import PROCESSING_STEP_DATASET_PARQUET_VERSION
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import (
-    DoesNotExist,
     get_previous_step_or_raise,
     get_response,
 )
+from mongoengine.errors import DoesNotExist
 
 from worker.job_runners.config.parquet import ConfigParquetResponse
 from worker.job_runners.config.parquet_and_info import ParquetFileItem

--- a/services/worker/src/worker/job_runners/dataset/size.py
+++ b/services/worker/src/worker/job_runners/dataset/size.py
@@ -8,10 +8,10 @@ from typing import Tuple, TypedDict
 from libcommon.constants import PROCESSING_STEP_DATASET_SIZE_VERSION
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import (
-    DoesNotExist,
     get_previous_step_or_raise,
     get_response,
 )
+from mongoengine.errors import DoesNotExist
 
 from worker.job_runners.config.size import ConfigSize, ConfigSizeResponse, SplitSize
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner

--- a/services/worker/src/worker/job_runners/dataset/size.py
+++ b/services/worker/src/worker/job_runners/dataset/size.py
@@ -7,8 +7,11 @@ from typing import Tuple, TypedDict
 
 from libcommon.constants import PROCESSING_STEP_DATASET_SIZE_VERSION
 from libcommon.exceptions import PreviousStepFormatError
-from libcommon.simple_cache import get_previous_step_or_raise, get_response
-from mongoengine.errors import DoesNotExist
+from libcommon.simple_cache import (
+    CacheEntryDoesNotExistError,
+    get_previous_step_or_raise,
+    get_response,
+)
 
 from worker.job_runners.config.size import ConfigSize, ConfigSizeResponse, SplitSize
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
@@ -68,7 +71,7 @@ def compute_sizes_response(dataset: str) -> Tuple[DatasetSizeResponse, float]:
             total += 1
             try:
                 response = get_response(kind="config-size", dataset=dataset, config=config)
-            except DoesNotExist:
+            except CacheEntryDoesNotExistError:
                 logging.debug("No response found in previous step for this dataset: 'config-size' endpoint.")
                 pending.append(
                     PreviousJob(

--- a/services/worker/src/worker/job_runners/dataset/size.py
+++ b/services/worker/src/worker/job_runners/dataset/size.py
@@ -7,10 +7,7 @@ from typing import Tuple, TypedDict
 
 from libcommon.constants import PROCESSING_STEP_DATASET_SIZE_VERSION
 from libcommon.exceptions import PreviousStepFormatError
-from libcommon.simple_cache import (
-    get_previous_step_or_raise,
-    get_response,
-)
+from libcommon.simple_cache import get_previous_step_or_raise, get_response
 from mongoengine.errors import DoesNotExist
 
 from worker.job_runners.config.size import ConfigSize, ConfigSizeResponse, SplitSize

--- a/services/worker/tests/test_executor.py
+++ b/services/worker/tests/test_executor.py
@@ -12,9 +12,9 @@ import pytest
 import pytz
 from filelock import FileLock
 from libcommon.processing_graph import ProcessingGraph
-from libcommon.queue import Job, Queue
+from libcommon.queue import Job, JobDoesNotExistError, Queue
 from libcommon.resources import CacheMongoResource, QueueMongoResource
-from libcommon.simple_cache import CachedResponse, CacheEntryDoesNotExistError
+from libcommon.simple_cache import CachedResponse
 from libcommon.storage import StrPath
 from libcommon.utils import JobInfo, Priority, Status, get_datetime
 from mirakuru import ProcessExitedWithError, TimeoutExpired
@@ -109,8 +109,8 @@ def set_just_started_job_in_queue(queue_mongo_resource: QueueMongoResource) -> I
         raise RuntimeError("Mongo resource is not available")
     job_info = get_job_info()
     try:
-        Job.objects(pk=job_info["job_id"]).get().delete()
-    except CacheEntryDoesNotExistError:
+        Job.get(job_id=job_info["job_id"]).delete()
+    except JobDoesNotExistError:
         pass
     created_at = get_datetime()
     job = Job(
@@ -138,8 +138,8 @@ def set_long_running_job_in_queue(app_config: AppConfig, queue_mongo_resource: Q
         raise RuntimeError("Mongo resource is not available")
     job_info = get_job_info("long")
     try:
-        Job.objects(pk=job_info["job_id"]).get().delete()
-    except CacheEntryDoesNotExistError:
+        Job.get(job_id=job_info["job_id"]).delete()
+    except JobDoesNotExistError:
         pass
     created_at = get_datetime() - timedelta(days=1)
     last_heartbeat = get_datetime() - timedelta(seconds=app_config.worker.heartbeat_interval_seconds)
@@ -169,8 +169,8 @@ def set_zombie_job_in_queue(queue_mongo_resource: QueueMongoResource) -> Iterato
         raise RuntimeError("Mongo resource is not available")
     job_info = get_job_info("zombie")
     try:
-        Job.objects(pk=job_info["job_id"]).get().delete()
-    except CacheEntryDoesNotExistError:
+        Job.get(job_id=job_info["job_id"]).delete()
+    except JobDoesNotExistError:
         pass
     created_at = get_datetime() - timedelta(days=1)
     job = Job(

--- a/services/worker/tests/test_executor.py
+++ b/services/worker/tests/test_executor.py
@@ -12,12 +12,13 @@ import pytest
 import pytz
 from filelock import FileLock
 from libcommon.processing_graph import ProcessingGraph
-from libcommon.queue import DoesNotExist, Job, Queue
+from libcommon.queue import Job, Queue
 from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.simple_cache import CachedResponse
 from libcommon.storage import StrPath
 from libcommon.utils import JobInfo, Priority, Status, get_datetime
 from mirakuru import ProcessExitedWithError, TimeoutExpired
+from mongoengine.errors import DoesNotExist
 from pytest import fixture
 
 from worker.config import AppConfig


### PR DESCRIPTION
Remove too restrictive `__all__` from `libcommon/simple_cache`:
- it contained only one attribute: `DoesNotExist`
- Python considers as private all the module attributes which are not defined in `__all__`

```
from libcommon.simple_cache import upsert_response

Warning: Accessing a protected member of a class or a module:
'upsert_response' is not declared in __all__
```