### PR TITLE
Adding EFS volumes for cache, parquet and duckdb storage

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -84,6 +84,15 @@ secrets:
 persistence:
   existingClaim: "nfs-datasets-server-pvc"
 
+cachePersistence:
+  existingClaim: "datasets-server-cache-pvc"
+
+parquetPersistence:
+  existingClaim: "datasets-server-parquet-pvc"
+
+duckdbPersistence:
+  existingClaim: "datasets-server-duckdb-pvc"
+
 monitoring:
   enabled: true
 

--- a/chart/env/staging.yaml
+++ b/chart/env/staging.yaml
@@ -81,6 +81,15 @@ secrets:
 persistence:
   existingClaim: "nfs-datasets-server-pvc"
 
+cachePersistence:
+  existingClaim: "datasets-server-cache-pvc"
+
+parquetPersistence:
+  existingClaim: "datasets-server-parquet-pvc"
+
+duckdbPersistence:
+  existingClaim: "datasets-server-duckdb-pvc"
+
 monitoring:
   enabled: false
 

--- a/chart/templates/_initContainerCache.tpl
+++ b/chart/templates/_initContainerCache.tpl
@@ -11,7 +11,7 @@
   volumeMounts:
   - mountPath: /mounted-path
     mountPropagation: None
-    name: data
+    name: cache-data
     subPath: "{{ include "cache.subpath" . }}"
     readOnly: false
   securityContext:

--- a/chart/templates/_initContainerDuckDBIndex.tpl
+++ b/chart/templates/_initContainerDuckDBIndex.tpl
@@ -11,7 +11,7 @@
   volumeMounts:
   - mountPath: /mounted-path
     mountPropagation: None
-    name: data
+    name: duckdb-data
     subPath: "{{ include "duckDBIndex.subpath" . }}"
     readOnly: false
   securityContext:

--- a/chart/templates/_initContainerParquetMetadata.tpl
+++ b/chart/templates/_initContainerParquetMetadata.tpl
@@ -11,7 +11,7 @@
   volumeMounts:
   - mountPath: /mounted-path
     mountPropagation: None
-    name: data
+    name: parquet-data
     subPath: "{{ include "parquetMetadata.subpath" . }}"
     readOnly: false
   securityContext:

--- a/chart/templates/_volumeCache.tpl
+++ b/chart/templates/_volumeCache.tpl
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+{{- define "volumeCache" -}}
+- name: cache-data
+  persistentVolumeClaim:
+    claimName: {{ .Values.cachePersistence.existingClaim | default (include "name" .) }}
+{{- end -}}

--- a/chart/templates/_volumeDuckDB.tpl
+++ b/chart/templates/_volumeDuckDB.tpl
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+{{- define "volumeDuckDB" -}}
+- name: duckdb-data
+  persistentVolumeClaim:
+    claimName: {{ .Values.duckdbPersistence.existingClaim | default (include "name" .) }}
+{{- end -}}

--- a/chart/templates/_volumeParquet.tpl
+++ b/chart/templates/_volumeParquet.tpl
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+{{- define "volumeParquet" -}}
+- name: parquet-data
+  persistentVolumeClaim:
+    claimName: {{ .Values.parquetPersistence.existingClaim | default (include "name" .) }}
+{{- end -}}

--- a/chart/templates/services/rows/deployment.yaml
+++ b/chart/templates/services/rows/deployment.yaml
@@ -29,5 +29,7 @@ spec:
       containers: {{ include "containerRows" . | nindent 8 }}
       nodeSelector: {{ toYaml .Values.rows.nodeSelector | nindent 8 }}
       tolerations: {{ toYaml .Values.rows.tolerations | nindent 8 }}
-      volumes: {{ include "volumeData" . | nindent 8 }}
+      volumes: 
+        {{ include "volumeData" . | nindent 8 }}
+        {{ include "volumeParquet" . | nindent 8 }}
       securityContext: {{ include "securityContext" . | nindent 8 }}

--- a/chart/templates/worker/_deployment.yaml
+++ b/chart/templates/worker/_deployment.yaml
@@ -30,6 +30,9 @@ spec:
       containers: {{ include "containerWorker" . | nindent 8 }}
       nodeSelector: {{ toYaml .workerValues.nodeSelector | nindent 8 }}
       tolerations: {{ toYaml .workerValues.tolerations | nindent 8 }}
-      volumes: {{ include "volumeData" . | nindent 8 }}
+      volumes: 
+        {{ include "volumeData" . | nindent 8 }}
+        {{ include "volumeDuckDB" . | nindent 8 }}
+        {{ include "volumeParquet" . | nindent 8 }}
       securityContext: {{ include "securityContext" . | nindent 8 }}
 {{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -105,6 +105,15 @@ persistence:
   storageClass: ""
   size: 20Gi
 
+cachePersistence:
+  existingClaim: ""
+
+parquetPersistence:
+  existingClaim: ""
+
+duckdbPersistence:
+  existingClaim: ""
+
 monitoring:
   enabled: false
 


### PR DESCRIPTION
Related to https://github.com/huggingface/datasets-server/issues/1407
Adding new volumes for: cache (datasets library), parquet and duckdb
Based on https://github.com/huggingface/infra/pull/607, the persistenceVolumeClaims should be:

- datasets-server-cache-pvc
- datasets-server-parquet-pvc
- datasets-server-duckdb-pvc

I think it depends on https://github.com/huggingface/infra/pull/607/files to be merged/implemented first.