### PR TITLE
Enable delete-indexes job to run every 10 minutes

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -189,6 +189,10 @@ backfill:
       memory: "8Gi"
   tolerations: []
 
+deleteIndexes:
+  schedule: "*/10  * * * *"
+  # every ten minutes
+
 metricsCollector:
   action: "collect-metrics"
   schedule: "*/2 * * * *"

--- a/chart/env/staging.yaml
+++ b/chart/env/staging.yaml
@@ -148,6 +148,10 @@ cacheMaintenance:
 backfill:
   enabled: false
 
+deleteIndexes:
+  schedule: "*/10  * * * *"
+  # every ten minutes
+
 metricsCollector:
   action: "collect-metrics"
   schedule: "*/2 * * * *"


### PR DESCRIPTION
In order to try correct functionality of delete-index job, I would like to test every 10 minutes.
Then I will remove this schedule and will keep as default (once a day).