### PR TITLE
Set Duckdb extensions install directory

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.13.0
+version: 1.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/_envWorker.tpl
+++ b/chart/templates/_envWorker.tpl
@@ -108,4 +108,6 @@
   value: {{ .Values.duckDBIndex.maxParquetSizeBytes | quote }}
 - name: DUCKDB_INDEX_STORAGE_DIRECTORY
   value: {{ .Values.duckDBIndex.storageDirectory | quote }}
+- name: DUCKDB_INDEX_EXTENSIONS_DIRECTORY
+  value: "/tmp/duckdb-extensions"
 {{- end -}}

--- a/libs/libcommon/src/libcommon/config.py
+++ b/libs/libcommon/src/libcommon/config.py
@@ -111,7 +111,7 @@ DUCKDB_INDEX_COMMITTER_HF_TOKEN = None
 DUCKDB_INDEX_MAX_PARQUET_SIZE_BYTES = 100_000_000
 DUCKDB_INDEX_TARGET_REVISION = "refs/convert/parquet"
 DUCKDB_INDEX_URL_TEMPLATE = "/datasets/%s/resolve/%s/%s"
-DUCKDB_INDEX_EXTENSIONS_DIRECTORY = "/tmp/duckdb-extensions"
+DUCKDB_INDEX_EXTENSIONS_DIRECTORY: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -122,7 +122,7 @@ class DuckDbIndexConfig:
     target_revision: str = DUCKDB_INDEX_TARGET_REVISION
     url_template: str = DUCKDB_INDEX_URL_TEMPLATE
     max_parquet_size_bytes: int = DUCKDB_INDEX_MAX_PARQUET_SIZE_BYTES
-    extensions_directory: str = DUCKDB_INDEX_EXTENSIONS_DIRECTORY
+    extensions_directory: Optional[str] = DUCKDB_INDEX_EXTENSIONS_DIRECTORY
 
     @classmethod
     def from_env(cls) -> "DuckDbIndexConfig":

--- a/libs/libcommon/src/libcommon/config.py
+++ b/libs/libcommon/src/libcommon/config.py
@@ -111,6 +111,7 @@ DUCKDB_INDEX_COMMITTER_HF_TOKEN = None
 DUCKDB_INDEX_MAX_PARQUET_SIZE_BYTES = 100_000_000
 DUCKDB_INDEX_TARGET_REVISION = "refs/convert/parquet"
 DUCKDB_INDEX_URL_TEMPLATE = "/datasets/%s/resolve/%s/%s"
+DUCKDB_INDEX_EXTENSIONS_DIRECTORY = "/tmp/duckdb-extensions"
 
 
 @dataclass(frozen=True)
@@ -121,6 +122,7 @@ class DuckDbIndexConfig:
     target_revision: str = DUCKDB_INDEX_TARGET_REVISION
     url_template: str = DUCKDB_INDEX_URL_TEMPLATE
     max_parquet_size_bytes: int = DUCKDB_INDEX_MAX_PARQUET_SIZE_BYTES
+    extensions_directory: str = DUCKDB_INDEX_EXTENSIONS_DIRECTORY
 
     @classmethod
     def from_env(cls) -> "DuckDbIndexConfig":
@@ -135,6 +137,7 @@ class DuckDbIndexConfig:
                 max_parquet_size_bytes=env.int(
                     name="MAX_PARQUET_SIZE_BYTES", default=DUCKDB_INDEX_MAX_PARQUET_SIZE_BYTES
                 ),
+                extensions_directory=env.str(name="EXTENSIONS_DIRECTORY", default=DUCKDB_INDEX_EXTENSIONS_DIRECTORY),
             )
 
 

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -58,10 +58,10 @@ def compute_index_rows(
     target_revision: str,
     hf_endpoint: str,
     commit_message: str,
-    extensions_directory: str,
     url_template: str,
     hf_token: Optional[str],
     max_parquet_size_bytes: int,
+    extensions_directory: Optional[str],
     committer_hf_token: Optional[str],
 ) -> SplitHubFile:
     logging.info(f"get split-duckdb-index for dataset={dataset} config={config} split={split}")
@@ -128,7 +128,9 @@ def compute_index_rows(
         ) from e
 
     # configure duckdb extensions
-    duckdb.execute(SET_EXTENSIONS_DIRECTORY_COMMAND.format(directory=extensions_directory))
+    if extensions_directory is not None:
+        duckdb.execute(SET_EXTENSIONS_DIRECTORY_COMMAND.format(directory=extensions_directory))
+
     duckdb.execute(INSTALL_EXTENSION_COMMAND.format(extension="httpfs"))
     duckdb.execute(LOAD_EXTENSION_COMMAND.format(extension="httpfs"))
     duckdb.execute(INSTALL_EXTENSION_COMMAND.format(extension="fts"))

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -46,6 +46,7 @@ CREATE_INDEX_COMMAND = "PRAGMA create_fts_index('data', '__hf_index_id', '*', ov
 CREATE_TABLE_COMMAND = "CREATE OR REPLACE TABLE data AS SELECT nextval('serial') AS __hf_index_id, {columns} FROM"
 INSTALL_EXTENSION_COMMAND = "INSTALL '{extension}';"
 LOAD_EXTENSION_COMMAND = "LOAD '{extension}';"
+SET_EXTENSIONS_DIRECTORY_COMMAND = "SET extension_directory='{directory}';"
 
 
 def compute_index_rows(
@@ -57,6 +58,7 @@ def compute_index_rows(
     target_revision: str,
     hf_endpoint: str,
     commit_message: str,
+    extensions_directory: str,
     url_template: str,
     hf_token: Optional[str],
     max_parquet_size_bytes: int,
@@ -126,6 +128,7 @@ def compute_index_rows(
         ) from e
 
     # configure duckdb extensions
+    duckdb.execute(SET_EXTENSIONS_DIRECTORY_COMMAND.format(directory=extensions_directory))
     duckdb.execute(INSTALL_EXTENSION_COMMAND.format(extension="httpfs"))
     duckdb.execute(LOAD_EXTENSION_COMMAND.format(extension="httpfs"))
     duckdb.execute(INSTALL_EXTENSION_COMMAND.format(extension="fts"))
@@ -257,6 +260,7 @@ class SplitDuckDbIndexJobRunner(SplitJobRunnerWithCache):
                 hf_token=self.app_config.common.hf_token,
                 url_template=self.duckdb_index_config.url_template,
                 commit_message=self.duckdb_index_config.commit_message,
+                extensions_directory=self.duckdb_index_config.extensions_directory,
                 committer_hf_token=self.duckdb_index_config.committer_hf_token,
                 hf_endpoint=self.app_config.common.hf_endpoint,
                 target_revision=self.duckdb_index_config.target_revision,


### PR DESCRIPTION
Error `duckdb.IOException: IO Error: Failed to create directory \"//.duckdb\"!\n `
is shown when computing duckdb index.