### PR TITLE
Update quality target in Makefile for /chart

### DIFF
--- a/chart/Makefile
+++ b/chart/Makefile
@@ -5,5 +5,5 @@ init:
 .PHONY: quality
 quality:
 	helm lint
-	helm lint --values env/dev.yaml
+	helm lint --values env/staging.yaml
 	helm lint --values env/prod.yaml


### PR DESCRIPTION
The path to staging environment in the Makefile was outdated (the name was changed from `dev` to `staging`)