### PR TITLE
Set default env values for staging and prod - delete indixes

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -137,7 +137,7 @@ optInOutUrlsScan:
 
 duckDBIndex:
   maxParquetSizeBytes: "5_000_000_000"
-  expiredTimeIntervalSeconds: 600
+  expiredTimeIntervalSeconds: 259_200 # 3 days
 
 descriptiveStatistics:
   maxParquetSizeBytes: "5_000_000_000"
@@ -188,10 +188,6 @@ backfill:
       cpu: 2
       memory: "8Gi"
   tolerations: []
-
-deleteIndexes:
-  schedule: "*/10 * * * *"
-  # every ten minutes
 
 metricsCollector:
   action: "collect-metrics"

--- a/chart/env/staging.yaml
+++ b/chart/env/staging.yaml
@@ -148,18 +148,6 @@ cacheMaintenance:
 backfill:
   enabled: false
 
-deleteIndexes:
-  schedule: "*/10 * * * *"
-  # every ten minutes
-  nodeSelector: {}
-  resources:
-    requests:
-      cpu: 1
-    limits:
-      cpu: 1
-      memory: "512Mi"
-  tolerations: []
-
 metricsCollector:
   action: "collect-metrics"
   schedule: "*/2 * * * *"


### PR DESCRIPTION
- delete indexes job will run at 00:00 for staging and prod (default in values.yaml)
- expiredTimeIntervalSeconds: 259_200 # 3 days for prod