### PR TITLE
More workers

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -126,7 +126,7 @@ cacheMaintenance:
   log:
     level: "debug"
   backfill:
-    error_codes_to_retry: null
+    error_codes_to_retry: ""
   resources:
     requests:
       cpu: 1

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -269,7 +269,7 @@ workers:
     workerJobTypesOnly: ""
     nodeSelector:
       role-datasets-server-worker: "true"
-    replicas: 20
+    replicas: 80
     resources:
       requests:
         cpu: 1
@@ -284,7 +284,7 @@ workers:
     workerJobTypesOnly: ""
     nodeSelector:
       role-datasets-server-worker: "true"
-    replicas: 4
+    replicas: 12
     resources:
       requests:
         cpu: 200m

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -121,12 +121,12 @@ mongodbMigration:
 # --- jobs (post-upgrade hooks) ---
 
 cacheMaintenance:
-  action: "backfill"
+  action: "skip"
   # ^ allowed values are {backfill, collect-metrics,skip}
   log:
     level: "debug"
   backfill:
-    error_codes_to_retry: "DatasetTooBigFromDatasetsError,DatasetTooBigFromHubError,DatasetWithTooBigExternalFilesError,DatasetWithTooManyExternalFilesError"
+    error_codes_to_retry: null
   resources:
     requests:
       cpu: 1


### PR DESCRIPTION
Following #1448 

note that `cache-maintenance` took care of running a backfill for the datasets >5GB:

```
"DatasetTooBigFromDatasetsError,DatasetTooBigFromHubError,DatasetWithTooBigExternalFilesError,DatasetWithTooManyExternalFilesError"
```