### PR TITLE
feat: 🎸 add RAM to the storage admin machine

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -210,11 +210,11 @@ storageAdmin:
   replicas: 1
   resources:
     requests:
-      cpu: 50m
-      memory: "64Mi"
+      cpu: 1
+      memory: "4Gi"
     limits:
       cpu: 1
-      memory: "256Mi"
+      memory: "4Gi"
 
 # --- reverse proxy ---
 


### PR DESCRIPTION
else: rsync crashes for lack of memory