### PR TITLE
Try to fix delete indexes job

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.15.3
+version: 1.16.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/env/staging.yaml
+++ b/chart/env/staging.yaml
@@ -151,6 +151,14 @@ backfill:
 deleteIndexes:
   schedule: "*/10  * * * *"
   # every ten minutes
+  nodeSelector: {}
+  resources:
+    requests:
+      cpu: 1
+    limits:
+      cpu: 1
+      memory: "512Mi"
+  tolerations: []
 
 metricsCollector:
   action: "collect-metrics"

--- a/chart/templates/_common/_helpers.tpl
+++ b/chart/templates/_common/_helpers.tpl
@@ -102,7 +102,7 @@ app.kubernetes.io/component: "{{ include "name" . }}-backfill"
 
 {{- define "labels.deleteIndexes" -}}
 {{ include "hf.labels.commons" . }}
-app.kubernetes.io/component: "{{ include "name" . }}-deleteIndexes"
+app.kubernetes.io/component: "{{ include "name" . }}-delete-indexes"
 {{- end -}}
 
 {{- define "labels.admin" -}}

--- a/chart/templates/cron-jobs/delete-indexes/_container.tpl
+++ b/chart/templates/cron-jobs/delete-indexes/_container.tpl
@@ -5,6 +5,8 @@
 - name: "{{ include "name" . }}-delete-indexes"
   image: {{ include "jobs.cacheMaintenance.image" . }}
   imagePullPolicy: {{ .Values.images.pullPolicy }}
+  volumeMounts:
+  {{ include "volumeMountDuckDBIndexRW" . | nindent 2 }}
   securityContext:
     allowPrivilegeEscalation: false
   resources: {{ toYaml .Values.deleteIndexes.resources | nindent 4 }}

--- a/chart/templates/cron-jobs/delete-indexes/job.yaml
+++ b/chart/templates/cron-jobs/delete-indexes/job.yaml
@@ -16,6 +16,7 @@ spec:
       template:
         spec:
           restartPolicy: OnFailure
+          {{- include "dnsConfig" . | nindent 10 }}
           {{- include "image.imagePullSecrets" . | nindent 6 }}
           nodeSelector: {{ toYaml .Values.deleteIndexes.nodeSelector | nindent 12 }}
           tolerations: {{ toYaml .Values.deleteIndexes.tolerations | nindent 12 }}


### PR DESCRIPTION
Staging deploy fails with message:

```
one or more objects failed to apply, reason: CronJob in version "v1" cannot be handled as a CronJob: json: cannot unmarshal number into Go struct field EnvVar.spec.jobTemplate.spec.template.spec.containers.env.value of type string
```