### PR TITLE
Separate parquet metadata by split

### DIFF
--- a/libs/libcommon/src/libcommon/viewer_utils/parquet_metadata.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/parquet_metadata.py
@@ -11,9 +11,9 @@ DATASET_SEPARATOR = "--"
 PARQUET_METADATA_DIR_MODE = 0o755
 
 
-def create_parquet_metadata_dir(dataset: str, config: str, parquet_metadata_directory: StrPath) -> Tuple[Path, str]:
-    dir_path = Path(parquet_metadata_directory).resolve() / dataset / DATASET_SEPARATOR / config
-    parquet_metadata_dir_subpath = f"{dataset}/{DATASET_SEPARATOR}/{config}"
+def create_parquet_metadata_dir(dataset: str, config: str, split: str, parquet_metadata_directory: StrPath) -> Tuple[Path, str]:
+    dir_path = Path(parquet_metadata_directory).resolve() / dataset / DATASET_SEPARATOR / config / split
+    parquet_metadata_dir_subpath = f"{dataset}/{DATASET_SEPARATOR}/{config}/{split}"
     makedirs(dir_path, PARQUET_METADATA_DIR_MODE, exist_ok=True)
     return dir_path, parquet_metadata_dir_subpath
 
@@ -21,6 +21,7 @@ def create_parquet_metadata_dir(dataset: str, config: str, parquet_metadata_dire
 def create_parquet_metadata_file(
     dataset: str,
     config: str,
+    split: str,
     parquet_file_metadata: pq.FileMetaData,
     filename: str,
     parquet_metadata_directory: StrPath,
@@ -29,6 +30,7 @@ def create_parquet_metadata_file(
     dir_path, parquet_metadata_dir_subpath = create_parquet_metadata_dir(
         dataset=dataset,
         config=config,
+        split=split,
         parquet_metadata_directory=parquet_metadata_directory,
     )
     parquet_metadata_file_path = dir_path / filename

--- a/libs/libcommon/src/libcommon/viewer_utils/parquet_metadata.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/parquet_metadata.py
@@ -11,7 +11,9 @@ DATASET_SEPARATOR = "--"
 PARQUET_METADATA_DIR_MODE = 0o755
 
 
-def create_parquet_metadata_dir(dataset: str, config: str, split: str, parquet_metadata_directory: StrPath) -> Tuple[Path, str]:
+def create_parquet_metadata_dir(
+    dataset: str, config: str, split: str, parquet_metadata_directory: StrPath
+) -> Tuple[Path, str]:
     dir_path = Path(parquet_metadata_directory).resolve() / dataset / DATASET_SEPARATOR / config / split
     parquet_metadata_dir_subpath = f"{dataset}/{DATASET_SEPARATOR}/{config}/{split}"
     makedirs(dir_path, PARQUET_METADATA_DIR_MODE, exist_ok=True)

--- a/services/worker/src/worker/job_runners/config/parquet_metadata.py
+++ b/services/worker/src/worker/job_runners/config/parquet_metadata.py
@@ -39,6 +39,7 @@ def create_parquet_metadata_file_from_remote_parquet(
     parquet_metadata_subpath = create_parquet_metadata_file(
         dataset=parquet_file_item["dataset"],
         config=parquet_file_item["config"],
+        split=parquet_file_item["split"],
         parquet_file_metadata=parquet_file.metadata,
         filename=parquet_file_item["filename"],
         parquet_metadata_directory=parquet_metadata_directory,

--- a/services/worker/tests/job_runners/config/test_parquet_metadata.py
+++ b/services/worker/tests/job_runners/config/test_parquet_metadata.py
@@ -117,7 +117,7 @@ def get_job_runner(
                         filename="filename1",
                         size=0,
                         num_rows=3,
-                        parquet_metadata_subpath="ok/--/config_1/filename1",
+                        parquet_metadata_subpath="ok/--/config_1/train/filename1",
                     ),
                     ParquetFileMetadataItem(
                         dataset="ok",
@@ -127,7 +127,7 @@ def get_job_runner(
                         filename="filename2",
                         size=0,
                         num_rows=3,
-                        parquet_metadata_subpath="ok/--/config_1/filename2",
+                        parquet_metadata_subpath="ok/--/config_1/train/filename2",
                     ),
                 ],
                 partial=False,


### PR DESCRIPTION
Since we added partial conversion to parquet, we introduced the new config/split/ssss.parquet paths but the parquet metadata worker was nos following it and therefore splits could overwrite each other

This affects any dataset with partial conversion and multiple splits, e.g. c4

Related tohttps://github.com/huggingface/datasets-server/issues/1483