### PR TITLE
feat: 🎸 use Normal priority only for API

### DIFF
--- a/libs/libcommon/src/libcommon/operations.py
+++ b/libs/libcommon/src/libcommon/operations.py
@@ -13,7 +13,7 @@ def backfill_dataset(
     dataset: str,
     revision: str,
     processing_graph: ProcessingGraph,
-    priority: Priority = Priority.NORMAL,
+    priority: Priority = Priority.LOW,
 ) -> None:
     """
     Update a dataset
@@ -22,7 +22,7 @@ def backfill_dataset(
         dataset (str): the dataset
         revision (str): The revision of the dataset.
         processing_graph (ProcessingGraph): the processing graph
-        priority (Priority, optional): The priority of the job. Defaults to Priority.NORMAL.
+        priority (Priority, optional): The priority of the job. Defaults to Priority.LOW.
 
     Returns: None.
     """

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -126,7 +126,7 @@ class JobDocument(Document):
         unicity_id (`str`): A string that identifies the job uniquely. Only one job with the same unicity_id can be in
           the started state. The revision is not part of the unicity_id.
         namespace (`str`): The dataset namespace (user or organization) if any, else the dataset name (canonical name).
-        priority (`Priority`, optional): The priority of the job. Defaults to Priority.NORMAL.
+        priority (`Priority`, optional): The priority of the job. Defaults to Priority.LOW.
         status (`Status`, optional): The status of the job. Defaults to Status.WAITING.
         created_at (`datetime`): The creation date of the job.
         started_at (`datetime`, optional): When the job has started.
@@ -166,7 +166,7 @@ class JobDocument(Document):
     split = StringField()
     unicity_id = StringField(required=True)
     namespace = StringField(required=True)
-    priority = EnumField(Priority, default=Priority.NORMAL)
+    priority = EnumField(Priority, default=Priority.LOW)
     status = EnumField(Status, default=Status.WAITING)
     created_at = DateTimeField(required=True)
     started_at = DateTimeField()
@@ -347,7 +347,7 @@ class Queue:
         revision: str,
         config: Optional[str] = None,
         split: Optional[str] = None,
-        priority: Priority = Priority.NORMAL,
+        priority: Priority = Priority.LOW,
     ) -> JobDocument:
         """Add a job to the queue in the waiting state.
 
@@ -360,7 +360,7 @@ class Queue:
             revision (`str`): The git revision of the dataset.
             config (`str`, optional): The config on which to apply the job.
             split (`str`, optional): The config on which to apply the job.
-            priority (`Priority`, optional): The priority of the job. Defaults to Priority.NORMAL.
+            priority (`Priority`, optional): The priority of the job. Defaults to Priority.LOW.
 
         Returns: the job
         """

--- a/libs/libcommon/tests/test_queue.py
+++ b/libs/libcommon/tests/test_queue.py
@@ -127,8 +127,8 @@ def test_priority_logic_creation_order() -> None:
     queue = Queue()
     queue.add_job(job_type=test_type, dataset="dataset1", revision=test_revision, config="config", split="split1")
     queue.add_job(job_type=test_type, dataset="dataset1", revision=test_revision, config="config", split="split2")
-    check_job(queue=queue, expected_dataset="dataset1", expected_split="split1", expected_priority=Priority.NORMAL)
-    check_job(queue=queue, expected_dataset="dataset1", expected_split="split2", expected_priority=Priority.NORMAL)
+    check_job(queue=queue, expected_dataset="dataset1", expected_split="split1", expected_priority=Priority.LOW)
+    check_job(queue=queue, expected_dataset="dataset1", expected_split="split2", expected_priority=Priority.LOW)
     with pytest.raises(EmptyQueueError):
         queue.start_job()
 
@@ -140,10 +140,10 @@ def test_priority_logic_started_jobs_per_dataset_order() -> None:
     queue.add_job(job_type=test_type, dataset="dataset1", revision=test_revision, config="config", split="split1")
     queue.add_job(job_type=test_type, dataset="dataset1", revision=test_revision, config="config", split="split2")
     queue.add_job(job_type=test_type, dataset="dataset2", revision=test_revision, config="config", split="split1")
-    check_job(queue=queue, expected_dataset="dataset1", expected_split="split1", expected_priority=Priority.NORMAL)
-    check_job(queue=queue, expected_dataset="dataset2", expected_split="split1", expected_priority=Priority.NORMAL)
+    check_job(queue=queue, expected_dataset="dataset1", expected_split="split1", expected_priority=Priority.LOW)
+    check_job(queue=queue, expected_dataset="dataset2", expected_split="split1", expected_priority=Priority.LOW)
     # ^ before, even if the creation date is after, because the dataset is different and has no started job
-    check_job(queue=queue, expected_dataset="dataset1", expected_split="split2", expected_priority=Priority.NORMAL)
+    check_job(queue=queue, expected_dataset="dataset1", expected_split="split2", expected_priority=Priority.LOW)
     with pytest.raises(EmptyQueueError):
         queue.start_job()
 
@@ -158,19 +158,11 @@ def test_priority_logic_started_jobs_per_namespace_order() -> None:
     queue.add_job(
         job_type=test_type, dataset="no_org_dataset3", revision=test_revision, config="config", split="split1"
     )
-    check_job(
-        queue=queue, expected_dataset="org1/dataset1", expected_split="split1", expected_priority=Priority.NORMAL
-    )
-    check_job(
-        queue=queue, expected_dataset="org2/dataset2", expected_split="split1", expected_priority=Priority.NORMAL
-    )
+    check_job(queue=queue, expected_dataset="org1/dataset1", expected_split="split1", expected_priority=Priority.LOW)
+    check_job(queue=queue, expected_dataset="org2/dataset2", expected_split="split1", expected_priority=Priority.LOW)
     # ^ before, even if the creation date is after, because the namespace is different and has no started job
-    check_job(
-        queue=queue, expected_dataset="no_org_dataset3", expected_split="split1", expected_priority=Priority.NORMAL
-    )
-    check_job(
-        queue=queue, expected_dataset="org1/dataset2", expected_split="split1", expected_priority=Priority.NORMAL
-    )
+    check_job(queue=queue, expected_dataset="no_org_dataset3", expected_split="split1", expected_priority=Priority.LOW)
+    check_job(queue=queue, expected_dataset="org1/dataset2", expected_split="split1", expected_priority=Priority.LOW)
     with pytest.raises(EmptyQueueError):
         queue.start_job()
 
@@ -185,9 +177,15 @@ def test_priority_logic_priority_order() -> None:
         revision=test_revision,
         config="config",
         split="split1",
-        priority=Priority.LOW,
     )
-    queue.add_job(job_type=test_type, dataset="dataset2", revision=test_revision, config="config", split="split1")
+    queue.add_job(
+        job_type=test_type,
+        dataset="dataset2",
+        revision=test_revision,
+        config="config",
+        split="split1",
+        priority=Priority.NORMAL,
+    )
     check_job(queue=queue, expected_dataset="dataset2", expected_split="split1", expected_priority=Priority.NORMAL)
     # ^ before, even if the creation date is after, because the priority is higher
     check_job(queue=queue, expected_dataset="dataset1", expected_split="split1", expected_priority=Priority.LOW)

--- a/services/admin/src/admin/routes/dataset_backfill.py
+++ b/services/admin/src/admin/routes/dataset_backfill.py
@@ -50,7 +50,7 @@ def create_dataset_backfill_endpoint(
                 dataset=dataset, hf_endpoint=hf_endpoint, hf_token=hf_token, hf_timeout_seconds=hf_timeout_seconds
             )
             dataset_orchestrator = DatasetOrchestrator(dataset=dataset, processing_graph=processing_graph)
-            dataset_orchestrator.backfill(revision=dataset_git_revision, priority=Priority.NORMAL)
+            dataset_orchestrator.backfill(revision=dataset_git_revision, priority=Priority.LOW)
             return get_json_ok_response(
                 {"status": "ok", "message": "Backfilling dataset."},
                 max_age=0,

--- a/services/admin/src/admin/routes/force_refresh.py
+++ b/services/admin/src/admin/routes/force_refresh.py
@@ -8,6 +8,7 @@ from libcommon.dataset import get_dataset_git_revision
 from libcommon.exceptions import CustomError
 from libcommon.processing_graph import InputType
 from libcommon.queue import Queue
+from libcommon.utils import Priority
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -59,7 +60,14 @@ def create_force_refresh_endpoint(
                 hf_timeout_seconds=hf_timeout_seconds,
             )
             revision = get_dataset_git_revision(dataset=dataset, hf_endpoint=hf_endpoint, hf_token=hf_token)
-            Queue().add_job(job_type=job_type, dataset=dataset, revision=revision, config=config, split=split)
+            Queue().add_job(
+                job_type=job_type,
+                dataset=dataset,
+                revision=revision,
+                config=config,
+                split=split,
+                priority=Priority.LOW,
+            )
             return get_json_ok_response(
                 {"status": "ok"},
                 max_age=0,


### PR DESCRIPTION
webhook and jobs created when a requested cache entry is missing are the only ones with Priority.NORMAL. All the jobs created by administrative tasks (/force-refresh, /backfill, backfill job...) will use Priority.LOW.