### PR TITLE
split-duckdb-index config

### DIFF
--- a/libs/libcommon/src/libcommon/config.py
+++ b/libs/libcommon/src/libcommon/config.py
@@ -105,42 +105,6 @@ class ParquetMetadataConfig:
             )
 
 
-DUCKDB_INDEX_STORAGE_DIRECTORY = None
-DUCKDB_INDEX_COMMIT_MESSAGE = "Update duckdb index file"
-DUCKDB_INDEX_COMMITTER_HF_TOKEN = None
-DUCKDB_INDEX_MAX_PARQUET_SIZE_BYTES = 100_000_000
-DUCKDB_INDEX_TARGET_REVISION = "refs/convert/parquet"
-DUCKDB_INDEX_URL_TEMPLATE = "/datasets/%s/resolve/%s/%s"
-DUCKDB_INDEX_EXTENSIONS_DIRECTORY: Optional[str] = None
-
-
-@dataclass(frozen=True)
-class DuckDbIndexConfig:
-    storage_directory: Optional[str] = DUCKDB_INDEX_STORAGE_DIRECTORY
-    commit_message: str = DUCKDB_INDEX_COMMIT_MESSAGE
-    committer_hf_token: Optional[str] = DUCKDB_INDEX_COMMITTER_HF_TOKEN
-    target_revision: str = DUCKDB_INDEX_TARGET_REVISION
-    url_template: str = DUCKDB_INDEX_URL_TEMPLATE
-    max_parquet_size_bytes: int = DUCKDB_INDEX_MAX_PARQUET_SIZE_BYTES
-    extensions_directory: Optional[str] = DUCKDB_INDEX_EXTENSIONS_DIRECTORY
-
-    @classmethod
-    def from_env(cls) -> "DuckDbIndexConfig":
-        env = Env(expand_vars=True)
-        with env.prefixed("DUCKDB_INDEX_"):
-            return cls(
-                storage_directory=env.str(name="STORAGE_DIRECTORY", default=DUCKDB_INDEX_STORAGE_DIRECTORY),
-                commit_message=env.str(name="COMMIT_MESSAGE", default=DUCKDB_INDEX_COMMIT_MESSAGE),
-                committer_hf_token=env.str(name="COMMITTER_HF_TOKEN", default=DUCKDB_INDEX_COMMITTER_HF_TOKEN),
-                target_revision=env.str(name="TARGET_REVISION", default=DUCKDB_INDEX_TARGET_REVISION),
-                url_template=env.str(name="URL_TEMPLATE", default=DUCKDB_INDEX_URL_TEMPLATE),
-                max_parquet_size_bytes=env.int(
-                    name="MAX_PARQUET_SIZE_BYTES", default=DUCKDB_INDEX_MAX_PARQUET_SIZE_BYTES
-                ),
-                extensions_directory=env.str(name="EXTENSIONS_DIRECTORY", default=DUCKDB_INDEX_EXTENSIONS_DIRECTORY),
-            )
-
-
 COMMON_HF_ENDPOINT = "https://huggingface.co"
 COMMON_HF_TOKEN = None
 

--- a/services/worker/README.md
+++ b/services/worker/README.md
@@ -75,6 +75,18 @@ Set environment variables to configure the parquet worker (`PARQUET_AND_INFO_` p
 - `PARQUET_AND_INFO_TARGET_REVISION`: the git revision of the dataset where to store the parquet files. Make sure the committer token (`PARQUET_AND_INFO_COMMITTER_HF_TOKEN`) has the permission to write there. Defaults to `refs/convert/parquet`.
 - `PARQUET_AND_INFO_URL_TEMPLATE`: the URL template to build the parquet file URLs. Defaults to `/datasets/%s/resolve/%s/%s`.
 
+### Duckdb Index worker
+
+Set environment variables to configure the duckdb index worker (`DUCKDB_INDEX_` prefix):
+
+- `DUCKDB_INDEX_STORAGE_DIRECTORY`: directory where the temporal duckdb index files are stored. Defaults to empty.
+- `DUCKDB_INDEX_COMMIT_MESSAGE`: the git commit message when the worker uploads the duckdb index file to the Hub. Defaults to `Update duckdb index file`.
+- `DUCKDB_INDEX_COMMITTER_HF_TOKEN`: the HuggingFace token to commit the duckdb index file to the Hub. The token must be an app token associated with a user that has the right to 1. create the `refs/convert/parquet` branch (see `DUCKDB_INDEX_TARGET_REVISION`) and 2. push commits to it on any dataset. [Datasets maintainers](https://huggingface.co/datasets-maintainers) members have these rights. The token must have permission to write. If not set, the worker will fail. Defaults to None.
+- `DUCKDB_INDEX_MAX_PARQUET_SIZE_BYTES`: the maximum size in bytes of the dataset's parquet files to index. Datasets with bigger size are ignored. Defaults to `100_000_000`.
+- `DUCKDB_INDEX_TARGET_REVISION`: the git revision of the dataset where to store the duckdb index file. Make sure the committer token (`DUCKDB_INDEX_COMMITTER_HF_TOKEN`) has the permission to write there. Defaults to `refs/convert/parquet`.
+- `DUCKDB_INDEX_URL_TEMPLATE`: the URL template to build the duckdb index file URL. Defaults to `/datasets/%s/resolve/%s/%s`.
+- `DUCKDB_INDEX_EXTENSIONS_DIRECTORY`: directory where the duckdb extensions will be downloaded. Defaults to empty.
+
 ### Splits worker
 
 The splits worker does not need any additional configuration.

--- a/services/worker/src/worker/config.py
+++ b/services/worker/src/worker/config.py
@@ -9,7 +9,6 @@ from libcommon.config import (
     AssetsConfig,
     CacheConfig,
     CommonConfig,
-    DuckDbIndexConfig,
     LogConfig,
     ParquetMetadataConfig,
     ProcessingGraphConfig,
@@ -231,6 +230,42 @@ class ConfigNamesConfig:
         with env.prefixed("CONFIG_NAMES_"):
             return cls(
                 max_number=env.int(name="MAX_NUMBER", default=CONFIG_NAMES_MAX_NUMBER),
+            )
+
+
+DUCKDB_INDEX_STORAGE_DIRECTORY = None
+DUCKDB_INDEX_COMMIT_MESSAGE = "Update duckdb index file"
+DUCKDB_INDEX_COMMITTER_HF_TOKEN = None
+DUCKDB_INDEX_MAX_PARQUET_SIZE_BYTES = 100_000_000
+DUCKDB_INDEX_TARGET_REVISION = "refs/convert/parquet"
+DUCKDB_INDEX_URL_TEMPLATE = "/datasets/%s/resolve/%s/%s"
+DUCKDB_INDEX_EXTENSIONS_DIRECTORY: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class DuckDbIndexConfig:
+    storage_directory: Optional[str] = DUCKDB_INDEX_STORAGE_DIRECTORY
+    commit_message: str = DUCKDB_INDEX_COMMIT_MESSAGE
+    committer_hf_token: Optional[str] = DUCKDB_INDEX_COMMITTER_HF_TOKEN
+    target_revision: str = DUCKDB_INDEX_TARGET_REVISION
+    url_template: str = DUCKDB_INDEX_URL_TEMPLATE
+    max_parquet_size_bytes: int = DUCKDB_INDEX_MAX_PARQUET_SIZE_BYTES
+    extensions_directory: Optional[str] = DUCKDB_INDEX_EXTENSIONS_DIRECTORY
+
+    @classmethod
+    def from_env(cls) -> "DuckDbIndexConfig":
+        env = Env(expand_vars=True)
+        with env.prefixed("DUCKDB_INDEX_"):
+            return cls(
+                storage_directory=env.str(name="STORAGE_DIRECTORY", default=DUCKDB_INDEX_STORAGE_DIRECTORY),
+                commit_message=env.str(name="COMMIT_MESSAGE", default=DUCKDB_INDEX_COMMIT_MESSAGE),
+                committer_hf_token=env.str(name="COMMITTER_HF_TOKEN", default=DUCKDB_INDEX_COMMITTER_HF_TOKEN),
+                target_revision=env.str(name="TARGET_REVISION", default=DUCKDB_INDEX_TARGET_REVISION),
+                url_template=env.str(name="URL_TEMPLATE", default=DUCKDB_INDEX_URL_TEMPLATE),
+                max_parquet_size_bytes=env.int(
+                    name="MAX_PARQUET_SIZE_BYTES", default=DUCKDB_INDEX_MAX_PARQUET_SIZE_BYTES
+                ),
+                extensions_directory=env.str(name="EXTENSIONS_DIRECTORY", default=DUCKDB_INDEX_EXTENSIONS_DIRECTORY),
             )
 
 

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -13,7 +13,6 @@ from huggingface_hub._commit_api import (
 )
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils._errors import HfHubHTTPError, RepositoryNotFoundError
-from libcommon.config import DuckDbIndexConfig
 from libcommon.constants import PROCESSING_STEP_SPLIT_DUCKDB_INDEX_VERSION
 from libcommon.exceptions import (
     CacheDirectoryNotInitializedError,
@@ -33,7 +32,7 @@ from libcommon.simple_cache import get_previous_step_or_raise
 from libcommon.storage import StrPath
 from libcommon.utils import JobInfo, SplitHubFile
 
-from worker.config import AppConfig
+from worker.config import AppConfig, DuckDbIndexConfig
 from worker.dtos import CompleteJobResult
 from worker.job_runners.split.split_job_runner import SplitJobRunnerWithCache
 from worker.utils import (


### PR DESCRIPTION
Moving config to worker folder since it is not used from any other project.
Also adding doc in the readme file.