### PR TITLE
Fix HfFileSystem

### DIFF
--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -706,6 +706,10 @@ def fill_builder_info(
     data_files = builder.config.data_files
     if not data_files:
         raise EmptyDatasetError("Empty parquet data_files")
+    builder.info.builder_name = builder.name
+    builder.info.dataset_name = builder.dataset_name
+    builder.info.config_name = builder.config.name
+    builder.info.version = builder.config.version
     builder.info.splits = SplitDict()
     builder.info.download_size = 0
     builder.info.dataset_size = 0

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -608,9 +608,7 @@ def copy_parquet_files(builder: DatasetBuilder) -> List[CommitOperationCopy]:
     for split in data_files:
         num_shards = len(data_files[split])
         for shard_idx, data_file in enumerate(data_files[split]):
-            src_revision, src_path_in_repo = data_file.split("/datasets/" + builder.repo_id + "/resolve/", 1)[1].split(
-                "/", 1
-            )
+            src_revision, src_path_in_repo = data_file.split("@")[1].split("/", 1)
             src_revision = unquote(src_revision)
             src_path_in_repo = unquote(src_path_in_repo)
             filename_suffix = f"-{shard_idx:05d}-of-{num_shards:05d}" if num_shards > 1 else ""

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -45,7 +45,6 @@ from datasets.utils.file_utils import (
     url_or_path_join,
 )
 from datasets.utils.py_utils import asdict, map_nested
-from fsspec.implementations.http import HTTPFileSystem
 from huggingface_hub._commit_api import (
     CommitOperation,
     CommitOperationAdd,
@@ -53,6 +52,7 @@ from huggingface_hub._commit_api import (
     CommitOperationDelete,
 )
 from huggingface_hub.hf_api import CommitInfo, DatasetInfo, HfApi, RepoFile
+from huggingface_hub.hf_file_system import HfFileSystem
 from huggingface_hub.utils._errors import HfHubHTTPError, RepositoryNotFoundError
 from libcommon.constants import (
     PROCESSING_STEP_CONFIG_PARQUET_AND_INFO_ROW_GROUP_SIZE_FOR_AUDIO_DATASETS,
@@ -640,9 +640,9 @@ class TooBigRowGroupsError(ParquetValidationError):
         self.row_group_byte_size = row_group_byte_size
 
 
-def get_parquet_file_and_size(url: str, fs: HTTPFileSystem, hf_token: Optional[str]) -> Tuple[pq.ParquetFile, int]:
-    headers = get_authentication_headers_for_url(url, use_auth_token=hf_token)
-    f = fs.open(url, headers=headers)
+def get_parquet_file_and_size(url: str, hf_endpoint: str, hf_token: Optional[str]) -> Tuple[pq.ParquetFile, int]:
+    fs = HfFileSystem(endpoint=hf_endpoint, token=hf_token)
+    f = fs.open(url)
     return pq.ParquetFile(f), f.size
 
 

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -947,6 +947,7 @@ def test_limit_parquet_writes(tmp_path: Path) -> None:
 )
 def test_fill_builder_info(
     hub_responses_big: HubDatasetTest,
+    app_config: AppConfig,
     tmp_path: Path,
     validate: Optional[Callable[[pq.ParquetFile], None]],
     too_big_row_groups: bool,
@@ -957,12 +958,12 @@ def test_fill_builder_info(
     builder.info = datasets.info.DatasetInfo()
     if too_big_row_groups:
         with pytest.raises(TooBigRowGroupsError) as exc_info:
-            fill_builder_info(builder, hf_token=None, validate=validate)
+            fill_builder_info(builder, hf_endpoint=app_config.common.hf_endpoint, hf_token=None, validate=validate)
         assert isinstance(exc_info.value, TooBigRowGroupsError)
         assert isinstance(exc_info.value.num_rows, int)
         assert isinstance(exc_info.value.row_group_byte_size, int)
     else:
-        fill_builder_info(builder, hf_token=None, validate=validate)
+        fill_builder_info(builder, hf_endpoint=app_config.common.hf_endpoint, hf_token=None, validate=validate)
         expected_info = hub_responses_big["parquet_and_info_response"]["dataset_info"]
         assert expected_info == asdict(builder.info)
 


### PR DESCRIPTION
Fix usage of `HfFileSystem` (instead of `HTTPFileSystem`) and filename format of `data_files`.

Additionally, fix `fill_builder_info` with additional builder information: `builder_name`, `dataset_name`, `config_name` and `version`.

Fix partially #1589.