### PR TITLE
move cache metrics inc to orchestrator

### DIFF
--- a/chart/templates/worker/_container.tpl
+++ b/chart/templates/worker/_container.tpl
@@ -8,6 +8,7 @@
   env:
   {{ include "envAssets" . | nindent 2 }}
   {{ include "envCache" . | nindent 2 }}
+  {{ include "envMetrics" . | nindent 2 }}
   {{ include "envCommon" . | nindent 2 }}
   {{ include "envDatasetsBased" . | nindent 2 }}
   {{ include "envLog" . | nindent 2 }}

--- a/jobs/cache_maintenance/src/cache_maintenance/metrics.py
+++ b/jobs/cache_maintenance/src/cache_maintenance/metrics.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 The HuggingFace Authors.
+# Copyright 2023 The HuggingFace Authors.
 
 import logging
 
-from libcommon.metrics import CacheTotalMetricDocument, JobTotalMetricDocument
+from libcommon.metrics import JobTotalMetricDocument
 from libcommon.processing_graph import ProcessingGraph
 from libcommon.queue import Queue
-from libcommon.simple_cache import get_responses_count_by_kind_status_and_error_code
 
 
 def collect_metrics(processing_graph: ProcessingGraph) -> None:
@@ -15,10 +14,3 @@ def collect_metrics(processing_graph: ProcessingGraph) -> None:
     for processing_step in processing_graph.get_processing_steps():
         for status, total in queue.get_jobs_count_by_status(job_type=processing_step.job_type).items():
             JobTotalMetricDocument.objects(queue=processing_step.job_type, status=status).upsert_one(total=total)
-
-    logging.info("collecting cache metrics")
-    for metric in get_responses_count_by_kind_status_and_error_code():
-        CacheTotalMetricDocument.objects(
-            kind=metric["kind"], http_status=metric["http_status"], error_code=metric["error_code"]
-        ).upsert_one(total=metric["count"])
-    logging.info("metrics have been collected")

--- a/jobs/cache_maintenance/tests/test_collect_metrics.py
+++ b/jobs/cache_maintenance/tests/test_collect_metrics.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 The HuggingFace Authors.
+# Copyright 2023 The HuggingFace Authors.
 
 from http import HTTPStatus
 
-from libcommon.metrics import CacheTotalMetricDocument, JobTotalMetricDocument
+from libcommon.metrics import JobTotalMetricDocument
 from libcommon.processing_graph import ProcessingGraph
 from libcommon.queue import Queue
 from libcommon.simple_cache import upsert_response
@@ -42,10 +42,6 @@ def test_collect_metrics() -> None:
     )
 
     collect_metrics(processing_graph=processing_graph)
-
-    cache_metrics = CacheTotalMetricDocument.objects()
-    assert cache_metrics
-    assert len(cache_metrics) == 1
 
     job_metrics = JobTotalMetricDocument.objects()
     assert job_metrics

--- a/libs/libcommon/src/libcommon/orchestrator.py
+++ b/libs/libcommon/src/libcommon/orchestrator.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional, Set, Union
 import pandas as pd
 
 from libcommon.constants import ERROR_CODES_TO_RETRY
+from libcommon.metrics import CacheTotalMetricDocument
 from libcommon.processing_graph import (
     ProcessingGraph,
     ProcessingStep,
@@ -681,6 +682,11 @@ class DatasetOrchestrator:
             details=output["details"],
             progress=output["progress"],
         )
+
+        CacheTotalMetricDocument.objects(
+            kind=processing_step.cache_kind, http_status=output["http_status"], error_code=output["error_code"]
+        ).upsert_one(inc__total=1)
+
         logging.debug("the job output has been written to the cache.")
         # finish the job
         Queue().finish_job(job_id=job_info["job_id"], is_success=job_result["is_success"])

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -494,45 +494,6 @@ class CountEntry(TypedDict):
     count: int
 
 
-def format_group(group: Dict[str, Any]) -> CountEntry:
-    kind = group["kind"]
-    if not isinstance(kind, str):
-        raise TypeError("kind must be a str")
-    http_status = group["http_status"]
-    if not isinstance(http_status, int):
-        raise TypeError("http_status must be an int")
-    error_code = group["error_code"]
-    if not isinstance(error_code, str) and error_code is not None:
-        raise TypeError("error_code must be a str or None")
-    count = group["count"]
-    if not isinstance(count, int):
-        raise TypeError("count must be an int")
-    return {"kind": kind, "http_status": http_status, "error_code": error_code, "count": count}
-
-
-def get_responses_count_by_kind_status_and_error_code() -> List[CountEntry]:
-    groups = CachedResponseDocument.objects().aggregate(
-        [
-            {"$sort": {"kind": 1, "http_status": 1, "error_code": 1}},
-            {
-                "$group": {
-                    "_id": {"kind": "$kind", "http_status": "$http_status", "error_code": "$error_code"},
-                    "count": {"$sum": 1},
-                }
-            },
-            {
-                "$project": {
-                    "kind": "$_id.kind",
-                    "http_status": "$_id.http_status",
-                    "error_code": "$_id.error_code",
-                    "count": "$count",
-                }
-            },
-        ]
-    )
-    return [format_group(group) for group in groups]
-
-
 # /cache-reports/... endpoints
 
 

--- a/libs/libcommon/tests/test_orchestrator.py
+++ b/libs/libcommon/tests/test_orchestrator.py
@@ -6,10 +6,15 @@ from typing import List
 
 import pytest
 
+from libcommon.metrics import CacheTotalMetricDocument
 from libcommon.orchestrator import AfterJobPlan, DatasetOrchestrator
 from libcommon.processing_graph import Artifact, ProcessingGraph
 from libcommon.queue import JobDocument, Queue
-from libcommon.resources import CacheMongoResource, QueueMongoResource
+from libcommon.resources import (
+    CacheMongoResource,
+    MetricsMongoResource,
+    QueueMongoResource,
+)
 from libcommon.simple_cache import CachedResponseDocument, upsert_response_params
 from libcommon.utils import JobOutput, JobResult, Priority, Status
 
@@ -50,6 +55,11 @@ def queue_mongo_resource_autouse(queue_mongo_resource: QueueMongoResource) -> Qu
 @pytest.fixture(autouse=True)
 def cache_mongo_resource_autouse(cache_mongo_resource: CacheMongoResource) -> CacheMongoResource:
     return cache_mongo_resource
+
+
+@pytest.fixture(autouse=True)
+def metrics_mongo_resource_autouse(metrics_mongo_resource: MetricsMongoResource) -> MetricsMongoResource:
+    return metrics_mongo_resource
 
 
 @pytest.mark.parametrize(
@@ -167,8 +177,16 @@ def test_finish_job(
             progress=1.0,
         ),
     )
+
+    assert CacheTotalMetricDocument.objects().count() == 0
+
     dataset_orchestrator = DatasetOrchestrator(dataset=DATASET_NAME, processing_graph=processing_graph)
     dataset_orchestrator.finish_job(job_result=job_result)
+
+    cache_metrics = CacheTotalMetricDocument.objects()
+    assert cache_metrics.count() > 0
+    for cache_metric in cache_metrics:
+        assert cache_metric.total == 1
 
     assert JobDocument.objects(dataset=DATASET_NAME).count() == 1 + len(artifacts_to_create)
 

--- a/libs/libcommon/tests/test_simple_cache.py
+++ b/libs/libcommon/tests/test_simple_cache.py
@@ -29,7 +29,6 @@ from libcommon.simple_cache import (
     get_response,
     get_response_with_details,
     get_response_without_content,
-    get_responses_count_by_kind_status_and_error_code,
     get_valid_datasets,
     has_any_successful_response,
     upsert_response,
@@ -317,38 +316,6 @@ def test_has_any_successful_response_only_invalid_responses() -> None:
         kind=kind, dataset=dataset, config=config_b, content={}, http_status=HTTPStatus.INTERNAL_SERVER_ERROR
     )
     assert not has_any_successful_response(dataset=dataset, kinds=[kind])
-
-
-def test_count_by_status_and_error_code() -> None:
-    assert not get_responses_count_by_kind_status_and_error_code()
-
-    upsert_response(
-        kind="test_kind",
-        dataset="test_dataset",
-        content={"key": "value"},
-        http_status=HTTPStatus.OK,
-    )
-
-    assert get_responses_count_by_kind_status_and_error_code() == [
-        {"kind": "test_kind", "http_status": 200, "error_code": None, "count": 1}
-    ]
-
-    upsert_response(
-        kind="test_kind2",
-        dataset="test_dataset",
-        config="test_config",
-        split="test_split",
-        content={
-            "key": "value",
-        },
-        http_status=HTTPStatus.INTERNAL_SERVER_ERROR,
-        error_code="error_code",
-    )
-
-    metrics = get_responses_count_by_kind_status_and_error_code()
-    assert len(metrics) == 2
-    assert {"kind": "test_kind", "http_status": 200, "error_code": None, "count": 1} in metrics
-    assert {"kind": "test_kind2", "http_status": 500, "error_code": "error_code", "count": 1} in metrics
 
 
 def test_get_cache_reports() -> None:

--- a/services/worker/src/worker/config.py
+++ b/services/worker/src/worker/config.py
@@ -10,6 +10,7 @@ from libcommon.config import (
     CacheConfig,
     CommonConfig,
     LogConfig,
+    MetricsConfig,
     ParquetMetadataConfig,
     ProcessingGraphConfig,
     QueueConfig,
@@ -323,6 +324,7 @@ class AppConfig:
     datasets_based: DatasetsBasedConfig = field(default_factory=DatasetsBasedConfig)
     first_rows: FirstRowsConfig = field(default_factory=FirstRowsConfig)
     log: LogConfig = field(default_factory=LogConfig)
+    metrics: MetricsConfig = field(default_factory=MetricsConfig)
     numba: NumbaConfig = field(default_factory=NumbaConfig)
     parquet_and_info: ParquetAndInfoConfig = field(default_factory=ParquetAndInfoConfig)
     processing_graph: ProcessingGraphConfig = field(default_factory=ProcessingGraphConfig)
@@ -343,6 +345,7 @@ class AppConfig:
             datasets_based=DatasetsBasedConfig.from_env(),
             first_rows=FirstRowsConfig.from_env(),
             log=LogConfig.from_env(),
+            metrics=MetricsConfig.from_env(),
             numba=NumbaConfig.from_env(),
             parquet_and_info=ParquetAndInfoConfig.from_env(),
             processing_graph=ProcessingGraphConfig.from_env(),

--- a/services/worker/src/worker/main.py
+++ b/services/worker/src/worker/main.py
@@ -5,7 +5,11 @@ import tempfile
 
 from libcommon.log import init_logging
 from libcommon.processing_graph import ProcessingGraph
-from libcommon.resources import CacheMongoResource, QueueMongoResource
+from libcommon.resources import (
+    CacheMongoResource,
+    MetricsMongoResource,
+    QueueMongoResource,
+)
 from libcommon.storage import (
     init_assets_dir,
     init_duckdb_index_cache_dir,
@@ -49,11 +53,16 @@ if __name__ == "__main__":
             QueueMongoResource(
                 database=app_config.queue.mongo_database, host=app_config.queue.mongo_url
             ) as queue_resource,
+            MetricsMongoResource(
+                database=app_config.metrics.mongo_database, host=app_config.metrics.mongo_url
+            ) as metrics_resource,
         ):
             if not cache_resource.is_available():
                 raise RuntimeError("The connection to the cache database could not be established. Exiting.")
             if not queue_resource.is_available():
                 raise RuntimeError("The connection to the queue database could not be established. Exiting.")
+            if not metrics_resource.is_available():
+                raise RuntimeError("The connection to the metrics database could not be established. Exiting.")
 
             job_runner_factory = JobRunnerFactory(
                 app_config=app_config,

--- a/services/worker/src/worker/start_worker_loop.py
+++ b/services/worker/src/worker/start_worker_loop.py
@@ -5,7 +5,11 @@ import sys
 
 from libcommon.log import init_logging
 from libcommon.processing_graph import ProcessingGraph
-from libcommon.resources import CacheMongoResource, QueueMongoResource
+from libcommon.resources import (
+    CacheMongoResource,
+    MetricsMongoResource,
+    QueueMongoResource,
+)
 from libcommon.storage import (
     init_assets_dir,
     init_duckdb_index_cache_dir,
@@ -48,11 +52,16 @@ if __name__ == "__main__":
         QueueMongoResource(
             database=app_config.queue.mongo_database, host=app_config.queue.mongo_url
         ) as queue_resource,
+        MetricsMongoResource(
+            database=app_config.metrics.mongo_database, host=app_config.metrics.mongo_url
+        ) as metrics_resource,
     ):
         if not cache_resource.is_available():
             raise RuntimeError("The connection to the cache database could not be established. Exiting.")
         if not queue_resource.is_available():
             raise RuntimeError("The connection to the queue database could not be established. Exiting.")
+        if not metrics_resource.is_available():
+            raise RuntimeError("The connection to the metrics database could not be established. Exiting.")
 
         job_runner_factory = JobRunnerFactory(
             app_config=app_config,


### PR DESCRIPTION
Currently, we calculate cache metrics in a job that runs every X minutes but this one queries the full cache collection every time leading to mongo query targeting issues in Mongo Atlas (ratio > 1000).
In order to avoid this alert, this PR moves the metrics increase to orchestrator so that, every time a cache in recorded, it will update the metrics collection as well..

Caveats: 

- There is no way to "decrease" the counters if a cache record is deleted. It could be implemented when doing the delete but It could increase db load.