### PR TITLE
Skip real test

### DIFF
--- a/services/worker/tests/job_runners/split/test_opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/tests/job_runners/split/test_opt_in_out_urls_scan_from_streaming.py
@@ -299,7 +299,12 @@ def test_compute_error_from_spawning(
         job_runner.compute()
 
 
-@pytest.mark.skip(reason="Temporarily disabled, we can't use secrets on fork repos. See https://github.com/huggingface/datasets-server/issues/1085")
+@pytest.mark.skip(
+    reason=(
+        "Temporarily disabled, we can't use secrets on fork repos. See"
+        " https://github.com/huggingface/datasets-server/issues/1085"
+    )
+)
 @pytest.mark.asyncio
 async def test_real_check_spawning_response(app_config: AppConfig) -> None:
     semaphore = Semaphore(value=10)

--- a/services/worker/tests/job_runners/split/test_opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/tests/job_runners/split/test_opt_in_out_urls_scan_from_streaming.py
@@ -299,6 +299,7 @@ def test_compute_error_from_spawning(
         job_runner.compute()
 
 
+@pytest.mark.skip(reason="Temporarily disabled, we can't use secrets on fork repos. See https://github.com/huggingface/datasets-server/issues/1085")
 @pytest.mark.asyncio
 async def test_real_check_spawning_response(app_config: AppConfig) -> None:
     semaphore = Semaphore(value=10)


### PR DESCRIPTION
Related to https://github.com/huggingface/datasets-server/issues/1085.
Temporarily disabling real test for spawning API to unblock external PRs like https://github.com/huggingface/datasets-server/pull/1570
