### PR TITLE
Add partial to subsequent parquet-and-info jobs

### DIFF
--- a/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230703110100_cache_add_partial_field_in_config_parquet_and_info.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230703110100_cache_add_partial_field_in_config_parquet_and_info.py
@@ -17,12 +17,21 @@ class MigrationAddPartialToCacheResponse(Migration):
         # See https://docs.mongoengine.org/guide/migration.html#example-1-addition-of-a-field
         logging.info(
             "If missing, add the partial field with the default value (false) to the cached results of"
-            " config-parquet-and-info"
+            " config-parquet-and-info and subsequent steps"
         )
         db = get_db(CACHE_MONGOENGINE_ALIAS)
         db[CACHE_COLLECTION_RESPONSES].update_many(
             {
-                "kind": "config-parquet-and-info",
+                "kind": {
+                    "$in": [
+                        "config-parquet-and-info",
+                        "config-parquet",
+                        "dataset-parquet",
+                        "config-parquet-metadata",
+                        "config-info",
+                        "dataset-info",
+                    ]
+                },
                 "http_status": 200,
                 "content.partial": {"$exists": False},
             },
@@ -33,7 +42,20 @@ class MigrationAddPartialToCacheResponse(Migration):
         logging.info("Remove the partial field from all the cached results")
         db = get_db(CACHE_MONGOENGINE_ALIAS)
         db[CACHE_COLLECTION_RESPONSES].update_many(
-            {"kind": "config-parquet-and-info", "http_status": 200}, {"$unset": {"content.partial": ""}}
+            {
+                "kind": {
+                    "$in": [
+                        "config-parquet-and-info",
+                        "config-parquet",
+                        "dataset-parquet",
+                        "config-parquet-metadata",
+                        "config-info",
+                        "dataset-info",
+                    ]
+                },
+                "http_status": 200,
+            },
+            {"$unset": {"content.partial": ""}},
         )
 
     def validate(self) -> None:

--- a/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230703110100_cache_add_partial_field_in_config_parquet_and_info.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230703110100_cache_add_partial_field_in_config_parquet_and_info.py
@@ -30,6 +30,8 @@ class MigrationAddPartialToCacheResponse(Migration):
                         "config-parquet-metadata",
                         "config-info",
                         "dataset-info",
+                        "config-size",
+                        "dataset-size",
                     ]
                 },
                 "http_status": 200,
@@ -51,6 +53,8 @@ class MigrationAddPartialToCacheResponse(Migration):
                         "config-parquet-metadata",
                         "config-info",
                         "dataset-info",
+                        "config-size",
+                        "dataset-size",
                     ]
                 },
                 "http_status": 200,

--- a/jobs/mongodb_migration/tests/migrations/test_20230703110100_cache_add_partial_field_in_config_parquet_and_info.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230703110100_cache_add_partial_field_in_config_parquet_and_info.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
+from typing import Any, Dict, List
 
 from libcommon.constants import CACHE_COLLECTION_RESPONSES, CACHE_MONGOENGINE_ALIAS
 from libcommon.resources import MongoResource
@@ -10,169 +11,141 @@ from mongodb_migration.migrations._20230703110100_cache_add_partial_field_in_con
 )
 
 
-def assert_partial(dataset: str) -> None:
+def assert_partial(dataset: str, kind: str) -> None:
     db = get_db(CACHE_MONGOENGINE_ALIAS)
-    entry = db[CACHE_COLLECTION_RESPONSES].find_one({"dataset": dataset})
+    entry = db[CACHE_COLLECTION_RESPONSES].find_one({"dataset": dataset, "kind": kind})
     assert entry is not None
     assert entry["content"]["partial"] is False
 
 
-def assert_unchanged(dataset: str) -> None:
+def assert_unchanged(dataset: str, kind: str) -> None:
     db = get_db(CACHE_MONGOENGINE_ALIAS)
-    entry = db[CACHE_COLLECTION_RESPONSES].find_one({"dataset": dataset})
+    entry = db[CACHE_COLLECTION_RESPONSES].find_one({"dataset": dataset, "kind": kind})
     assert entry is not None
     assert "partial" not in entry["content"]
+
+
+cache: List[Dict[str, Any]] = [
+    {
+        "config": "lhoestq--demo1",
+        "dataset": "lhoestq/demo1",
+        "kind": "config-parquet-and-info",
+        "split": None,
+        "content": {
+            "parquet_files": [
+                {
+                    "dataset": "lhoestq/demo1",
+                    "config": "lhoestq--demo1",
+                    "split": "test",
+                    "url": "https://huggingface.co/.../csv-test.parquet",
+                    "filename": "csv-test.parquet",
+                    "size": 4415,
+                },
+                {
+                    "dataset": "lhoestq/demo1",
+                    "config": "lhoestq--demo1",
+                    "split": "train",
+                    "url": "https://huggingface.co/.../csv-train.parquet",
+                    "filename": "csv-train.parquet",
+                    "size": 5038,
+                },
+            ],
+            "dataset_info": {
+                "description": "",
+                "citation": "",
+                "homepage": "",
+                "license": "",
+                "features": {},
+                "builder_name": "csv",
+                "config_name": "lhoestq--demo1",
+                "version": {},
+                "splits": {},
+                "download_checksums": {},
+                "download_size": 2340,
+                "dataset_size": 2464,
+                "size_in_bytes": 4804,
+            },
+        },
+        "dataset_git_revision": "87ecf163bedca9d80598b528940a9c4f99e14c11",
+        "details": None,
+        "error_code": None,
+        "http_status": 200,
+        "job_runner_version": 3,
+        "progress": 1.0,
+    },
+    {
+        "config": "lhoestq--error",
+        "dataset": "lhoestq/error",
+        "kind": "config-parquet-and-info",
+        "split": None,
+        "content": {"error": "Streaming is not supported for lhoestq/error"},
+        "dataset_git_revision": "ec3c8d414af3dfe600399f5e6ef2c682938676f3",
+        "details": {
+            "error": "Streaming is not supported for lhoestq/error",
+            "cause_exception": "TypeError",
+            "cause_message": "Streaming is not supported for lhoestq/error",
+            "cause_traceback": [
+                "Traceback (most recent call last):\n",
+                (
+                    '  File "/src/services/worker/src/worker/job_manager.py", line 163, in process\n   '
+                    " job_result = self.job_runner.compute()\n"
+                ),
+                (
+                    '  File "/src/services/worker/src/worker/job_runners/config/parquet_and_info.py", line'
+                    " 932, in compute\n    compute_config_parquet_and_info_response(\n"
+                ),
+                (
+                    '  File "/src/services/worker/src/worker/job_runners/config/parquet_and_info.py", line'
+                    " 825, in compute_config_parquet_and_info_response\n    raise_if_not_supported(\n"
+                ),
+                (
+                    '  File "/src/services/worker/src/worker/job_runners/config/parquet_and_info.py", line'
+                    " 367, in raise_if_not_supported\n    raise_if_too_big_from_external_data_files(\n"
+                ),
+                (
+                    '  File "/src/services/worker/src/worker/job_runners/config/parquet_and_info.py", line'
+                    " 447, in raise_if_too_big_from_external_data_files\n   "
+                    " builder._split_generators(mock_dl_manager)\n"
+                ),
+                (
+                    "  File"
+                    ' "/tmp/modules-cache/datasets_modules/.../error.py",'
+                    ' line 190, in _split_generators\n    raise TypeError("Streaming is not supported for'
+                    ' lhoestq/error")\n'
+                ),
+                "TypeError: Streaming is not supported for lhoestq/error\n",
+            ],
+        },
+        "error_code": "UnexpectedError",
+        "http_status": 500,
+        "job_runner_version": 3,
+        "progress": None,
+    },
+]
+cache2: List[Dict[str, Any]] = [
+    {
+        "config": "lhoestq--demo2",
+        "dataset": "lhoestq/demo2",
+        "kind": kind,
+        "split": None,
+        "content": {},
+        "http_status": 200,
+    }
+    for kind in [
+        "config-parquet-and-info",
+        "config-parquet",
+        "dataset-parquet",
+        "config-parquet-metadata",
+        "config-info",
+        "dataset-info",
+    ]
+]
 
 
 def test_cache_add_partial(mongo_host: str) -> None:
     with MongoResource(database="test_cache_add_partial", host=mongo_host, mongoengine_alias="cache"):
         db = get_db(CACHE_MONGOENGINE_ALIAS)
-        db[CACHE_COLLECTION_RESPONSES].insert_many(
-            [
-                {
-                    "config": "lhoestq--demo1",
-                    "dataset": "lhoestq/demo1",
-                    "kind": "config-parquet-and-info",
-                    "split": None,
-                    "content": {
-                        "parquet_files": [
-                            {
-                                "dataset": "lhoestq/demo1",
-                                "config": "lhoestq--demo1",
-                                "split": "test",
-                                "url": "https://huggingface.co/.../csv-test.parquet",
-                                "filename": "csv-test.parquet",
-                                "size": 4415,
-                            },
-                            {
-                                "dataset": "lhoestq/demo1",
-                                "config": "lhoestq--demo1",
-                                "split": "train",
-                                "url": "https://huggingface.co/.../csv-train.parquet",
-                                "filename": "csv-train.parquet",
-                                "size": 5038,
-                            },
-                        ],
-                        "dataset_info": {
-                            "description": "",
-                            "citation": "",
-                            "homepage": "",
-                            "license": "",
-                            "features": {},
-                            "builder_name": "csv",
-                            "config_name": "lhoestq--demo1",
-                            "version": {},
-                            "splits": {},
-                            "download_checksums": {},
-                            "download_size": 2340,
-                            "dataset_size": 2464,
-                            "size_in_bytes": 4804,
-                        },
-                    },
-                    "dataset_git_revision": "87ecf163bedca9d80598b528940a9c4f99e14c11",
-                    "details": None,
-                    "error_code": None,
-                    "http_status": 200,
-                    "job_runner_version": 3,
-                    "progress": 1.0,
-                },
-                {
-                    "config": "lhoestq--demo2",
-                    "dataset": "lhoestq/demo2",
-                    "kind": "config-parquet-and-info",
-                    "split": None,
-                    "content": {
-                        "parquet_files": [
-                            {
-                                "dataset": "lhoestq/demo2",
-                                "config": "lhoestq--demo2",
-                                "split": "test",
-                                "url": "https://huggingface.co/.../csv-test.parquet",
-                                "filename": "csv-test.parquet",
-                                "size": 4415,
-                            },
-                            {
-                                "dataset": "lhoestq/demo2",
-                                "config": "lhoestq--demo2",
-                                "split": "train",
-                                "url": "https://huggingface.co/.../csv-train.parquet",
-                                "filename": "csv-train.parquet",
-                                "size": 5038,
-                            },
-                        ],
-                        "dataset_info": {
-                            "description": "",
-                            "citation": "",
-                            "homepage": "",
-                            "license": "",
-                            "features": {},
-                            "builder_name": "csv",
-                            "config_name": "lhoestq--demo2",
-                            "version": {},
-                            "splits": {},
-                            "download_checksums": {},
-                            "download_size": 2340,
-                            "dataset_size": 2464,
-                            "size_in_bytes": 4804,
-                        },
-                    },
-                    "dataset_git_revision": "87ecf163bedca9d80598b528940a9c4f99e14c11",
-                    "details": None,
-                    "error_code": None,
-                    "http_status": 200,
-                    "job_runner_version": 3,
-                    "progress": 1.0,
-                },
-                {
-                    "config": "lhoestq--error",
-                    "dataset": "lhoestq/error",
-                    "kind": "config-parquet-and-info",
-                    "split": None,
-                    "content": {"error": "Streaming is not supported for lhoestq/error"},
-                    "dataset_git_revision": "ec3c8d414af3dfe600399f5e6ef2c682938676f3",
-                    "details": {
-                        "error": "Streaming is not supported for lhoestq/error",
-                        "cause_exception": "TypeError",
-                        "cause_message": "Streaming is not supported for lhoestq/error",
-                        "cause_traceback": [
-                            "Traceback (most recent call last):\n",
-                            (
-                                '  File "/src/services/worker/src/worker/job_manager.py", line 163, in process\n   '
-                                " job_result = self.job_runner.compute()\n"
-                            ),
-                            (
-                                '  File "/src/services/worker/src/worker/job_runners/config/parquet_and_info.py", line'
-                                " 932, in compute\n    compute_config_parquet_and_info_response(\n"
-                            ),
-                            (
-                                '  File "/src/services/worker/src/worker/job_runners/config/parquet_and_info.py", line'
-                                " 825, in compute_config_parquet_and_info_response\n    raise_if_not_supported(\n"
-                            ),
-                            (
-                                '  File "/src/services/worker/src/worker/job_runners/config/parquet_and_info.py", line'
-                                " 367, in raise_if_not_supported\n    raise_if_too_big_from_external_data_files(\n"
-                            ),
-                            (
-                                '  File "/src/services/worker/src/worker/job_runners/config/parquet_and_info.py", line'
-                                " 447, in raise_if_too_big_from_external_data_files\n   "
-                                " builder._split_generators(mock_dl_manager)\n"
-                            ),
-                            (
-                                "  File"
-                                ' "/tmp/modules-cache/datasets_modules/.../error.py",'
-                                ' line 190, in _split_generators\n    raise TypeError("Streaming is not supported for'
-                                ' lhoestq/error")\n'
-                            ),
-                            "TypeError: Streaming is not supported for lhoestq/error\n",
-                        ],
-                    },
-                    "error_code": "UnexpectedError",
-                    "http_status": 500,
-                    "job_runner_version": 3,
-                    "progress": None,
-                },
-            ]
-        )
+        db[CACHE_COLLECTION_RESPONSES].insert_many(cache + cache2)
 
         migration = MigrationAddPartialToCacheResponse(
             version="20230703110100",
@@ -180,13 +153,29 @@ def test_cache_add_partial(mongo_host: str) -> None:
         )
         migration.up()
 
-        assert_partial("lhoestq/demo1")
-        assert_partial("lhoestq/demo2")
-        assert_unchanged("lhoestq/error")
+        assert_partial("lhoestq/demo1", kind="config-parquet-and-info")
+        assert_unchanged("lhoestq/error", kind="config-parquet-and-info")
+        for kind in [
+            "config-parquet-and-info",
+            "config-parquet",
+            "dataset-parquet",
+            "config-parquet-metadata",
+            "config-info",
+            "dataset-info",
+        ]:
+            assert_partial("lhoestq/demo2", kind=kind)
 
         migration.down()
-        assert_unchanged("lhoestq/demo1")
-        assert_unchanged("lhoestq/demo2")
-        assert_unchanged("lhoestq/error")
+        assert_unchanged("lhoestq/demo1", kind="config-parquet-and-info")
+        assert_unchanged("lhoestq/error", kind="config-parquet-and-info")
+        for kind in [
+            "config-parquet-and-info",
+            "config-parquet",
+            "dataset-parquet",
+            "config-parquet-metadata",
+            "config-info",
+            "dataset-info",
+        ]:
+            assert_unchanged("lhoestq/demo2", kind=kind)
 
         db[CACHE_COLLECTION_RESPONSES].drop()

--- a/jobs/mongodb_migration/tests/migrations/test_20230703110100_cache_add_partial_field_in_config_parquet_and_info.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230703110100_cache_add_partial_field_in_config_parquet_and_info.py
@@ -138,6 +138,8 @@ cache2: List[Dict[str, Any]] = [
         "config-parquet-metadata",
         "config-info",
         "dataset-info",
+        "config-size",
+        "dataset-size",
     ]
 ]
 
@@ -162,6 +164,8 @@ def test_cache_add_partial(mongo_host: str) -> None:
             "config-parquet-metadata",
             "config-info",
             "dataset-info",
+            "config-size",
+            "dataset-size",
         ]:
             assert_partial("lhoestq/demo2", kind=kind)
 
@@ -175,6 +179,8 @@ def test_cache_add_partial(mongo_host: str) -> None:
             "config-parquet-metadata",
             "config-info",
             "dataset-info",
+            "config-size",
+            "dataset-size",
         ]:
             assert_unchanged("lhoestq/demo2", kind=kind)
 

--- a/services/worker/src/worker/dtos.py
+++ b/services/worker/src/worker/dtos.py
@@ -161,6 +161,7 @@ class ConfigSizeContent(TypedDict):
 
 class ConfigSizeResponse(TypedDict):
     size: ConfigSizeContent
+    partial: bool
 
 
 class ConfigNameItem(TypedDict):
@@ -209,3 +210,4 @@ class DatasetSizeResponse(TypedDict):
     size: DatasetSizeContent
     pending: list[PreviousJob]
     failed: list[PreviousJob]
+    partial: bool

--- a/services/worker/src/worker/dtos.py
+++ b/services/worker/src/worker/dtos.py
@@ -110,6 +110,7 @@ class RowsContent(TypedDict):
 
 class ConfigInfoResponse(TypedDict):
     dataset_info: Dict[str, Any]
+    partial: bool
 
 
 class ConfigParquetAndInfoResponse(TypedDict):
@@ -128,10 +129,12 @@ class ParquetFileMetadataItem(SplitItem):
 
 class ConfigParquetMetadataResponse(TypedDict):
     parquet_files_metadata: List[ParquetFileMetadataItem]
+    partial: bool
 
 
 class ConfigParquetResponse(TypedDict):
     parquet_files: List[SplitHubFile]
+    partial: bool
 
 
 class ConfigSize(TypedDict):
@@ -173,6 +176,7 @@ class DatasetInfoResponse(TypedDict):
     dataset_info: Dict[str, Any]
     pending: List[PreviousJob]
     failed: List[PreviousJob]
+    partial: bool
 
 
 class DatasetIsValidResponse(TypedDict):
@@ -184,6 +188,7 @@ class DatasetParquetResponse(TypedDict):
     parquet_files: List[SplitHubFile]
     pending: list[PreviousJob]
     failed: list[PreviousJob]
+    partial: bool
 
 
 class DatasetSize(TypedDict):

--- a/services/worker/src/worker/job_runners/config/info.py
+++ b/services/worker/src/worker/job_runners/config/info.py
@@ -31,6 +31,7 @@ def compute_config_info_response(dataset: str, config: str) -> ConfigInfoRespons
     content = dataset_info_best_response.response["content"]
     try:
         config_info = content["dataset_info"]
+        partial = content["partial"]
     except Exception as e:
         raise PreviousStepFormatError(
             f"Previous step '{previous_step}' did not return the expected content: 'dataset_info'.", e
@@ -42,7 +43,7 @@ def compute_config_info_response(dataset: str, config: str) -> ConfigInfoRespons
             TypeError(f"dataset_info should be a dict, but got {type(config_info)}"),
         )
 
-    return ConfigInfoResponse(dataset_info=config_info)
+    return ConfigInfoResponse(dataset_info=config_info, partial=partial)
 
 
 class ConfigInfoJobRunner(ConfigJobRunner):

--- a/services/worker/src/worker/job_runners/config/parquet.py
+++ b/services/worker/src/worker/job_runners/config/parquet.py
@@ -42,9 +42,10 @@ def compute_parquet_response(dataset: str, config: str) -> ConfigParquetResponse
         ]
         # sort by filename, which ensures the shards are in order: 00000, 00001, 00002, ...
         parquet_files.sort(key=lambda x: x["filename"])  # type: ignore
+        partial = content["partial"]
     except KeyError as e:
         raise PreviousStepFormatError("Previous step did not return the expected content: 'parquet_files'.", e) from e
-    return ConfigParquetResponse(parquet_files=parquet_files)
+    return ConfigParquetResponse(parquet_files=parquet_files, partial=partial)
 
 
 class ConfigParquetJobRunner(ConfigJobRunner):

--- a/services/worker/src/worker/job_runners/config/size.py
+++ b/services/worker/src/worker/job_runners/config/size.py
@@ -74,6 +74,7 @@ def compute_config_size_response(dataset: str, config: str) -> ConfigSizeRespons
                 "num_columns": num_columns,
             }
         )
+        partial = content["partial"]
     except Exception as e:
         raise PreviousStepFormatError("Previous step did not return the expected content.", e) from e
 
@@ -82,7 +83,8 @@ def compute_config_size_response(dataset: str, config: str) -> ConfigSizeRespons
             "size": {
                 "config": config_size,
                 "splits": split_sizes,
-            }
+            },
+            "partial": partial,
         }
     )
 

--- a/services/worker/src/worker/job_runners/dataset/info.py
+++ b/services/worker/src/worker/job_runners/dataset/info.py
@@ -46,6 +46,7 @@ def compute_dataset_info_response(dataset: str) -> Tuple[DatasetInfoResponse, fl
         config_infos: Dict[str, Any] = {}
         total = 0
         pending, failed = [], []
+        partial = False
         for config_item in content["config_names"]:
             config = config_item["config"]
             total += 1
@@ -74,13 +75,14 @@ def compute_dataset_info_response(dataset: str) -> Tuple[DatasetInfoResponse, fl
                 )
                 continue
             config_infos[config] = config_response["content"]["dataset_info"]
+            partial = partial or partial
 
     except Exception as e:
         raise PreviousStepFormatError("Previous step did not return the expected content.", e) from e
 
     progress = (total - len(pending)) / total if total else 1.0
 
-    return DatasetInfoResponse(dataset_info=config_infos, pending=pending, failed=failed), progress
+    return DatasetInfoResponse(dataset_info=config_infos, pending=pending, failed=failed, partial=partial), progress
 
 
 class DatasetInfoJobRunner(DatasetJobRunner):

--- a/services/worker/src/worker/job_runners/dataset/info.py
+++ b/services/worker/src/worker/job_runners/dataset/info.py
@@ -75,7 +75,7 @@ def compute_dataset_info_response(dataset: str) -> Tuple[DatasetInfoResponse, fl
                 )
                 continue
             config_infos[config] = config_response["content"]["dataset_info"]
-            partial = partial or partial
+            partial = partial or config_response["content"]["partial"]
 
     except Exception as e:
         raise PreviousStepFormatError("Previous step did not return the expected content.", e) from e

--- a/services/worker/src/worker/job_runners/dataset/parquet.py
+++ b/services/worker/src/worker/job_runners/dataset/parquet.py
@@ -50,6 +50,7 @@ def compute_parquet_response(dataset: str) -> Tuple[DatasetParquetResponse, floa
         total = 0
         pending = []
         failed = []
+        partial = False
         for config_item in content["config_names"]:
             config = config_item["config"]
             total += 1
@@ -81,19 +82,18 @@ def compute_parquet_response(dataset: str) -> Tuple[DatasetParquetResponse, floa
                     )
                 )
                 continue
-            config_parquet_content = ConfigParquetResponse(parquet_files=response["content"]["parquet_files"])
+            config_parquet_content = ConfigParquetResponse(
+                parquet_files=response["content"]["parquet_files"], partial=False
+            )
             parquet_files.extend(config_parquet_content["parquet_files"])
+            partial = partial or config_parquet_content["partial"]
     except Exception as e:
         raise PreviousStepFormatError("Previous step did not return the expected content.", e) from e
 
     progress = (total - len(pending)) / total if total else 1.0
 
     return (
-        DatasetParquetResponse(
-            parquet_files=parquet_files,
-            pending=pending,
-            failed=failed,
-        ),
+        DatasetParquetResponse(parquet_files=parquet_files, pending=pending, failed=failed, partial=partial),
         progress,
     )
 

--- a/services/worker/src/worker/job_runners/dataset/parquet.py
+++ b/services/worker/src/worker/job_runners/dataset/parquet.py
@@ -83,7 +83,7 @@ def compute_parquet_response(dataset: str) -> Tuple[DatasetParquetResponse, floa
                 )
                 continue
             config_parquet_content = ConfigParquetResponse(
-                parquet_files=response["content"]["parquet_files"], partial=False
+                parquet_files=response["content"]["parquet_files"], partial=response["content"]["partial"]
             )
             parquet_files.extend(config_parquet_content["parquet_files"])
             partial = partial or config_parquet_content["partial"]

--- a/services/worker/src/worker/job_runners/dataset/size.py
+++ b/services/worker/src/worker/job_runners/dataset/size.py
@@ -53,6 +53,7 @@ def compute_sizes_response(dataset: str) -> Tuple[DatasetSizeResponse, float]:
         total = 0
         pending = []
         failed = []
+        partial = False
         for config_item in content["config_names"]:
             config = config_item["config"]
             total += 1
@@ -84,9 +85,12 @@ def compute_sizes_response(dataset: str) -> Tuple[DatasetSizeResponse, float]:
                     )
                 )
                 continue
-            config_size_content = ConfigSizeResponse(size=response["content"]["size"])
+            config_size_content = ConfigSizeResponse(
+                size=response["content"]["size"], partial=response["content"]["partial"]
+            )
             config_sizes.append(config_size_content["size"]["config"])
             split_sizes.extend(config_size_content["size"]["splits"])
+            partial = partial or config_size_content["partial"]
         dataset_size: DatasetSize = {
             "dataset": dataset,
             "num_bytes_original_files": sum(config_size["num_bytes_original_files"] for config_size in config_sizes),
@@ -109,6 +113,7 @@ def compute_sizes_response(dataset: str) -> Tuple[DatasetSizeResponse, float]:
                 },
                 "pending": pending,
                 "failed": failed,
+                "partial": partial,
             }
         ),
         progress,

--- a/services/worker/tests/job_runners/config/test_info.py
+++ b/services/worker/tests/job_runners/config/test_info.py
@@ -178,12 +178,9 @@ def get_job_runner(
             "dataset_ok",
             "config_1",
             HTTPStatus.OK,
-            {
-                "parquet_files": PARQUET_FILES,
-                "dataset_info": CONFIG_INFO_1,
-            },
+            {"parquet_files": PARQUET_FILES, "dataset_info": CONFIG_INFO_1, "partial": False},
             None,
-            {"dataset_info": CONFIG_INFO_1},
+            {"dataset_info": CONFIG_INFO_1, "partial": False},
             False,
         ),
         (

--- a/services/worker/tests/job_runners/config/test_parquet.py
+++ b/services/worker/tests/job_runners/config/test_parquet.py
@@ -93,7 +93,8 @@ def get_job_runner(
                     SplitHubFile(
                         dataset="ok", config="config_1", split="train", url="url2", filename="filename2", size=0
                     ),
-                ]
+                ],
+                partial=False,
             ),
             False,
         ),
@@ -176,7 +177,8 @@ def get_job_runner(
                         filename="parquet-train-00001-of-05534.parquet",
                         size=0,
                     ),
-                ]
+                ],
+                partial=False,
             ),
             False,
         ),

--- a/services/worker/tests/job_runners/config/test_parquet_metadata.py
+++ b/services/worker/tests/job_runners/config/test_parquet_metadata.py
@@ -103,6 +103,7 @@ def get_job_runner(
                         dataset="ok", config="config_1", split="train", url="url2", filename="filename2", size=0
                     ),
                 ],
+                partial=False,
             ),
             None,
             ConfigParquetMetadataResponse(
@@ -127,7 +128,8 @@ def get_job_runner(
                         num_rows=3,
                         parquet_metadata_subpath="ok/--/config_1/filename2",
                     ),
-                ]
+                ],
+                partial=False,
             ),
             False,
         ),

--- a/services/worker/tests/job_runners/config/test_size.py
+++ b/services/worker/tests/job_runners/config/test_size.py
@@ -120,6 +120,7 @@ def get_job_runner(
                     "dataset_size": 20387232,
                     "size_in_bytes": 31981954,
                 },
+                "partial": False,
             },
             None,
             {
@@ -153,7 +154,8 @@ def get_job_runner(
                             "num_columns": 2,
                         },
                     ],
-                }
+                },
+                "partial": False,
             },
             False,
         ),

--- a/services/worker/tests/job_runners/dataset/test_info.py
+++ b/services/worker/tests/job_runners/dataset/test_info.py
@@ -46,7 +46,7 @@ UPSTREAM_RESPONSE_CONFIG_INFO_1: UpstreamResponse = UpstreamResponse(
     dataset="dataset_ok",
     config="config_1",
     http_status=HTTPStatus.OK,
-    content={"dataset_info": CONFIG_INFO_1},
+    content={"dataset_info": CONFIG_INFO_1, "partial": False},
 )
 
 UPSTREAM_RESPONSE_CONFIG_INFO_2: UpstreamResponse = UpstreamResponse(
@@ -54,7 +54,7 @@ UPSTREAM_RESPONSE_CONFIG_INFO_2: UpstreamResponse = UpstreamResponse(
     dataset="dataset_ok",
     config="config_2",
     http_status=HTTPStatus.OK,
-    content={"dataset_info": CONFIG_INFO_2},
+    content={"dataset_info": CONFIG_INFO_2, "partial": False},
 )
 
 EXPECTED_OK = (
@@ -62,6 +62,7 @@ EXPECTED_OK = (
         "dataset_info": DATASET_INFO_OK,
         "pending": [],
         "failed": [],
+        "partial": False,
     },
     1.0,
 )

--- a/services/worker/tests/job_runners/dataset/test_info.py
+++ b/services/worker/tests/job_runners/dataset/test_info.py
@@ -81,6 +81,7 @@ EXPECTED_PARTIAL_PENDING = (
             )
         ],
         "failed": [],
+        "partial": False,
     },
     0.5,
 )
@@ -99,6 +100,7 @@ EXPECTED_PARTIAL_FAILED = (
                 split=None,
             )
         ],
+        "partial": False,
     },
     1.0,
 )

--- a/services/worker/tests/job_runners/dataset/test_parquet.py
+++ b/services/worker/tests/job_runners/dataset/test_parquet.py
@@ -97,7 +97,8 @@ def get_job_runner(
                                 filename="filename1",
                                 size=0,
                             ),
-                        ]
+                        ],
+                        partial=False,
                     ),
                 ),
                 UpstreamResponse(
@@ -115,7 +116,8 @@ def get_job_runner(
                                 filename="filename2",
                                 size=0,
                             ),
-                        ]
+                        ],
+                        partial=False,
                     ),
                 ),
             ],
@@ -131,6 +133,7 @@ def get_job_runner(
                 ],
                 pending=[],
                 failed=[],
+                partial=False,
             ),
             False,
         ),

--- a/services/worker/tests/job_runners/dataset/test_size.py
+++ b/services/worker/tests/job_runners/dataset/test_size.py
@@ -117,7 +117,8 @@ def get_job_runner(
                                     "num_columns": 2,
                                 },
                             ],
-                        }
+                        },
+                        "partial": False,
                     },
                 ),
                 UpstreamResponse(
@@ -156,7 +157,8 @@ def get_job_runner(
                                     "num_columns": 3,
                                 },
                             ],
-                        }
+                        },
+                        "partial": False,
                     },
                 ),
             ],
@@ -231,6 +233,7 @@ def get_job_runner(
                 },
                 "failed": [],
                 "pending": [],
+                "partial": False,
             },
             False,
         ),


### PR DESCRIPTION
Following #1448 we need all subsequent jobs to `config-parquet-and-info` to have the "partial" field:

- "config-parquet-and-info"
- "config-parquet"
- "dataset-parquet"
- "config-parquet-metadata"
- "config-info"
- "dataset-info"

For dataset level jobs, "partial" is True if there is at least one config with "partial == True".

I updated the code of all the jobs and update the migration job to add "partial" to existing entries.

I'll update the docs in another PR.