### PR TITLE
fix: 🐛 remove the "required" constraint on created_at in Lock

### DIFF
--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -236,7 +236,7 @@ class Lock(Document):
     owner = StringField()
     job_id = StringField()  # deprecated
 
-    created_at = DateTimeField(required=True)
+    created_at = DateTimeField()
     updated_at = DateTimeField()
 
     objects = QuerySetManager["Lock"]()


### PR DESCRIPTION
the code does not rely on always having a created_at field. And it's not that easy to always ensure it's filled (see `update(upsert=True, ...`)