### PR TITLE
Optional num_bytes_original_files

### DIFF
--- a/services/worker/src/worker/dtos.py
+++ b/services/worker/src/worker/dtos.py
@@ -140,7 +140,9 @@ class ConfigParquetResponse(TypedDict):
 class ConfigSize(TypedDict):
     dataset: str
     config: str
-    num_bytes_original_files: int
+    num_bytes_original_files: Optional[
+        int
+    ]  # optional because partial parquet conversion can't provide the size of the original data
     num_bytes_parquet_files: int
     num_bytes_memory: int
     num_rows: int
@@ -194,7 +196,7 @@ class DatasetParquetResponse(TypedDict):
 
 class DatasetSize(TypedDict):
     dataset: str
-    num_bytes_original_files: int
+    num_bytes_original_files: Optional[int]
     num_bytes_parquet_files: int
     num_bytes_memory: int
     num_rows: int

--- a/services/worker/src/worker/job_runners/config/size.py
+++ b/services/worker/src/worker/job_runners/config/size.py
@@ -65,7 +65,7 @@ def compute_config_size_response(dataset: str, config: str) -> ConfigSizeRespons
             {
                 "dataset": dataset,
                 "config": config,
-                "num_bytes_original_files": config_info["download_size"],
+                "num_bytes_original_files": config_info["download_size"] if not content["partial"] else None,
                 "num_bytes_parquet_files": sum(split_size["num_bytes_parquet_files"] for split_size in split_sizes),
                 "num_bytes_memory": sum(
                     split_size["num_bytes_memory"] for split_size in split_sizes

--- a/services/worker/src/worker/job_runners/dataset/size.py
+++ b/services/worker/src/worker/job_runners/dataset/size.py
@@ -3,7 +3,7 @@
 
 import logging
 from http import HTTPStatus
-from typing import Tuple
+from typing import Optional, Tuple
 
 from libcommon.constants import PROCESSING_STEP_DATASET_SIZE_VERSION
 from libcommon.exceptions import PreviousStepFormatError
@@ -91,9 +91,16 @@ def compute_sizes_response(dataset: str) -> Tuple[DatasetSizeResponse, float]:
             config_sizes.append(config_size_content["size"]["config"])
             split_sizes.extend(config_size_content["size"]["splits"])
             partial = partial or config_size_content["partial"]
+        num_bytes_original_files: Optional[int] = 0
+        for config_size in config_sizes:
+            if num_bytes_original_files is not None and isinstance(config_size["num_bytes_original_files"], int):
+                num_bytes_original_files += config_size["num_bytes_original_files"]
+            else:
+                num_bytes_original_files = None
+                break
         dataset_size: DatasetSize = {
             "dataset": dataset,
-            "num_bytes_original_files": sum(config_size["num_bytes_original_files"] for config_size in config_sizes),
+            "num_bytes_original_files": num_bytes_original_files,
             "num_bytes_parquet_files": sum(config_size["num_bytes_parquet_files"] for config_size in config_sizes),
             "num_bytes_memory": sum(config_size["num_bytes_memory"] for config_size in config_sizes),
             "num_rows": sum(config_size["num_rows"] for config_size in config_sizes),


### PR DESCRIPTION
Because `download_size` is `None` in `config-and-parquet-info` if the dataset is >5GB