### PR TITLE
Move dtos to its own file

### DIFF
--- a/services/worker/src/worker/dtos.py
+++ b/services/worker/src/worker/dtos.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 The HuggingFace Authors.
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, TypedDict
+
+
+class JobRunnerInfo(TypedDict):
+    job_type: str
+    job_runner_version: int
+
+
+@dataclass
+class JobResult:
+    content: Mapping[str, Any]
+    progress: float
+
+    def __post_init__(self) -> None:
+        if self.progress < 0.0 or self.progress > 1.0:
+            raise ValueError(f"Progress should be between 0 and 1, but got {self.progress}")
+
+
+@dataclass
+class CompleteJobResult(JobResult):
+    content: Mapping[str, Any]
+    progress: float = field(init=False, default=1.0)
+
+
+class DatasetItem(TypedDict):
+    dataset: str
+
+
+class ConfigItem(DatasetItem):
+    config: Optional[str]
+
+
+class SplitItem(ConfigItem):
+    split: Optional[str]
+
+
+class SplitsList(TypedDict):
+    splits: List[SplitItem]
+
+
+class FailedConfigItem(ConfigItem):
+    error: Mapping[str, Any]
+
+
+class DatasetSplitNamesResponse(TypedDict):
+    splits: List[SplitItem]
+    pending: List[ConfigItem]
+    failed: List[FailedConfigItem]
+
+
+class PreviousJob(SplitItem):
+    kind: str
+
+
+class FeatureItem(TypedDict):
+    feature_idx: int
+    name: str
+    type: Mapping[str, Any]
+
+
+class RowItem(TypedDict):
+    row_idx: int
+    row: Mapping[str, Any]
+    truncated_cells: List[str]
+
+
+class SplitFirstRowsResponse(SplitItem):
+    features: List[FeatureItem]
+    rows: List[RowItem]
+
+
+class OptUrl(TypedDict):
+    url: str
+    row_idx: int
+    column_name: str
+
+
+class OptInOutUrlsCountResponse(TypedDict):
+    urls_columns: List[str]
+    num_opt_in_urls: int
+    num_opt_out_urls: int
+    num_urls: int
+    num_scanned_rows: int
+    has_urls_columns: bool
+    full_scan: Optional[bool]
+
+
+class OptInOutUrlsScanResponse(OptInOutUrlsCountResponse):
+    opt_in_urls: List[OptUrl]
+    opt_out_urls: List[OptUrl]
+
+
+class ImageUrlColumnsResponse(TypedDict):
+    columns: List[str]
+
+
+Row = Mapping[str, Any]
+
+
+class RowsContent(TypedDict):
+    rows: List[Row]
+    all_fetched: bool
+
+
+class ConfigInfoResponse(TypedDict):
+    dataset_info: Dict[str, Any]
+
+
+class ParquetFileItem(SplitItem):
+    url: str
+    filename: str
+    size: int
+
+
+class ConfigParquetAndInfoResponse(TypedDict):
+    parquet_files: List[ParquetFileItem]
+    dataset_info: Dict[str, Any]
+
+
+class ParquetFileMetadataItem(SplitItem):
+    url: str
+    filename: str
+    size: int
+    num_rows: int
+    parquet_metadata_subpath: str
+
+
+class ConfigParquetMetadataResponse(TypedDict):
+    parquet_files_metadata: List[ParquetFileMetadataItem]
+
+
+class ConfigParquetResponse(TypedDict):
+    parquet_files: List[ParquetFileItem]
+
+
+class ConfigSize(TypedDict):
+    dataset: str
+    config: str
+    num_bytes_original_files: int
+    num_bytes_parquet_files: int
+    num_bytes_memory: int
+    num_rows: int
+    num_columns: int
+
+
+class SplitSize(SplitItem):
+    num_bytes_parquet_files: int
+    num_bytes_memory: int
+    num_rows: int
+    num_columns: int
+
+
+class ConfigSizeContent(TypedDict):
+    config: ConfigSize
+    splits: list[SplitSize]
+
+
+class ConfigSizeResponse(TypedDict):
+    size: ConfigSizeContent
+
+
+class ConfigNameItem(TypedDict):
+    dataset: str
+    config: str
+
+
+class DatasetConfigNamesResponse(TypedDict):
+    config_names: List[ConfigNameItem]
+
+
+class DatasetInfoResponse(TypedDict):
+    dataset_info: Dict[str, Any]
+    pending: List[PreviousJob]
+    failed: List[PreviousJob]
+
+
+class DatasetIsValidResponse(TypedDict):
+    valid: bool
+
+
+class DatasetParquetResponse(TypedDict):
+    parquet_files: List[ParquetFileItem]
+    pending: list[PreviousJob]
+    failed: list[PreviousJob]
+
+
+class DatasetSize(TypedDict):
+    dataset: str
+    num_bytes_original_files: int
+    num_bytes_parquet_files: int
+    num_bytes_memory: int
+    num_rows: int
+
+
+class DatasetSizeContent(TypedDict):
+    dataset: DatasetSize
+    configs: list[ConfigSize]
+    splits: list[SplitSize]
+
+
+class DatasetSizeResponse(TypedDict):
+    size: DatasetSizeContent
+    pending: list[PreviousJob]
+    failed: list[PreviousJob]

--- a/services/worker/src/worker/job_runner.py
+++ b/services/worker/src/worker/job_runner.py
@@ -8,7 +8,7 @@ from libcommon.processing_graph import ProcessingStep
 from libcommon.utils import JobInfo
 
 from worker.config import AppConfig
-from worker.utils import JobResult, JobRunnerInfo
+from worker.dtos import JobResult, JobRunnerInfo
 
 
 class JobRunner(ABC):

--- a/services/worker/src/worker/job_runners/config/info.py
+++ b/services/worker/src/worker/job_runners/config/info.py
@@ -1,16 +1,11 @@
 import logging
-from typing import Any, Dict, TypedDict
 
 from libcommon.constants import PROCESSING_STEP_CONFIG_INFO_VERSION
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import get_previous_step_or_raise
 
+from worker.dtos import CompleteJobResult, ConfigInfoResponse
 from worker.job_runners.config.config_job_runner import ConfigJobRunner
-from worker.utils import CompleteJobResult
-
-
-class ConfigInfoResponse(TypedDict):
-    dataset_info: Dict[str, Any]
 
 
 def compute_config_info_response(dataset: str, config: str) -> ConfigInfoResponse:

--- a/services/worker/src/worker/job_runners/config/opt_in_out_urls_count.py
+++ b/services/worker/src/worker/job_runners/config/opt_in_out_urls_count.py
@@ -13,8 +13,8 @@ from libcommon.simple_cache import (
     get_response,
 )
 
+from worker.dtos import JobResult, OptInOutUrlsCountResponse
 from worker.job_runners.config.config_job_runner import ConfigJobRunner
-from worker.utils import JobResult, OptInOutUrlsCountResponse
 
 
 def compute_opt_in_out_urls_scan_response(dataset: str, config: str) -> Tuple[OptInOutUrlsCountResponse, float]:

--- a/services/worker/src/worker/job_runners/config/parquet.py
+++ b/services/worker/src/worker/job_runners/config/parquet.py
@@ -2,19 +2,13 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
-from typing import List, TypedDict
 
 from libcommon.constants import PROCESSING_STEP_CONFIG_PARQUET_VERSION
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import get_previous_step_or_raise
 
+from worker.dtos import CompleteJobResult, ConfigParquetResponse
 from worker.job_runners.config.config_job_runner import ConfigJobRunner
-from worker.job_runners.config.parquet_and_info import ParquetFileItem
-from worker.utils import CompleteJobResult
-
-
-class ConfigParquetResponse(TypedDict):
-    parquet_files: List[ParquetFileItem]
 
 
 def compute_parquet_response(dataset: str, config: str) -> ConfigParquetResponse:

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -7,7 +7,7 @@ import re
 from functools import partial
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple, TypedDict
+from typing import Any, List, Optional, Set, Tuple
 from urllib.parse import quote
 
 import datasets
@@ -75,23 +75,9 @@ from libcommon.utils import JobInfo
 from tqdm.contrib.concurrent import thread_map
 
 from worker.config import AppConfig, ParquetAndInfoConfig
+from worker.dtos import CompleteJobResult, ConfigParquetAndInfoResponse, ParquetFileItem
 from worker.job_runners.config.config_job_runner import ConfigJobRunnerWithDatasetsCache
-from worker.utils import CompleteJobResult, retry
-
-
-class ParquetFileItem(TypedDict):
-    dataset: str
-    config: str
-    split: str
-    url: str
-    filename: str
-    size: int
-
-
-class ConfigParquetAndInfoResponse(TypedDict):
-    parquet_files: List[ParquetFileItem]
-    dataset_info: Dict[str, Any]
-
+from worker.utils import retry
 
 DATASET_TYPE = "dataset"
 MAX_FILES_PER_DIRECTORY = 10_000  # hf hub limitation

--- a/services/worker/src/worker/job_runners/config/parquet_metadata.py
+++ b/services/worker/src/worker/job_runners/config/parquet_metadata.py
@@ -3,7 +3,7 @@
 
 import logging
 from functools import partial
-from typing import List, Optional, TypedDict
+from typing import List, Optional
 
 from datasets.utils.file_utils import get_authentication_headers_for_url
 from fsspec.implementations.http import HTTPFileSystem
@@ -22,24 +22,13 @@ from pyarrow.parquet import ParquetFile
 from tqdm.contrib.concurrent import thread_map
 
 from worker.config import AppConfig
+from worker.dtos import (
+    CompleteJobResult,
+    ConfigParquetMetadataResponse,
+    ParquetFileItem,
+    ParquetFileMetadataItem,
+)
 from worker.job_runners.config.config_job_runner import ConfigJobRunner
-from worker.job_runners.config.parquet_and_info import ParquetFileItem
-from worker.utils import CompleteJobResult
-
-
-class ParquetFileMetadataItem(TypedDict):
-    dataset: str
-    config: str
-    split: str
-    url: str
-    filename: str
-    size: int
-    num_rows: int
-    parquet_metadata_subpath: str
-
-
-class ConfigParquetMetadataResponse(TypedDict):
-    parquet_files_metadata: List[ParquetFileMetadataItem]
 
 
 def get_parquet_file(url: str, fs: HTTPFileSystem, hf_token: Optional[str]) -> ParquetFile:

--- a/services/worker/src/worker/job_runners/config/size.py
+++ b/services/worker/src/worker/job_runners/config/size.py
@@ -2,43 +2,13 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
-from typing import TypedDict
 
 from libcommon.constants import PROCESSING_STEP_CONFIG_SIZE_VERSION
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import get_previous_step_or_raise
 
+from worker.dtos import CompleteJobResult, ConfigSize, ConfigSizeResponse, SplitSize
 from worker.job_runners.config.config_job_runner import ConfigJobRunner
-from worker.utils import CompleteJobResult
-
-
-class ConfigSize(TypedDict):
-    dataset: str
-    config: str
-    num_bytes_original_files: int
-    num_bytes_parquet_files: int
-    num_bytes_memory: int
-    num_rows: int
-    num_columns: int
-
-
-class SplitSize(TypedDict):
-    dataset: str
-    config: str
-    split: str
-    num_bytes_parquet_files: int
-    num_bytes_memory: int
-    num_rows: int
-    num_columns: int
-
-
-class ConfigSizeContent(TypedDict):
-    config: ConfigSize
-    splits: list[SplitSize]
-
-
-class ConfigSizeResponse(TypedDict):
-    size: ConfigSizeContent
 
 
 def compute_config_size_response(dataset: str, config: str) -> ConfigSizeResponse:

--- a/services/worker/src/worker/job_runners/config/split_names_from_info.py
+++ b/services/worker/src/worker/job_runners/config/split_names_from_info.py
@@ -11,8 +11,8 @@ from libcommon.constants import (
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import get_previous_step_or_raise
 
+from worker.dtos import CompleteJobResult, JobRunnerInfo, SplitItem, SplitsList
 from worker.job_runners.config.config_job_runner import ConfigJobRunner
-from worker.utils import CompleteJobResult, JobRunnerInfo, SplitItem, SplitsList
 
 
 def compute_split_names_from_info_response(dataset: str, config: str) -> SplitsList:

--- a/services/worker/src/worker/job_runners/config/split_names_from_streaming.py
+++ b/services/worker/src/worker/job_runners/config/split_names_from_streaming.py
@@ -17,8 +17,8 @@ from libcommon.exceptions import (
     SplitNamesFromStreamingError,
 )
 
+from worker.dtos import CompleteJobResult, JobRunnerInfo, SplitItem, SplitsList
 from worker.job_runners.config.config_job_runner import ConfigJobRunnerWithDatasetsCache
-from worker.utils import CompleteJobResult, JobRunnerInfo, SplitItem, SplitsList
 
 
 def compute_split_names_from_streaming_response(

--- a/services/worker/src/worker/job_runners/dataset/config_names.py
+++ b/services/worker/src/worker/job_runners/dataset/config_names.py
@@ -2,7 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
-from typing import List, Optional, TypedDict, Union
+from typing import List, Optional, Union
 
 from datasets import get_dataset_config_names
 from datasets.data_files import EmptyDatasetError as _EmptyDatasetError
@@ -14,19 +14,10 @@ from libcommon.exceptions import (
     EmptyDatasetError,
 )
 
+from worker.dtos import CompleteJobResult, ConfigNameItem, DatasetConfigNamesResponse
 from worker.job_runners.dataset.dataset_job_runner import (
     DatasetJobRunnerWithDatasetsCache,
 )
-from worker.utils import CompleteJobResult
-
-
-class ConfigNameItem(TypedDict):
-    dataset: str
-    config: str
-
-
-class DatasetConfigNamesResponse(TypedDict):
-    config_names: List[ConfigNameItem]
 
 
 def compute_config_names_response(

--- a/services/worker/src/worker/job_runners/dataset/info.py
+++ b/services/worker/src/worker/job_runners/dataset/info.py
@@ -3,7 +3,7 @@
 
 import logging
 from http import HTTPStatus
-from typing import Any, Dict, List, Tuple, TypedDict
+from typing import Any, Dict, Tuple
 
 from libcommon.constants import PROCESSING_STEP_DATASET_INFO_VERSION
 from libcommon.exceptions import PreviousStepFormatError
@@ -13,14 +13,8 @@ from libcommon.simple_cache import (
     get_response,
 )
 
+from worker.dtos import DatasetInfoResponse, JobResult, PreviousJob
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
-from worker.utils import JobResult, PreviousJob
-
-
-class DatasetInfoResponse(TypedDict):
-    dataset_info: Dict[str, Any]
-    pending: List[PreviousJob]
-    failed: List[PreviousJob]
 
 
 def compute_dataset_info_response(dataset: str) -> Tuple[DatasetInfoResponse, float]:

--- a/services/worker/src/worker/job_runners/dataset/is_valid.py
+++ b/services/worker/src/worker/job_runners/dataset/is_valid.py
@@ -2,18 +2,13 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
-from typing import Tuple, TypedDict
+from typing import Tuple
 
 from libcommon.constants import PROCESSING_STEP_DATASET_IS_VALID_VERSION
 from libcommon.simple_cache import get_validity_by_kind
 
+from worker.dtos import DatasetIsValidResponse, JobResult
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
-from worker.utils import JobResult
-
-
-class DatasetIsValidResponse(TypedDict):
-    valid: bool
-
 
 SPLIT_KINDS = ["config-split-names-from-streaming", "config-split-names-from-info"]
 FIRST_ROWS_KINDS = ["split-first-rows-from-streaming", "split-first-rows-from-parquet"]

--- a/services/worker/src/worker/job_runners/dataset/opt_in_out_urls_count.py
+++ b/services/worker/src/worker/job_runners/dataset/opt_in_out_urls_count.py
@@ -13,8 +13,8 @@ from libcommon.simple_cache import (
     get_response,
 )
 
+from worker.dtos import JobResult, OptInOutUrlsCountResponse
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
-from worker.utils import JobResult, OptInOutUrlsCountResponse
 
 
 def compute_opt_in_out_urls_count_response(dataset: str) -> Tuple[OptInOutUrlsCountResponse, float]:

--- a/services/worker/src/worker/job_runners/dataset/parquet.py
+++ b/services/worker/src/worker/job_runners/dataset/parquet.py
@@ -3,7 +3,7 @@
 
 import logging
 from http import HTTPStatus
-from typing import List, Tuple, TypedDict
+from typing import Tuple
 
 from libcommon.constants import PROCESSING_STEP_DATASET_PARQUET_VERSION
 from libcommon.exceptions import PreviousStepFormatError
@@ -13,16 +13,14 @@ from libcommon.simple_cache import (
     get_response,
 )
 
-from worker.job_runners.config.parquet import ConfigParquetResponse
-from worker.job_runners.config.parquet_and_info import ParquetFileItem
+from worker.dtos import (
+    ConfigParquetResponse,
+    DatasetParquetResponse,
+    JobResult,
+    ParquetFileItem,
+    PreviousJob,
+)
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
-from worker.utils import JobResult, PreviousJob
-
-
-class DatasetParquetResponse(TypedDict):
-    parquet_files: List[ParquetFileItem]
-    pending: list[PreviousJob]
-    failed: list[PreviousJob]
 
 
 def compute_sizes_response(dataset: str) -> Tuple[DatasetParquetResponse, float]:

--- a/services/worker/src/worker/job_runners/dataset/size.py
+++ b/services/worker/src/worker/job_runners/dataset/size.py
@@ -3,7 +3,7 @@
 
 import logging
 from http import HTTPStatus
-from typing import Tuple, TypedDict
+from typing import Tuple
 
 from libcommon.constants import PROCESSING_STEP_DATASET_SIZE_VERSION
 from libcommon.exceptions import PreviousStepFormatError
@@ -13,29 +13,16 @@ from libcommon.simple_cache import (
     get_response,
 )
 
-from worker.job_runners.config.size import ConfigSize, ConfigSizeResponse, SplitSize
+from worker.dtos import (
+    ConfigSize,
+    ConfigSizeResponse,
+    DatasetSize,
+    DatasetSizeResponse,
+    JobResult,
+    PreviousJob,
+    SplitSize,
+)
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
-from worker.utils import JobResult, PreviousJob
-
-
-class DatasetSize(TypedDict):
-    dataset: str
-    num_bytes_original_files: int
-    num_bytes_parquet_files: int
-    num_bytes_memory: int
-    num_rows: int
-
-
-class DatasetSizeContent(TypedDict):
-    dataset: DatasetSize
-    configs: list[ConfigSize]
-    splits: list[SplitSize]
-
-
-class DatasetSizeResponse(TypedDict):
-    size: DatasetSizeContent
-    pending: list[PreviousJob]
-    failed: list[PreviousJob]
 
 
 def compute_sizes_response(dataset: str) -> Tuple[DatasetSizeResponse, float]:

--- a/services/worker/src/worker/job_runners/dataset/split_names.py
+++ b/services/worker/src/worker/job_runners/dataset/split_names.py
@@ -9,14 +9,14 @@ from libcommon.constants import PROCESSING_STEP_DATASET_SPLIT_NAMES_VERSION
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import get_best_response, get_previous_step_or_raise
 
-from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
-from worker.utils import (
+from worker.dtos import (
     ConfigItem,
     DatasetSplitNamesResponse,
     FailedConfigItem,
     JobResult,
     SplitItem,
 )
+from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 
 
 def compute_dataset_split_names_response(dataset: str) -> Tuple[DatasetSplitNamesResponse, float]:

--- a/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
@@ -21,17 +21,15 @@ from libcommon.utils import JobInfo
 from libcommon.viewer_utils.features import get_cell_value
 
 from worker.config import AppConfig, FirstRowsConfig
-from worker.job_runners.split.split_job_runner import SplitJobRunner
-from worker.utils import (
+from worker.dtos import (
     CompleteJobResult,
     JobRunnerInfo,
     Row,
     RowItem,
     SplitFirstRowsResponse,
-    create_truncated_row_items,
-    get_json_size,
-    to_features_list,
 )
+from worker.job_runners.split.split_job_runner import SplitJobRunner
+from worker.utils import create_truncated_row_items, get_json_size, to_features_list
 
 
 def transform_rows(

--- a/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
@@ -33,12 +33,9 @@ from libcommon.utils import JobInfo
 from libcommon.viewer_utils.features import get_cell_value
 
 from worker.config import AppConfig, FirstRowsConfig
+from worker.dtos import CompleteJobResult, JobRunnerInfo, Row, SplitFirstRowsResponse
 from worker.job_runners.split.split_job_runner import SplitJobRunnerWithDatasetsCache
 from worker.utils import (
-    CompleteJobResult,
-    JobRunnerInfo,
-    Row,
-    SplitFirstRowsResponse,
     create_truncated_row_items,
     get_json_size,
     get_rows_or_raise,

--- a/services/worker/src/worker/job_runners/split/image_url_columns.py
+++ b/services/worker/src/worker/job_runners/split/image_url_columns.py
@@ -8,12 +8,12 @@ from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import get_previous_step_or_raise
 from libcommon.utils import is_image_url
 
-from worker.job_runners.split.split_job_runner import SplitJobRunner
-from worker.utils import (
+from worker.dtos import (
     CompleteJobResult,
     ImageUrlColumnsResponse,
     SplitFirstRowsResponse,
 )
+from worker.job_runners.split.split_job_runner import SplitJobRunner
 
 STRING_FEATURE_DTYPE = "string"
 VALUE_FEATURE_TYPE = "Value"

--- a/services/worker/src/worker/job_runners/split/opt_in_out_urls_count.py
+++ b/services/worker/src/worker/job_runners/split/opt_in_out_urls_count.py
@@ -7,8 +7,8 @@ from libcommon.constants import PROCESSING_STEP_SPLIT_OPT_IN_OUT_URLS_COUNT_VERS
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import get_previous_step_or_raise
 
+from worker.dtos import CompleteJobResult, OptInOutUrlsCountResponse
 from worker.job_runners.split.split_job_runner import SplitJobRunner
-from worker.utils import CompleteJobResult, OptInOutUrlsCountResponse
 
 
 def compute_opt_in_out_urls_count_response(

--- a/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
@@ -22,13 +22,9 @@ from libcommon.simple_cache import get_previous_step_or_raise
 from libcommon.utils import JobInfo
 
 from worker.config import AppConfig, OptInOutUrlsScanConfig
+from worker.dtos import CompleteJobResult, OptInOutUrlsScanResponse, OptUrl
 from worker.job_runners.split.split_job_runner import SplitJobRunnerWithDatasetsCache
-from worker.utils import (
-    CompleteJobResult,
-    OptInOutUrlsScanResponse,
-    OptUrl,
-    get_rows_or_raise,
-)
+from worker.utils import get_rows_or_raise
 
 
 async def check_spawning(

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -6,17 +6,14 @@ import itertools
 import logging
 import time
 import warnings
-from dataclasses import dataclass, field
 from typing import (
     Any,
     Callable,
     List,
-    Mapping,
     Optional,
     Sequence,
     Tuple,
     Type,
-    TypedDict,
     TypeVar,
     Union,
     cast,
@@ -34,118 +31,10 @@ from datasets import (
 from libcommon.exceptions import NormalRowsError, StreamingRowsError
 from libcommon.utils import orjson_dumps
 
+from worker.dtos import FeatureItem, Row, RowItem, RowsContent
+
 MAX_IMAGE_PIXELS = 10_000_000_000
 # ^ see https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.MAX_IMAGE_PIXELS
-
-
-class JobRunnerInfo(TypedDict):
-    job_type: str
-    job_runner_version: int
-
-
-@dataclass
-class JobResult:
-    content: Mapping[str, Any]
-    progress: float
-
-    def __post_init__(self) -> None:
-        if self.progress < 0.0 or self.progress > 1.0:
-            raise ValueError(f"Progress should be between 0 and 1, but got {self.progress}")
-
-
-@dataclass
-class CompleteJobResult(JobResult):
-    content: Mapping[str, Any]
-    progress: float = field(init=False, default=1.0)
-
-
-class DatasetItem(TypedDict):
-    dataset: str
-
-
-class ConfigItem(DatasetItem):
-    config: Optional[str]
-
-
-class SplitItem(ConfigItem):
-    split: Optional[str]
-
-
-class SplitsList(TypedDict):
-    splits: List[SplitItem]
-
-
-class FailedConfigItem(ConfigItem):
-    error: Mapping[str, Any]
-
-
-class DatasetSplitNamesResponse(TypedDict):
-    splits: List[SplitItem]
-    pending: List[ConfigItem]
-    failed: List[FailedConfigItem]
-
-
-class PreviousJob(TypedDict):
-    kind: str
-    dataset: str
-    config: Optional[str]
-    split: Optional[str]
-
-
-class FeatureItem(TypedDict):
-    feature_idx: int
-    name: str
-    type: Mapping[str, Any]
-
-
-class RowItem(TypedDict):
-    row_idx: int
-    row: Mapping[str, Any]
-    truncated_cells: List[str]
-
-
-class SplitFirstRowsResponse(TypedDict):
-    dataset: str
-    config: str
-    split: str
-    features: List[FeatureItem]
-    rows: List[RowItem]
-
-
-class OptUrl(TypedDict):
-    url: str
-    row_idx: int
-    column_name: str
-
-
-class OptInOutUrlsCountResponse(TypedDict):
-    urls_columns: List[str]
-    num_opt_in_urls: int
-    num_opt_out_urls: int
-    num_urls: int
-    num_scanned_rows: int
-    has_urls_columns: bool
-    full_scan: Optional[bool]
-
-
-class OptInOutUrlsScanResponse(OptInOutUrlsCountResponse):
-    opt_in_urls: List[OptUrl]
-    opt_out_urls: List[OptUrl]
-
-
-class ImageUrlColumnsResponse(TypedDict):
-    columns: List[str]
-
-
-Row = Mapping[str, Any]
-
-
-class RowsContent(TypedDict):
-    rows: List[Row]
-    all_fetched: bool
-
-
-# TODO: separate functions from common classes and named dicts otherwise this file will continue growing
 
 
 # in JSON, dicts do not carry any order, so we need to return a list

--- a/services/worker/tests/job_runners/config/test_config_job_runner.py
+++ b/services/worker/tests/job_runners/config/test_config_job_runner.py
@@ -9,8 +9,8 @@ from libcommon.processing_graph import ProcessingStep
 from libcommon.utils import Priority
 
 from worker.config import AppConfig
+from worker.dtos import CompleteJobResult
 from worker.job_runners.config.config_job_runner import ConfigJobRunner
-from worker.utils import CompleteJobResult
 
 
 class DummyConfigJobRunner(ConfigJobRunner):

--- a/services/worker/tests/job_runners/config/test_parquet.py
+++ b/services/worker/tests/job_runners/config/test_parquet.py
@@ -12,14 +12,12 @@ from libcommon.simple_cache import CachedArtifactError, upsert_response
 from libcommon.utils import Priority
 
 from worker.config import AppConfig
-from worker.job_runners.config.parquet import (
-    ConfigParquetJobRunner,
-    ConfigParquetResponse,
-)
-from worker.job_runners.config.parquet_and_info import (
+from worker.dtos import (
     ConfigParquetAndInfoResponse,
+    ConfigParquetResponse,
     ParquetFileItem,
 )
+from worker.job_runners.config.parquet import ConfigParquetJobRunner
 
 
 @pytest.fixture(autouse=True)

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -34,6 +34,7 @@ from libcommon.simple_cache import CachedArtifactError, upsert_response
 from libcommon.utils import JobInfo, JobParams, Priority
 
 from worker.config import AppConfig
+from worker.dtos import CompleteJobResult
 from worker.job_manager import JobManager
 from worker.job_runners.config.parquet_and_info import (
     ConfigParquetAndInfoJobRunner,
@@ -48,7 +49,6 @@ from worker.job_runners.config.parquet_and_info import (
 )
 from worker.job_runners.dataset.config_names import DatasetConfigNamesJobRunner
 from worker.resources import LibrariesResource
-from worker.utils import CompleteJobResult
 
 from ...constants import CI_HUB_ENDPOINT, CI_USER_TOKEN
 from ...fixtures.hub import HubDatasetTest

--- a/services/worker/tests/job_runners/config/test_parquet_metadata.py
+++ b/services/worker/tests/job_runners/config/test_parquet_metadata.py
@@ -19,13 +19,13 @@ from libcommon.storage import StrPath
 from libcommon.utils import Priority
 
 from worker.config import AppConfig
-from worker.job_runners.config.parquet import ConfigParquetResponse
-from worker.job_runners.config.parquet_and_info import ParquetFileItem
-from worker.job_runners.config.parquet_metadata import (
-    ConfigParquetMetadataJobRunner,
+from worker.dtos import (
     ConfigParquetMetadataResponse,
+    ConfigParquetResponse,
+    ParquetFileItem,
     ParquetFileMetadataItem,
 )
+from worker.job_runners.config.parquet_metadata import ConfigParquetMetadataJobRunner
 
 
 @pytest.fixture(autouse=True)

--- a/services/worker/tests/job_runners/dataset/test_dataset_job_runner.py
+++ b/services/worker/tests/job_runners/dataset/test_dataset_job_runner.py
@@ -9,8 +9,8 @@ from libcommon.processing_graph import ProcessingStep
 from libcommon.utils import Priority
 
 from worker.config import AppConfig
+from worker.dtos import CompleteJobResult
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
-from worker.utils import CompleteJobResult
 
 
 class DummyDatasetJobRunner(DatasetJobRunner):

--- a/services/worker/tests/job_runners/dataset/test_info.py
+++ b/services/worker/tests/job_runners/dataset/test_info.py
@@ -12,8 +12,8 @@ from libcommon.simple_cache import CachedArtifactError, upsert_response
 from libcommon.utils import Priority
 
 from worker.config import AppConfig
+from worker.dtos import PreviousJob
 from worker.job_runners.dataset.info import DatasetInfoJobRunner
-from worker.utils import PreviousJob
 
 from ..config.test_info import CONFIG_INFO_1, CONFIG_INFO_2, DATASET_INFO_OK
 from ..utils import UpstreamResponse

--- a/services/worker/tests/job_runners/dataset/test_parquet.py
+++ b/services/worker/tests/job_runners/dataset/test_parquet.py
@@ -12,12 +12,8 @@ from libcommon.simple_cache import CachedArtifactError, upsert_response
 from libcommon.utils import Priority
 
 from worker.config import AppConfig
-from worker.job_runners.config.parquet import ConfigParquetResponse
-from worker.job_runners.config.parquet_and_info import ParquetFileItem
-from worker.job_runners.dataset.parquet import (
-    DatasetParquetJobRunner,
-    DatasetParquetResponse,
-)
+from worker.dtos import ConfigParquetResponse, DatasetParquetResponse, ParquetFileItem
+from worker.job_runners.dataset.parquet import DatasetParquetJobRunner
 
 from ..utils import UpstreamResponse
 

--- a/services/worker/tests/job_runners/split/test_image_url_columns.py
+++ b/services/worker/tests/job_runners/split/test_image_url_columns.py
@@ -15,8 +15,8 @@ from libcommon.simple_cache import upsert_response
 from libcommon.utils import Priority
 
 from worker.config import AppConfig
+from worker.dtos import ImageUrlColumnsResponse
 from worker.job_runners.split.image_url_columns import SplitImageUrlColumnsJobRunner
-from worker.utils import ImageUrlColumnsResponse
 
 from ...fixtures.hub import get_default_config_split
 

--- a/services/worker/tests/job_runners/split/test_opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/tests/job_runners/split/test_opt_in_out_urls_scan_from_streaming.py
@@ -21,12 +21,12 @@ from libcommon.simple_cache import upsert_response
 from libcommon.utils import Priority
 
 from worker.config import AppConfig
+from worker.dtos import ImageUrlColumnsResponse
 from worker.job_runners.split.opt_in_out_urls_scan_from_streaming import (
     SplitOptInOutUrlsScanJobRunner,
     check_spawning,
 )
 from worker.resources import LibrariesResource
-from worker.utils import ImageUrlColumnsResponse
 
 from ...constants import CI_SPAWNING_TOKEN
 from ...fixtures.hub import HubDatasetTest, get_default_config_split

--- a/services/worker/tests/job_runners/split/test_split_job_runner.py
+++ b/services/worker/tests/job_runners/split/test_split_job_runner.py
@@ -9,8 +9,8 @@ from libcommon.processing_graph import ProcessingStep
 from libcommon.utils import Priority
 
 from worker.config import AppConfig
+from worker.dtos import CompleteJobResult
 from worker.job_runners.split.split_job_runner import SplitJobRunner
-from worker.utils import CompleteJobResult
 
 
 class DummySplitJobRunner(SplitJobRunner):

--- a/services/worker/tests/job_runners/test__job_runner_with_cache.py
+++ b/services/worker/tests/job_runners/test__job_runner_with_cache.py
@@ -11,9 +11,9 @@ from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.utils import Priority
 
 from worker.config import AppConfig
+from worker.dtos import CompleteJobResult
 from worker.job_runners._job_runner_with_cache import JobRunnerWithCache
 from worker.resources import LibrariesResource
-from worker.utils import CompleteJobResult
 
 from ..fixtures.hub import get_default_config_split
 

--- a/services/worker/tests/job_runners/test__job_runner_with_datasets_cache.py
+++ b/services/worker/tests/job_runners/test__job_runner_with_datasets_cache.py
@@ -11,11 +11,11 @@ from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.utils import Priority
 
 from worker.config import AppConfig
+from worker.dtos import CompleteJobResult
 from worker.job_runners._job_runner_with_datasets_cache import (
     JobRunnerWithDatasetsCache,
 )
 from worker.resources import LibrariesResource
-from worker.utils import CompleteJobResult
 
 from ..fixtures.hub import get_default_config_split
 

--- a/services/worker/tests/test_job_manager.py
+++ b/services/worker/tests/test_job_manager.py
@@ -11,9 +11,9 @@ from libcommon.simple_cache import CachedResponse, get_response, upsert_response
 from libcommon.utils import JobInfo, Priority, Status
 
 from worker.config import AppConfig
+from worker.dtos import CompleteJobResult
 from worker.job_manager import JobManager
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
-from worker.utils import CompleteJobResult
 
 from .fixtures.hub import get_default_config_split
 

--- a/services/worker/tests/test_loop.py
+++ b/services/worker/tests/test_loop.py
@@ -5,11 +5,11 @@ from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.utils import JobInfo
 
 from worker.config import AppConfig
+from worker.dtos import CompleteJobResult
 from worker.job_runner import JobRunner
 from worker.job_runner_factory import BaseJobRunnerFactory
 from worker.loop import Loop
 from worker.resources import LibrariesResource
-from worker.utils import CompleteJobResult
 
 
 class DummyJobRunner(JobRunner):


### PR DESCRIPTION
Currently, we have data transfer objects in the `utils.py` file, but this one is growing and growing and sometime we could have duplicated code if don't verify the existing models.
This PR just moves all the abstractions of responses to a `dtos.py` file.
Most of the files are changes on the `imports` definition.
