### PR TITLE
Fix regression: use parquet metadata when possible

### DIFF
--- a/e2e/tests/test_11_api.py
+++ b/e2e/tests/test_11_api.py
@@ -106,9 +106,9 @@ def test_rows_endpoint(
     headers = auth_headers[auth]
     # ensure the /rows endpoint works as well
     offset = 1
-    limit = 10
+    length = 10
     rows_response = poll_until_ready_and_assert(
-        relative_url=f"/rows?dataset={dataset}&config={config}&split={split}&offset={offset}&limit={limit}",
+        relative_url=f"/rows?dataset={dataset}&config={config}&split={split}&offset={offset}&length={length}",
         expected_status_code=expected_status_code,
         expected_error_code=expected_error_code,
         headers=headers,

--- a/libs/libcommon/src/libcommon/parquet_utils.py
+++ b/libs/libcommon/src/libcommon/parquet_utils.py
@@ -1,10 +1,9 @@
-import asyncio
 import logging
 import os
 from dataclasses import dataclass
 from functools import lru_cache, partial
 from os import PathLike
-from typing import Any, Callable, List, Literal, Optional, Tuple, TypedDict, Union, cast
+from typing import Callable, List, Literal, Optional, Tuple, TypedDict, Union
 
 import numpy as np
 import numpy.typing as npt

--- a/libs/libcommon/src/libcommon/parquet_utils.py
+++ b/libs/libcommon/src/libcommon/parquet_utils.py
@@ -4,7 +4,7 @@ import os
 from dataclasses import dataclass
 from functools import lru_cache, partial
 from os import PathLike
-from typing import Callable, List, Literal, Optional, Tuple, TypedDict, Union, cast
+from typing import Any, Callable, List, Literal, Optional, Tuple, TypedDict, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -55,28 +55,6 @@ class ParquetFileMetadataItem(TypedDict):
     size: int
     num_rows: int
     parquet_metadata_subpath: str
-
-
-class HTTPFileSystemSession(object):
-    _singleton: Optional["HTTPFileSystemSession"] = None
-
-    @classmethod
-    def get_instance(cls) -> "HTTPFileSystemSession":
-        if cls._singleton is None:
-            HTTPFileSystemSession()
-        return cast("HTTPFileSystemSession", HTTPFileSystemSession._singleton)
-
-    def __new__(cls) -> "HTTPFileSystemSession":
-        if HTTPFileSystemSession._singleton is not None:
-            raise RuntimeError(
-                "cannot initialize another instance of HTTPFileSystemSession, use .get_instance() instead"
-            )
-        return super(HTTPFileSystemSession, cls).__new__(cls)
-
-    def __init__(self) -> None:
-        HTTPFileSystemSession._singleton = self
-        self.httpfs = HTTPFileSystem()
-        self.session = asyncio.run(self.httpfs.set_session())
 
 
 def get_supported_unsupported_columns(
@@ -234,6 +212,7 @@ class ParquetIndexWithMetadata:
     metadata_paths: List[str]
     num_bytes: List[int]
     num_rows: List[int]
+    httpfs: HTTPFileSystem
     hf_token: Optional[str]
 
     def query(self, offset: int, length: int) -> pa.Table:
@@ -270,12 +249,16 @@ class ParquetIndexWithMetadata:
         with StepProfiler(
             method="parquet_index_with_metadata.query", step="load the remote parquet files using metadata from disk"
         ):
-            httpFileSystemSession = HTTPFileSystemSession.get_instance()
-            session = httpFileSystemSession.session
-            httpfs = httpFileSystemSession.httpfs
             parquet_files = [
                 pq.ParquetFile(
-                    HTTPFile(httpfs, url, session=session, size=size, loop=httpfs.loop, cache_type=None),
+                    HTTPFile(
+                        self.httpfs,
+                        url,
+                        session=self.httpfs._session,
+                        size=size,
+                        loop=self.httpfs.loop,
+                        cache_type=None,
+                    ),
                     metadata=pq.read_metadata(metadata_path),
                     pre_buffer=True,
                 )
@@ -317,6 +300,7 @@ class ParquetIndexWithMetadata:
     def from_parquet_metadata_items(
         parquet_file_metadata_items: List[ParquetFileMetadataItem],
         parquet_metadata_directory: StrPath,
+        httpfs: HTTPFileSystem,
         hf_token: Optional[str],
         unsupported_features_magic_strings: List[str] = [],
     ) -> "ParquetIndexWithMetadata":
@@ -357,6 +341,7 @@ class ParquetIndexWithMetadata:
             metadata_paths=metadata_paths,
             num_bytes=num_bytes,
             num_rows=num_rows,
+            httpfs=httpfs,
             hf_token=hf_token,
         )
 
@@ -368,6 +353,7 @@ class RowsIndex:
         config: str,
         split: str,
         processing_graph: ProcessingGraph,
+        httpfs: HfFileSystem,
         hf_token: Optional[str],
         parquet_metadata_directory: StrPath,
         unsupported_features_magic_strings: List[str] = [],
@@ -377,6 +363,7 @@ class RowsIndex:
         self.config = config
         self.split = split
         self.processing_graph = processing_graph
+        self.httpfs = httpfs
         self.parquet_index = self._init_parquet_index(
             hf_token=hf_token,
             parquet_metadata_directory=parquet_metadata_directory,
@@ -436,6 +423,7 @@ class RowsIndex:
                         if parquet_item["split"] == self.split and parquet_item["config"] == self.config
                     ],
                     parquet_metadata_directory=parquet_metadata_directory,
+                    httpfs=self.httpfs,
                     hf_token=hf_token,
                     unsupported_features_magic_strings=unsupported_features_magic_strings,
                 )
@@ -463,12 +451,14 @@ class Indexer:
         self,
         processing_graph: ProcessingGraph,
         parquet_metadata_directory: StrPath,
+        httpfs: HTTPFileSystem,
         unsupported_features_magic_strings: List[str] = [],
         all_columns_supported_datasets_allow_list: Union[Literal["all"], List[str]] = "all",
         hf_token: Optional[str] = None,
     ):
         self.processing_graph = processing_graph
         self.parquet_metadata_directory = parquet_metadata_directory
+        self.httpfs = httpfs
         self.hf_token = hf_token
         self.unsupported_features_magic_strings = unsupported_features_magic_strings
         self.all_columns_supported_datasets_allow_list = all_columns_supported_datasets_allow_list
@@ -490,6 +480,7 @@ class Indexer:
             config=config,
             split=split,
             processing_graph=self.processing_graph,
+            httpfs=self.httpfs,
             hf_token=self.hf_token,
             parquet_metadata_directory=self.parquet_metadata_directory,
             unsupported_features_magic_strings=unsupported_features_magic_strings,

--- a/libs/libcommon/src/libcommon/parquet_utils.py
+++ b/libs/libcommon/src/libcommon/parquet_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from dataclasses import dataclass
@@ -214,6 +215,12 @@ class ParquetIndexWithMetadata:
     httpfs: HTTPFileSystem
     hf_token: Optional[str]
 
+    def __post_init__(self) -> None:
+        if self.httpfs._session is None:
+            self.httpfs_session = asyncio.run(self.httpfs.set_session())
+        else:
+            self.httpfs_session = self.httpfs._session
+
     def query(self, offset: int, length: int) -> pa.Table:
         """Query the parquet files
 
@@ -253,7 +260,7 @@ class ParquetIndexWithMetadata:
                     HTTPFile(
                         self.httpfs,
                         url,
-                        session=self.httpfs._session,
+                        session=self.httpfs_session,
                         size=size,
                         loop=self.httpfs.loop,
                         cache_type=None,

--- a/libs/libcommon/src/libcommon/parquet_utils.py
+++ b/libs/libcommon/src/libcommon/parquet_utils.py
@@ -400,8 +400,8 @@ class RowsIndex:
                     self.processing_graph.get_config_parquet_metadata_processing_steps()
                 )
 
-                cache_kinds = [step.cache_kind for step in config_parquet_processing_steps]
-                cache_kinds.extend([step.cache_kind for step in config_parquet_metadata_processing_steps])
+                cache_kinds = [step.cache_kind for step in config_parquet_metadata_processing_steps]
+                cache_kinds.extend([step.cache_kind for step in config_parquet_processing_steps])
 
                 try:
                     result = get_previous_step_or_raise(

--- a/services/api/src/api/routes/rows.py
+++ b/services/api/src/api/routes/rows.py
@@ -10,6 +10,7 @@ from typing import Any, List, Literal, Mapping, Optional, TypedDict, Union
 
 import pyarrow as pa
 from datasets import Features
+from fsspec.implementations.http import HTTPFileSystem
 from libcommon.parquet_utils import Indexer, StrPath
 from libcommon.processing_graph import ProcessingGraph
 from libcommon.prometheus import StepProfiler
@@ -267,11 +268,13 @@ def create_rows_endpoint(
         processing_graph=processing_graph,
         hf_token=hf_token,
         parquet_metadata_directory=parquet_metadata_directory,
+        httpfs=HTTPFileSystem(),
         unsupported_features_magic_strings=UNSUPPORTED_FEATURES_MAGIC_STRINGS,
         all_columns_supported_datasets_allow_list=ALL_COLUMNS_SUPPORTED_DATASETS_ALLOW_LIST,
     )
 
     async def rows_endpoint(request: Request) -> Response:
+        await indexer.httpfs.set_session()
         revision: Optional[str] = None
         with StepProfiler(method="rows_endpoint", step="all"):
             try:

--- a/services/api/tests/routes/test_rows.py
+++ b/services/api/tests/routes/test_rows.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import shutil
 import time
@@ -245,25 +244,17 @@ def dataset_image_with_config_parquet() -> dict[str, Any]:
     return config_parquet_content
 
 
-@pytest.fixture(scope="session")
-def httpfs() -> HTTPFileSystem:
-    httpfs = HTTPFileSystem()
-    asyncio.run(httpfs.set_session())
-    return httpfs
-
-
 @pytest.fixture
 def indexer(
     app_config: AppConfig,
     processing_graph: ProcessingGraph,
     parquet_metadata_directory: StrPath,
-    httpfs: HTTPFileSystem,
 ) -> Indexer:
     return Indexer(
         processing_graph=processing_graph,
         hf_token=app_config.common.hf_token,
         parquet_metadata_directory=parquet_metadata_directory,
-        httpfs=httpfs,
+        httpfs=HTTPFileSystem(),
     )
 
 

--- a/services/api/tests/routes/test_rows.py
+++ b/services/api/tests/routes/test_rows.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import shutil
 import time
@@ -12,6 +13,7 @@ import pytest
 from datasets import Dataset, Image, concatenate_datasets
 from datasets.table import embed_table_storage
 from fsspec import AbstractFileSystem
+from fsspec.implementations.http import HTTPFileSystem
 from libcommon.parquet_utils import (
     Indexer,
     ParquetIndexWithMetadata,
@@ -243,12 +245,25 @@ def dataset_image_with_config_parquet() -> dict[str, Any]:
     return config_parquet_content
 
 
+@pytest.fixture(scope="session")
+def httpfs() -> HTTPFileSystem:
+    httpfs = HTTPFileSystem()
+    asyncio.run(httpfs.set_session())
+    return httpfs
+
+
 @pytest.fixture
-def indexer(app_config: AppConfig, processing_graph: ProcessingGraph, parquet_metadata_directory: StrPath) -> Indexer:
+def indexer(
+    app_config: AppConfig,
+    processing_graph: ProcessingGraph,
+    parquet_metadata_directory: StrPath,
+    httpfs: HTTPFileSystem,
+) -> Indexer:
     return Indexer(
         processing_graph=processing_graph,
         hf_token=app_config.common.hf_token,
         parquet_metadata_directory=parquet_metadata_directory,
+        httpfs=httpfs,
     )
 
 

--- a/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
@@ -5,6 +5,7 @@ import logging
 from typing import List
 
 from datasets import Audio, Features, Image
+from fsspec.implementations.http import HTTPFileSystem
 from libcommon.constants import (
     PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_PARQUET_VERSION,
     PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_STREAMING_VERSION,
@@ -196,6 +197,7 @@ class SplitFirstRowsFromParquetJobRunner(SplitJobRunner):
             processing_graph=processing_graph,
             hf_token=self.app_config.common.hf_token,
             parquet_metadata_directory=parquet_metadata_directory,
+            httpfs=HTTPFileSystem(),
             unsupported_features_magic_strings=[],
             all_columns_supported_datasets_allow_list="all",
         )


### PR DESCRIPTION
I noticed some datasets have a slow pagination like https://huggingface.co/datasets/mlfoundations/datacomp_1b that times out.

This is because there was a regression in https://github.com/huggingface/datasets-server/pull/1287 where it wouldn't use the parquet metadata because `get_best_response` returns the first successful response