### PR TITLE
Adding debug logs for split-duckdb-index

### DIFF
--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -161,6 +161,7 @@ def compute_index_rows(
         with lock.git_branch(
             dataset=dataset, branch=target_revision, owner=job_id, sleeps=LOCK_GIT_BRANCH_RETRY_SLEEPS
         ):
+            logging.debug(f"try to create branch for {dataset=} with {target_revision=}")
             create_branch(
                 dataset=dataset,
                 target_revision=target_revision,
@@ -168,16 +169,19 @@ def compute_index_rows(
                 committer_hf_api=committer_hf_api,
             )
 
+            logging.debug(f"get dataset info for {dataset=} with {target_revision=}")
             target_dataset_info = hf_api.dataset_info(repo_id=dataset, revision=target_revision, files_metadata=False)
             all_repo_files: Set[str] = {f.rfilename for f in target_dataset_info.siblings}
             delete_operations: List[CommitOperation] = []
             if index_file_location in all_repo_files:
                 delete_operations.append(CommitOperationDelete(path_in_repo=index_file_location))
+            logging.debug(f"delete operations for {dataset=} {delete_operations=}")
 
             # send the files to the target revision
             add_operations: List[CommitOperation] = [
                 CommitOperationAdd(path_in_repo=index_file_location, path_or_fileobj=db_path.resolve())
             ]
+            logging.debug(f"add operations for {dataset=} {add_operations=}")
 
             committer_hf_api.create_commit(
                 repo_id=dataset,
@@ -187,9 +191,11 @@ def compute_index_rows(
                 commit_message=commit_message,
                 parent_commit=target_dataset_info.sha,
             )
+            logging.debug(f"create commit {commit_message} for {dataset=} {add_operations=}")
 
             # call the API again to get the index file
             target_dataset_info = hf_api.dataset_info(repo_id=dataset, revision=target_revision, files_metadata=True)
+            logging.debug(f"dataset info for {dataset=} {target_dataset_info=}")
     except TimeoutError as err:
         raise LockedDatasetTimeoutError("the dataset is currently locked, please try again later.") from err
     except RepositoryNotFoundError as err:

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -161,7 +161,7 @@ def compute_index_rows(
         with lock.git_branch(
             dataset=dataset, branch=target_revision, owner=job_id, sleeps=LOCK_GIT_BRANCH_RETRY_SLEEPS
         ):
-            logging.debug(f"try to create branch for {dataset=} with {target_revision=}")
+            logging.debug(f"try to create branch for {dataset=} with {target_revision=} on {hf_endpoint=}")
             create_branch(
                 dataset=dataset,
                 target_revision=target_revision,


### PR DESCRIPTION
When processing split-duckdb-index in staging env, it is showing this message:
```
DEBUG: 2023-06-28 13:42:51,345 - root - The dataset does not exist on the Hub.
DEBUG: 2023-06-28 13:42:51,349 - root - Directory removed: /duckdb-index/21626898975922-split-duckdb-index-asoria-sample_glue-84f50613
DEBUG: 2023-06-28 13:42:51,349 - root - [split-duckdb-index] the dataset=asoria/sample_glue could not be found, don't update the cache
DEBUG: 2023-06-28 13:42:51,350 - root - [split-duckdb-index] job output with ERROR - JobManager(job_id=649c38d766b00b1fb05b8e4e dataset=asoria/sample_glue job_info={'job_id': '649c38d766b00b1fb05b8e4e', 'type': 'split-duckdb-index', 'params': {'dataset': 'asoria/sample_glue', 'revision': 'cf2d2d9273f1d361831baafab1f29eeb95a6af56', 'config': 'default', 'split': 'test'}, 'priority': <Priority.NORMAL: 'normal'>}

```
Looks like some hub operation does not find the dataset and it is not possible to store the cache result.
Adding a couple of logs for debug.