### PR TITLE
More logging for /rows

### DIFF
--- a/libs/libapi/src/libapi/utils.py
+++ b/libs/libapi/src/libapi/utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
 
+import logging
 from http import HTTPStatus
 from typing import Any, Callable, Coroutine, List, Optional
 
@@ -98,6 +99,7 @@ def try_backfill_dataset(
             raise ResponseNotFoundError("Not found.") from e
         # The dataset is supported, and the revision is known. We set the revision (it will create the jobs)
         # and tell the user to retry.
+        logging.info(f"Set orchestrator revision for dataset={dataset}, revision={revision}")
         dataset_orchestrator.set_revision(
             revision=revision, priority=Priority.NORMAL, error_codes_to_retry=[], cache_max_days=cache_max_days
         )

--- a/libs/libcommon/src/libcommon/parquet_utils.py
+++ b/libs/libcommon/src/libcommon/parquet_utils.py
@@ -398,7 +398,8 @@ class RowsIndex:
                 content = result.response["content"]
             if content and "parquet_files" in content:
                 logging.info(
-                    f"Create ParquetIndexWithoutMetadata for dataset={self.dataset}, config={self.config}, split={self.split}"
+                    f"Create ParquetIndexWithoutMetadata for dataset={self.dataset}, config={self.config},"
+                    f" split={self.split}"
                 )
                 return ParquetIndexWithoutMetadata.from_parquet_file_items(
                     [
@@ -414,7 +415,8 @@ class RowsIndex:
                 )
             else:
                 logging.info(
-                    f"Create ParquetIndexWithMetadata for dataset={self.dataset}, config={self.config}, split={self.split}"
+                    f"Create ParquetIndexWithMetadata for dataset={self.dataset}, config={self.config},"
+                    f" split={self.split}"
                 )
                 return ParquetIndexWithMetadata.from_parquet_metadata_items(
                     [
@@ -444,7 +446,8 @@ class RowsIndex:
             pa.Table: The requested rows.
         """
         logging.info(
-            f"Query {type(self.parquet_index).__name__} for dataset={self.dataset}, config={self.config}, split={self.split}, offset={offset}, length={length}"
+            f"Query {type(self.parquet_index).__name__} for dataset={self.dataset}, config={self.config},"
+            f" split={self.split}, offset={offset}, length={length}"
         )
         return self.parquet_index.query(offset=offset, length=length)
 

--- a/libs/libcommon/src/libcommon/parquet_utils.py
+++ b/libs/libcommon/src/libcommon/parquet_utils.py
@@ -397,6 +397,9 @@ class RowsIndex:
                 self.revision = result.response["dataset_git_revision"]
                 content = result.response["content"]
             if content and "parquet_files" in content:
+                logging.info(
+                    f"Create ParquetIndexWithoutMetadata for dataset={self.dataset}, config={self.config}, split={self.split}"
+                )
                 return ParquetIndexWithoutMetadata.from_parquet_file_items(
                     [
                         parquet_item
@@ -410,6 +413,9 @@ class RowsIndex:
                     unsupported_features_magic_strings=unsupported_features_magic_strings,
                 )
             else:
+                logging.info(
+                    f"Create ParquetIndexWithMetadata for dataset={self.dataset}, config={self.config}, split={self.split}"
+                )
                 return ParquetIndexWithMetadata.from_parquet_metadata_items(
                     [
                         parquet_item
@@ -437,6 +443,9 @@ class RowsIndex:
         Returns:
             pa.Table: The requested rows.
         """
+        logging.info(
+            f"Query {type(self.parquet_index).__name__} for dataset={self.dataset}, config={self.config}, split={self.split}, offset={offset}, length={length}"
+        )
         return self.parquet_index.query(offset=offset, length=length)
 
 

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -310,19 +310,20 @@ def create_rows_endpoint(
                         hf_jwt_algorithm=hf_jwt_algorithm,
                         hf_timeout_seconds=hf_timeout_seconds,
                     )
-                with StepProfiler(method="rows_endpoint", step="get row groups index"):
-                    try:
+                try:
+                    with StepProfiler(method="rows_endpoint", step="get row groups index"):
                         rows_index = indexer.get_rows_index(
                             dataset=dataset,
                             config=config,
                             split=split,
                         )
                         revision = rows_index.revision
-                    except CachedArtifactError:
-                        config_parquet_processing_steps = processing_graph.get_config_parquet_processing_steps()
-                        config_parquet_metadata_processing_steps = (
-                            processing_graph.get_config_parquet_metadata_processing_steps()
-                        )
+                except CachedArtifactError:
+                    config_parquet_processing_steps = processing_graph.get_config_parquet_processing_steps()
+                    config_parquet_metadata_processing_steps = (
+                        processing_graph.get_config_parquet_metadata_processing_steps()
+                    )
+                    with StepProfiler(method="rows_endpoint", step="try backfill dataset"):
                         try_backfill_dataset(
                             processing_steps=config_parquet_metadata_processing_steps
                             + config_parquet_processing_steps,

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -318,7 +318,6 @@ def create_rows_endpoint(
                             split=split,
                         )
                         revision = rows_index.revision
-                        indexer.get_rows_index.cache_info()
                     except CachedArtifactError:
                         config_parquet_processing_steps = processing_graph.get_config_parquet_processing_steps()
                         config_parquet_metadata_processing_steps = (

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -318,6 +318,7 @@ def create_rows_endpoint(
                             split=split,
                         )
                         revision = rows_index.revision
+                        indexer.get_rows_index.cache_info()
                     except CachedArtifactError:
                         config_parquet_processing_steps = processing_graph.get_config_parquet_processing_steps()
                         config_parquet_metadata_processing_steps = (


### PR DESCRIPTION
I'd like to understand better why specific requests take so long (eg refinedweb, the-stack).
Locally they work fine but take too much time in prod.