### PR TITLE
Sync advised indexes by Atlas

### DIFF
--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -151,7 +151,8 @@ class JobDocument(Document):
         "indexes": [
             ("type", "dataset", "status"),
             ("type", "dataset", "revision", "config", "split", "status", "priority"),
-            ("priority", "status", "created_at", "difficulty", "namespace", "type", "unicity_id"),
+            ("priority", "status", "created_at", "namespace"),
+            ("priority", "status", "type", "namespace", "unicity_id", "created_at", "-difficulty"),
             ("status", "type"),
             ("unicity_id", "status", "created_at"),
             {


### PR DESCRIPTION
Syncing advised indexes by Mongo Atlas and removing not used index (Replaced with a new one).
