### PR TITLE
Fix e2e test_16_statistics

### DIFF
--- a/e2e/tests/test_16_statistics.py
+++ b/e2e/tests/test_16_statistics.py
@@ -13,7 +13,8 @@ def test_statistics_endpoint(
     expected_status_code: int = 200
     expected_error_code = None
     # TODO: add dataset with various splits, or various configs
-    dataset, config, split = get_default_config_split(hf_public_dataset_repo_csv_data)
+    dataset = hf_public_dataset_repo_csv_data
+    config, split = get_default_config_split()
     headers = auth_headers[auth]
     statistics_response = poll_until_ready_and_assert(
         relative_url=f"/statistics?dataset={dataset}&config={config}&split={split}",


### PR DESCRIPTION
Fix e2e `test_16_statistics`. as this file was added after branch (https://github.com/huggingface/datasets-server/tree/update-datasets-2.14) was created from main.

This fix is necessary after the refactoring introduced by:
- #1616
