### PR TITLE
fix: 🐛 ensure the env vars are int

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -292,8 +292,8 @@ rows:
 workers:
   -
     deployName: "all"
-    workerDifficultyMax: ""
-    workerDifficultyMin: ""
+    workerDifficultyMax: 100
+    workerDifficultyMin: 0
     workerJobTypesBlocked: ""
     workerJobTypesOnly: ""
     nodeSelector:
@@ -309,10 +309,10 @@ workers:
     tolerations: []
   -
     deployName: "light"
-    workerDifficultyMax: ""
-    workerDifficultyMin: ""
+    workerDifficultyMax: 40
+    workerDifficultyMin: 0
     workerJobTypesBlocked: ""
-    workerJobTypesOnly: "config-parquet,dataset-parquet,config-info,dataset-info,config-split-names-from-info,config-size,dataset-size,dataset-split-names,dataset-is-valid,split-image-url-columns,split-opt-in-out-urls-count,config-opt-in-out-urls-count,dataset-opt-in-out-urls-count"
+    workerJobTypesOnly: ""
     nodeSelector:
       role-datasets-server-worker: "true"
     replicas: 12

--- a/chart/env/staging.yaml
+++ b/chart/env/staging.yaml
@@ -233,8 +233,8 @@ rows:
 workers:
   -
     deployName: "all"
-    workerDifficultyMax: ""
-    workerDifficultyMin: ""
+    workerDifficultyMax: 100
+    workerDifficultyMin: 0
     workerJobTypesBlocked: ""
     workerJobTypesOnly: ""
     nodeSelector: {}
@@ -249,9 +249,9 @@ workers:
     tolerations: []
   -
     deployName: "light"
-    workerDifficultyMax: ""
-    workerDifficultyMin: ""
-    workerJobTypesBlocked: "dataset-config-names,config-split-names-from-streaming,config-parquet-and-info,split-first-rows-from-parquet,split-first-rows-from-streaming,split-opt-in-out-urls-scan"
+    workerDifficultyMax: 40
+    workerDifficultyMin: 0
+    workerJobTypesBlocked: ""
     workerJobTypesOnly: ""
     nodeSelector: {}
     replicas: 1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -456,9 +456,9 @@ workers:
     # name of the deployment
     deployName: "all"
     # max difficulty of the jobs that this worker will process
-    workerDifficultyMax: ""
+    workerDifficultyMax: 100
     # min difficulty of the jobs that this worker will process
-    workerDifficultyMin: ""
+    workerDifficultyMin: 0
     # job types that this worker will not process
     workerJobTypesBlocked: ""
     # job types that this worker can process

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -157,6 +157,7 @@ class JobDocument(Document):
             ("priority", "status", "created_at", "type", "namespace"),
             ("priority", "status", "type", "created_at", "namespace", "unicity_id"),
             ("priority", "status", "created_at", "namespace", "type", "unicity_id"),
+            ("priority", "status", "created_at", "difficulty", "namespace", "type", "unicity_id"),
             ("status", "type"),
             ("status", "namespace", "priority", "type", "created_at"),
             ("status", "namespace", "unicity_id", "priority", "type", "created_at"),


### PR DESCRIPTION
note that the limits (min and max) will always be set in the mongo queries. I also added an index to make it quick but let's see if it works well.