### PR TITLE
Fix default config name

### DIFF
--- a/e2e/tests/test_11_api.py
+++ b/e2e/tests/test_11_api.py
@@ -32,7 +32,7 @@ def test_auth_e2e(
     expected_error_code: str,
 ) -> None:
     # TODO: add dataset with various splits, or various configs
-    dataset, config, split = get_default_config_split(hf_dataset_repos_csv_data[type])
+    dataset = hf_dataset_repos_csv_data[type]
     headers = auth_headers[auth]
 
     # asking for the dataset will launch the jobs, without the need of a webhook
@@ -71,7 +71,8 @@ def test_endpoint(
     expected_status_code: int = 200
     expected_error_code = None
     # TODO: add dataset with various splits, or various configs
-    dataset, config, split = get_default_config_split(hf_public_dataset_repo_csv_data)
+    dataset = hf_public_dataset_repo_csv_data
+    config, split = get_default_config_split()
     headers = auth_headers[auth]
 
     # asking for the dataset will launch the jobs, without the need of a webhook
@@ -100,7 +101,8 @@ def test_rows_endpoint(
     expected_status_code: int = 200
     expected_error_code = None
     # TODO: add dataset with various splits, or various configs
-    dataset, config, split = get_default_config_split(hf_public_dataset_repo_csv_data)
+    dataset = hf_public_dataset_repo_csv_data
+    config, split = get_default_config_split()
     headers = auth_headers[auth]
     # ensure the /rows endpoint works as well
     offset = 1

--- a/e2e/tests/test_52_search.py
+++ b/e2e/tests/test_52_search.py
@@ -13,7 +13,8 @@ def test_search_endpoint(
     expected_status_code: int = 200
     expected_error_code = None
     # TODO: add dataset with various splits, or various configs
-    dataset, config, split = get_default_config_split(hf_public_dataset_repo_csv_data)
+    dataset = hf_public_dataset_repo_csv_data
+    config, split = get_default_config_split()
     headers = auth_headers[auth]
     # ensure the /search endpoint works as well
     offset = 1

--- a/e2e/tests/utils.py
+++ b/e2e/tests/utils.py
@@ -97,7 +97,7 @@ def get_openapi_body_example(path: str, status: int, example_name: str) -> Any:
     ]["value"]
 
 
-def get_default_config_split() -> Tuple[str, str, str]:
+def get_default_config_split() -> Tuple[str, str]:
     config = "default"
     split = "train"
     return config, split

--- a/e2e/tests/utils.py
+++ b/e2e/tests/utils.py
@@ -97,10 +97,10 @@ def get_openapi_body_example(path: str, status: int, example_name: str) -> Any:
     ]["value"]
 
 
-def get_default_config_split(dataset: str) -> Tuple[str, str, str]:
+def get_default_config_split() -> Tuple[str, str, str]:
     config = "default"
     split = "train"
-    return dataset, config, split
+    return config, split
 
 
 def log(response: Response, url: str = URL, relative_url: Optional[str] = None, dataset: Optional[str] = None) -> str:

--- a/e2e/tests/utils.py
+++ b/e2e/tests/utils.py
@@ -98,7 +98,7 @@ def get_openapi_body_example(path: str, status: int, example_name: str) -> Any:
 
 
 def get_default_config_split(dataset: str) -> Tuple[str, str, str]:
-    config = dataset.replace("/", "--")
+    config = "default"
     split = "train"
     return dataset, config, split
 

--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -35,7 +35,7 @@ hf_api = HfApi(endpoint=CI_HUB_ENDPOINT)
 
 
 def get_default_config_split(dataset: str) -> Tuple[str, str, str]:
-    config = dataset.replace("/", "--")
+    config = "default"
     split = "train"
     return dataset, config, split
 

--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -307,7 +307,7 @@ HubDatasets = Mapping[str, HubDatasetTest]
 
 
 def create_config_names_response(dataset: str) -> Any:
-    dataset, config, _ = get_default_config_split(dataset)
+    config, _ = get_default_config_split()
     return {
         "config_names": [
             {
@@ -319,7 +319,7 @@ def create_config_names_response(dataset: str) -> Any:
 
 
 def create_splits_response(dataset: str) -> Any:
-    dataset, config, split = get_default_config_split(dataset)
+    config, split = get_default_config_split()
     return {
         "splits": [
             {
@@ -332,7 +332,7 @@ def create_splits_response(dataset: str) -> Any:
 
 
 def create_first_rows_response(dataset: str, cols: Mapping[str, Any], rows: List[Any]) -> Any:
-    dataset, config, split = get_default_config_split(dataset)
+    config, split = get_default_config_split()
     return {
         "dataset": dataset,
         "config": config,
@@ -445,7 +445,7 @@ def create_parquet_and_info_response(
     data_type: Literal["csv", "big-csv", "audio", "big_parquet", "big_parquet_no_info"],
     partial: bool = False,
 ) -> Any:
-    dataset, config, split = get_default_config_split(dataset)
+    config, split = get_default_config_split()
 
     if partial:
         filename = "0000.parquet"
@@ -530,7 +530,7 @@ AUDIO_cols = {
 
 
 def get_AUDIO_rows(dataset: str) -> Any:
-    dataset, config, split = get_default_config_split(dataset)
+    config, split = get_default_config_split()
     return [
         {
             "col": [
@@ -553,7 +553,7 @@ IMAGE_cols = {
 
 
 def get_IMAGE_rows(dataset: str) -> Any:
-    dataset, config, split = get_default_config_split(dataset)
+    config, split = get_default_config_split()
     return [
         {
             "col": {
@@ -571,7 +571,7 @@ IMAGES_LIST_cols = {
 
 
 def get_IMAGES_LIST_rows(dataset: str) -> Any:
-    dataset, config, split = get_default_config_split(dataset)
+    config, split = get_default_config_split()
     return [
         {
             "col": [

--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -34,7 +34,7 @@ DATASET = "dataset"
 hf_api = HfApi(endpoint=CI_HUB_ENDPOINT)
 
 
-def get_default_config_split() -> Tuple[str, str, str]:
+def get_default_config_split() -> Tuple[str, str]:
     config = "default"
     split = "train"
     return config, split

--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -34,10 +34,10 @@ DATASET = "dataset"
 hf_api = HfApi(endpoint=CI_HUB_ENDPOINT)
 
 
-def get_default_config_split(dataset: str) -> Tuple[str, str, str]:
+def get_default_config_split() -> Tuple[str, str, str]:
     config = "default"
     split = "train"
-    return dataset, config, split
+    return config, split
 
 
 def update_repo_settings(

--- a/services/worker/tests/job_runners/config/test_split_names_from_streaming.py
+++ b/services/worker/tests/job_runners/config/test_split_names_from_streaming.py
@@ -66,7 +66,8 @@ def get_job_runner(
 
 
 def test_compute(app_config: AppConfig, get_job_runner: GetJobRunner, hub_public_csv: str) -> None:
-    dataset, config, _ = get_default_config_split(hub_public_csv)
+    dataset = hub_public_csv
+    config, _ = get_default_config_split()
     job_runner = get_job_runner(dataset, config, app_config)
     response = job_runner.compute()
     content = response.content
@@ -110,7 +111,8 @@ def test_compute_split_names_from_streaming_response(
         "empty": hub_responses_empty,
         "does_not_exist": hub_responses_does_not_exist,
     }
-    dataset, config, _ = get_default_config_split(hub_datasets[name]["name"])
+    dataset = hub_datasets[name]["name"]
+    config, _ = get_default_config_split()
     expected_configs_response = hub_datasets[name]["splits_response"]
     job_runner = get_job_runner(
         dataset,

--- a/services/worker/tests/job_runners/split/test_first_rows_from_streaming.py
+++ b/services/worker/tests/job_runners/split/test_first_rows_from_streaming.py
@@ -74,7 +74,8 @@ def get_job_runner(
 
 
 def test_compute(app_config: AppConfig, get_job_runner: GetJobRunner, hub_public_csv: str) -> None:
-    dataset, config, split = get_default_config_split(hub_public_csv)
+    dataset = hub_public_csv
+    config, split = get_default_config_split()
     job_runner = get_job_runner(dataset, config, split, app_config)
     upsert_response(
         kind="config-split-names-from-streaming",
@@ -151,7 +152,7 @@ def test_number_rows(
     }
     dataset = hub_datasets[name]["name"]
     expected_first_rows_response = hub_datasets[name]["first_rows_response"]
-    dataset, config, split = get_default_config_split(dataset)
+    config, split = get_default_config_split()
     job_runner = get_job_runner(
         dataset,
         config,
@@ -216,7 +217,7 @@ def test_truncation(
     error_code: str,
 ) -> None:
     dataset = hub_public_csv if name == "public" else hub_public_big
-    dataset, config, split = get_default_config_split(dataset)
+    config, split = get_default_config_split()
     job_runner = get_job_runner(
         dataset,
         config,

--- a/services/worker/tests/job_runners/split/test_image_url_columns.py
+++ b/services/worker/tests/job_runners/split/test_image_url_columns.py
@@ -185,7 +185,7 @@ def test_compute(
     upstream_content: Mapping[str, Any],
     expected_content: Mapping[str, Any],
 ) -> None:
-    dataset, config, split = get_default_config_split(dataset)
+    config, split = get_default_config_split()
     job_runner = get_job_runner(
         dataset,
         config,
@@ -229,7 +229,7 @@ def test_compute_failed(
     upstream_status: HTTPStatus,
     exception_name: str,
 ) -> None:
-    dataset, config, split = get_default_config_split(dataset)
+    config, split = get_default_config_split()
     job_runner = get_job_runner(
         dataset,
         config,

--- a/services/worker/tests/job_runners/split/test_opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/tests/job_runners/split/test_opt_in_out_urls_scan_from_streaming.py
@@ -184,7 +184,8 @@ def test_compute(
     expected_content: Mapping[str, Any],
 ) -> None:
     hub_datasets = {"public": hub_responses_public, "spawning_opt_in_out": hub_responses_spawning_opt_in_out}
-    dataset, config, split = get_default_config_split(hub_datasets[name]["name"])
+    dataset = hub_datasets[name]["name"]
+    config, split = get_default_config_split()
     job_runner = get_job_runner(
         dataset,
         config,
@@ -248,7 +249,7 @@ def test_compute_failed(
 ) -> None:
     if dataset == "too_many_columns":
         dataset = hub_responses_spawning_opt_in_out["name"]
-    dataset, config, split = get_default_config_split(dataset)
+    config, split = get_default_config_split()
     job_runner = get_job_runner(
         dataset,
         config,
@@ -277,7 +278,8 @@ def test_compute_error_from_spawning(
     get_job_runner: GetJobRunner,
     hub_public_spawning_opt_in_out: str,
 ) -> None:
-    dataset, config, split = get_default_config_split(hub_public_spawning_opt_in_out)
+    dataset = hub_public_spawning_opt_in_out
+    config, split = get_default_config_split()
     job_runner = get_job_runner(
         dataset,
         config,

--- a/services/worker/tests/job_runners/test__job_runner_with_cache.py
+++ b/services/worker/tests/job_runners/test__job_runner_with_cache.py
@@ -108,7 +108,8 @@ def test_get_cache_subdirectory(
 
 
 def test_pre_compute_post_compute(app_config: AppConfig, get_job_runner: GetJobRunner) -> None:
-    dataset, config, split = get_default_config_split("user/dataset")
+    dataset = "user/dataset"
+    config, split = get_default_config_split()
     job_runner = get_job_runner(dataset, config, split, app_config)
     datasets_base_path = job_runner.base_cache_directory
     job_runner.pre_compute()

--- a/services/worker/tests/job_runners/test__job_runner_with_datasets_cache.py
+++ b/services/worker/tests/job_runners/test__job_runner_with_datasets_cache.py
@@ -81,7 +81,8 @@ def get_job_runner(
 
 
 def test_set_datasets_cache(app_config: AppConfig, get_job_runner: GetJobRunner) -> None:
-    dataset, config, split = get_default_config_split("dataset")
+    dataset = "dataset"
+    config, split = get_default_config_split()
     job_runner = get_job_runner(dataset, config, split, app_config)
     base_path = job_runner.base_cache_directory
     dummy_path = base_path / "dummy"
@@ -90,7 +91,8 @@ def test_set_datasets_cache(app_config: AppConfig, get_job_runner: GetJobRunner)
 
 
 def test_pre_compute_post_compute(app_config: AppConfig, get_job_runner: GetJobRunner) -> None:
-    dataset, config, split = get_default_config_split("user/dataset")
+    dataset = "user/dataset"
+    config, split = get_default_config_split()
     job_runner = get_job_runner(dataset, config, split, app_config)
     datasets_base_path = job_runner.base_cache_directory
     job_runner.pre_compute()

--- a/services/worker/tests/test_job_manager.py
+++ b/services/worker/tests/test_job_manager.py
@@ -284,7 +284,7 @@ def test_raise_if_parallel_response_exists(
 def test_doesnotexist(app_config: AppConfig) -> None:
     dataset = "doesnotexist"
     revision = "revision"
-    dataset, config, split = get_default_config_split(dataset)
+    config, split = get_default_config_split()
 
     job_info = JobInfo(
         job_id="job_id",


### PR DESCRIPTION
Fix default config name and refactor:
- the function no longer uses the argument `dataset`
- it returns a 2-tuple

Fix partially #1589.