### PR TITLE
Revert datasets authentication with DownloadConfig

### DIFF
--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -1252,7 +1252,7 @@ def compute_config_parquet_and_info_response(
     hf_api = HfApi(endpoint=hf_endpoint, token=hf_token)
     committer_hf_api = HfApi(endpoint=hf_endpoint, token=committer_hf_token)
 
-    download_config = DownloadConfig(delete_extracted=True, token=hf_token)
+    download_config = DownloadConfig(delete_extracted=True)
     try:
         builder = load_dataset_builder(
             path=dataset,

--- a/services/worker/src/worker/job_runners/config/split_names_from_streaming.py
+++ b/services/worker/src/worker/job_runners/config/split_names_from_streaming.py
@@ -4,7 +4,7 @@
 import logging
 from typing import List, Optional
 
-from datasets import DownloadConfig, get_dataset_split_names
+from datasets import get_dataset_split_names
 from datasets.builder import ManualDownloadError
 from datasets.data_files import EmptyDatasetError as _EmptyDatasetError
 from libcommon.constants import (
@@ -61,9 +61,7 @@ def compute_split_names_from_streaming_response(
     try:
         split_name_items: List[SplitItem] = [
             {"dataset": dataset, "config": config, "split": str(split)}
-            for split in get_dataset_split_names(
-                path=dataset, config_name=config, download_config=DownloadConfig(token=hf_token)
-            )
+            for split in get_dataset_split_names(path=dataset, config_name=config, token=hf_token)
         ]
     except ManualDownloadError as err:
         raise DatasetManualDownloadError(f"{dataset=} requires manual download.", cause=err) from err

--- a/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
@@ -7,7 +7,6 @@ from typing import List, Optional
 
 from datasets import (
     Audio,
-    DownloadConfig,
     Features,
     Image,
     IterableDataset,
@@ -148,7 +147,7 @@ def compute_first_rows_response(
         info = get_dataset_config_info(
             path=dataset,
             config_name=config,
-            download_config=DownloadConfig(token=hf_token),
+            token=hf_token,
         )
     except Exception as err:
         raise InfoError(
@@ -163,7 +162,6 @@ def compute_first_rows_response(
                 name=config,
                 split=split,
                 streaming=True,
-                download_config=DownloadConfig(token=hf_token),
                 token=hf_token,
             )
             if not isinstance(iterable_dataset, IterableDataset):

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -221,7 +221,7 @@ def get_rows(
     token: Union[bool, str, None] = False,
     column_names: Optional[List[str]] = None,
 ) -> RowsContent:
-    download_config = DownloadConfig(delete_extracted=True, token=token)
+    download_config = DownloadConfig(delete_extracted=True)
     PIL.Image.MAX_IMAGE_PIXELS = MAX_IMAGE_PIXELS
     ds = load_dataset(
         dataset,


### PR DESCRIPTION
Once we update `datasets` to version 2.14.4, we no longer need the authentication tweaks (where we had to use `download_config` instead of `token`) introduced by:
- #1620

Fix #1659.