### PR TITLE
Adding other processing steps

### DIFF
--- a/libs/libcommon/src/libcommon/config.py
+++ b/libs/libcommon/src/libcommon/config.py
@@ -360,6 +360,8 @@ class ProcessingGraphConfig:
                 "input_type": "split",
                 "triggered_by": [
                     "config-split-names-from-info",
+                    "config-split-names-from-streaming",
+                    "config-parquet-and-info",
                 ],
                 "job_runner_version": PROCESSING_STEP_SPLIT_DUCKDB_INDEX_VERSION,
             },

--- a/libs/libcommon/tests/test_processing_graph.py
+++ b/libs/libcommon/tests/test_processing_graph.py
@@ -83,6 +83,7 @@ def graph() -> ProcessingGraph:
                 "config-parquet",
                 "config-info",
                 "config-size",
+                "split-duckdb-index",
             ],
             ["dataset-config-names"],
             ["dataset-config-names"],
@@ -104,6 +105,7 @@ def graph() -> ProcessingGraph:
                 "split-first-rows-from-streaming",
                 "dataset-split-names",
                 "config-opt-in-out-urls-count",
+                "split-duckdb-index",
             ],
             ["dataset-config-names"],
             ["dataset-config-names"],
@@ -295,9 +297,10 @@ def graph() -> ProcessingGraph:
         (
             "split-duckdb-index",
             [],
-            ["config-split-names-from-info"],
+            ["config-split-names-from-info", "config-split-names-from-streaming", "config-parquet-and-info"],
             [
                 "config-split-names-from-info",
+                "config-split-names-from-streaming",
                 "config-parquet-and-info",
                 "config-info",
                 "dataset-config-names",


### PR DESCRIPTION
Previously, `split-duckdb-index` was triggered only by `config-split-names-from-info` but when this step finished with error 500 because of ResponseAlreadyComputedError, `split-duckdb-index` never started.
Adding other parents to avoid skipping job compute. 

Note that  the issue with parallel processing steps will remain and should be fixed on https://github.com/huggingface/datasets-server/issues/1358
