### PR TITLE
Don't run config-parquet-metadata in light workers

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -307,7 +307,7 @@ workers:
     tolerations: []
   -
     deployName: "light"
-    workerJobTypesBlocked: "dataset-config-names,config-split-names-from-streaming,config-parquet-and-info,split-first-rows-from-parquet,split-first-rows-from-streaming,split-opt-in-out-urls-scan,split-duckdb-index"
+    workerJobTypesBlocked: "dataset-config-names,config-split-names-from-streaming,config-parquet-and-info,config-parquet-metadata,split-first-rows-from-parquet,split-first-rows-from-streaming,split-opt-in-out-urls-scan,split-duckdb-index"
     workerJobTypesOnly: ""
     nodeSelector:
       role-datasets-server-worker: "true"


### PR DESCRIPTION
Because it causes an OOM for all the big parquet datasets like the-stack, refinedweb etc.

causing their pagination to hang because it uses the parquet index without metadata which is too slow for big datasets