### PR TITLE
feat: 🎸 request 4Gi per /rows pod

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -295,7 +295,7 @@ rows:
   resources:
     requests:
       cpu: 1
-      memory: "2Gi"
+      memory: "4Gi"
     limits:
       cpu: 4
       memory: "8Gi"


### PR DESCRIPTION
it will allocate less pods per node. We regularly have OOM errors, with pods that use 3, 5, 6, 7 GiB RAM, and the node has not enough RAM left for them.

<img width="305" alt="Capture d’écran 2023-07-25 à 12 29 26" src="https://github.com/huggingface/datasets-server/assets/1676121/6f237006-2bab-4604-82f7-2f0fa1a3ac0a">
