### PR TITLE
Fix cached filenames

### DIFF
--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -617,8 +617,7 @@ def copy_parquet_files(builder: DatasetBuilder) -> List[CommitOperationCopy]:
             src_revision = unquote(src_revision)
             src_path_in_repo = unquote(src_path_in_repo)
 
-            # for forward compatibility with https://github.com/huggingface/datasets/pull/5331
-            parquet_name = str(builder.dataset_name) if hasattr(builder, "dataset_name") else builder.name
+            parquet_name = str(builder.dataset_name)
 
             if num_shards > 1:
                 path_in_repo = (

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -850,10 +850,10 @@ def list_generated_parquet_files(builder: DatasetBuilder, partial: bool = False)
     local_parquet_files: List[ParquetFile] = []
     for split, split_info in split_dict.items():
         # We know the `datasets` library uses a template for the shards names:
-        # - {builder.name}-{split}.parquet if there is only one shard
-        # - {builder.name}-{split}-{shard_idx:05d}-of-{num_shards:05d}.parquet otherwise
+        # - {builder.dataset_name}-{split}.parquet if there is only one shard
+        # - {builder.dataset_name}-{split}-{shard_idx:05d}-of-{num_shards:05d}.parquet otherwise
         num_shards = len(split_info.shard_lengths) if isinstance(split_info.shard_lengths, list) else 1
-        fname_prefix = f"{builder.name}-{split}"
+        fname_prefix = f"{builder.dataset_name}-{split}"
         local_parquet_files.extend(
             [
                 ParquetFile(

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -616,16 +616,8 @@ def copy_parquet_files(builder: DatasetBuilder) -> List[CommitOperationCopy]:
             )
             src_revision = unquote(src_revision)
             src_path_in_repo = unquote(src_path_in_repo)
-
-            parquet_name = str(builder.dataset_name)
-
-            if num_shards > 1:
-                path_in_repo = (
-                    f"{builder.config.name}/{parquet_name}-{split}-{shard_idx:05d}-of-{num_shards:05d}.parquet"
-                )
-            else:
-                path_in_repo = f"{builder.config.name}/{parquet_name}-{split}.parquet"
-
+            filename_suffix = f"-{shard_idx:05d}-of-{num_shards:05d}" if num_shards > 1 else ""
+            path_in_repo = f"{builder.config.name}/{builder.dataset_name}-{split}{filename_suffix}.parquet"
             parquet_operations.append(
                 CommitOperationCopy(
                     src_path_in_repo=src_path_in_repo, path_in_repo=path_in_repo, src_revision=src_revision
@@ -852,14 +844,14 @@ def list_generated_parquet_files(builder: DatasetBuilder, partial: bool = False)
         # - {builder.dataset_name}-{split}.parquet if there is only one shard
         # - {builder.dataset_name}-{split}-{shard_idx:05d}-of-{num_shards:05d}.parquet otherwise
         num_shards = len(split_info.shard_lengths) if isinstance(split_info.shard_lengths, list) else 1
-        fname_prefix = f"{builder.dataset_name}-{split}"
+        filename_suffix = "-{shard_idx:05d}-of-" + f"{num_shards:05d}" if num_shards > 1 else ""
+        filename = f"{builder.dataset_name}-{split}{filename_suffix}.parquet"
         local_parquet_files.extend(
             [
                 ParquetFile(
                     local_file=os.path.join(
                         builder.cache_dir,
-                        fname_prefix
-                        + (f"-{shard_idx:05d}-of-{num_shards:05d}.parquet" if num_shards > 1 else ".parquet"),
+                        filename.format(shard_idx=shard_idx),
                     ),
                     local_dir=builder.cache_dir,
                     config=builder.config.name,

--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -357,6 +357,7 @@ def create_first_rows_response(dataset: str, cols: Mapping[str, Any], rows: List
 
 
 def create_dataset_info_response_for_csv(dataset: str, config: str) -> Any:
+    dataset_name = dataset.split("/")[-1]
     return {
         "description": "",
         "citation": "",
@@ -365,8 +366,9 @@ def create_dataset_info_response_for_csv(dataset: str, config: str) -> Any:
         "features": DATA_cols,
         "builder_name": "csv",
         "config_name": config,
+        "dataset_name": dataset_name,
         "version": {"version_str": "0.0.0", "major": 0, "minor": 0, "patch": 0},
-        "splits": {"train": {"name": "train", "num_bytes": 96, "num_examples": 4, "dataset_name": "csv"}},
+        "splits": {"train": {"name": "train", "num_bytes": 96, "num_examples": 4, "dataset_name": dataset_name}},
         "download_checksums": {
             f"https://hub-ci.huggingface.co/datasets/{dataset}/resolve/__COMMIT__/dataset.csv": {
                 "num_bytes": 50,
@@ -379,10 +381,11 @@ def create_dataset_info_response_for_csv(dataset: str, config: str) -> Any:
     }
 
 
-def create_dataset_info_response_for_partially_generated_big_csv(config: str) -> Any:
+def create_dataset_info_response_for_partially_generated_big_csv(dataset: str, config: str) -> Any:
     # Dataset is partially converted to parquet: the first 10KB instead of the full 5MB
     # Missing fields:
     # - download_size: not applicable, because the dataset is generated using partially downloaded files
+    dataset_name = dataset.split("/")[-1]
     return {
         "description": "",
         "citation": "",
@@ -391,19 +394,25 @@ def create_dataset_info_response_for_partially_generated_big_csv(config: str) ->
         "features": BIG_cols,
         "builder_name": "csv",
         "config_name": config,
+        "dataset_name": dataset_name,
         "version": {"version_str": "0.0.0", "major": 0, "minor": 0, "patch": 0},
         "splits": {"train": {"name": "train", "num_bytes": 12380, "num_examples": 10, "dataset_name": "csv"}},
         "dataset_size": 12380,
     }
 
 
-def create_dataset_info_response_for_big_parquet() -> Any:
+def create_dataset_info_response_for_big_parquet(dataset: str, config: str) -> Any:
+    dataset_name = dataset.split("/")[-1]
     return {
         "description": "",
         "citation": "",
         "homepage": "",
         "license": "",
         "features": BIG_cols,
+        "builder_name": "parquet",
+        "config_name": config,
+        "dataset_name": dataset_name,
+        "version": {"version_str": "0.0.0", "major": 0, "minor": 0, "patch": 0},
         "splits": {
             "train": {"name": "train", "num_bytes": 5653946, "num_examples": len(BIG_rows), "dataset_name": None}
         },
@@ -427,13 +436,18 @@ def create_dataset_info_response_for_big_parquet_no_info() -> Any:
     }
 
 
-def create_dataset_info_response_for_audio() -> Any:
+def create_dataset_info_response_for_audio(dataset: str, config: str) -> Any:
+    dataset_name = dataset.split("/")[-1]
     return {
         "description": "",
         "citation": "",
         "homepage": "",
         "license": "",
         "features": AUDIO_cols,
+        "builder_name": "parquet",
+        "config_name": config,
+        "dataset_name": dataset_name,
+        "version": {"version_str": "0.0.0", "major": 0, "minor": 0, "patch": 0},
         "splits": {"train": {"name": "train", "num_bytes": 59, "num_examples": 1, "dataset_name": None}},
         "download_size": AUDIO_PARQUET_SIZE,
         "dataset_size": 59,
@@ -446,11 +460,11 @@ def create_parquet_and_info_response(
     partial: bool = False,
 ) -> Any:
     config, split = get_default_config_split()
-
+    dataset_name = dataset.split("/")[-1]
     if partial:
         filename = "0000.parquet"
     else:
-        filename = "csv-train.parquet" if "csv" in data_type else "parquet-train.parquet"
+        filename = f"{dataset_name}-train.parquet"
     size = (
         CSV_PARQUET_SIZE
         if data_type == "csv"
@@ -463,11 +477,11 @@ def create_parquet_and_info_response(
     info = (
         create_dataset_info_response_for_csv(dataset, config)
         if data_type == "csv"
-        else create_dataset_info_response_for_partially_generated_big_csv(config)
+        else create_dataset_info_response_for_partially_generated_big_csv(dataset, config)
         if data_type == "big-csv"
-        else create_dataset_info_response_for_audio()
+        else create_dataset_info_response_for_audio(dataset, config)
         if data_type == "audio"
-        else create_dataset_info_response_for_big_parquet()
+        else create_dataset_info_response_for_big_parquet(dataset, config)
         if data_type == "big_parquet"
         else create_dataset_info_response_for_big_parquet_no_info()
     )


### PR DESCRIPTION
Fix the filename of cached files, so that it contains the `builder.dataset_name` instead of `builder.name`.

Fix partially #1589.