### PR TITLE
Minor fix in update_last_modified_date_of_rows_in_assets_dir

### DIFF
--- a/libs/libcommon/src/libcommon/viewer_utils/asset.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/asset.py
@@ -47,7 +47,10 @@ def update_last_modified_date_of_rows_in_assets_dir(
         if (row_dirs_path / str(row_idx)).is_dir():
             # update the directory's last modified date
             if (row_dirs_path / str(row_idx) / DATASETS_SERVER_MDATE_FILENAME).is_file():
-                (row_dirs_path / str(row_idx) / DATASETS_SERVER_MDATE_FILENAME).unlink()
+                try:
+                    (row_dirs_path / str(row_idx) / DATASETS_SERVER_MDATE_FILENAME).unlink()
+                except FileNotFoundError:
+                    pass
             (row_dirs_path / str(row_idx) / DATASETS_SERVER_MDATE_FILENAME).touch()
 
 


### PR DESCRIPTION
FileNotFoundError can happen because of concurrent api calls, and we can ignore it

(found this error while checking some logs today)