### PR TITLE
Set cache metrics cron schedule to default value

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -202,19 +202,6 @@ queueMetricsCollector:
       memory: "512Mi"
   tolerations: []
 
-cacheMetricsCollector:
-  action: "collect-cache-metrics"
-  schedule: "*/10 * * * *"
-  # every ten minutes first time, then it will be changed to default
-  nodeSelector: {}
-  resources:
-    requests:
-      cpu: 1
-    limits:
-      cpu: 1
-      memory: "512Mi"
-  tolerations: []
-
 # --- storage admin (to manually inspect the storage, in /data) ---
 
 storageAdmin:

--- a/chart/env/staging.yaml
+++ b/chart/env/staging.yaml
@@ -161,19 +161,6 @@ queueMetricsCollector:
       memory: "512Mi"
   tolerations: []
 
-cacheMetricsCollector:
-  action: "collect-cache-metrics"
-  schedule: "*/10 * * * *"
-  # every ten minutes first time, then it will be changed to default
-  nodeSelector: {}
-  resources:
-    requests:
-      cpu: 1
-    limits:
-      cpu: 1
-      memory: "512Mi"
-  tolerations: []
-
 # --- storage admin (to manually inspect the storage, in /data) ---
 
 storageAdmin:


### PR DESCRIPTION
It will be   `schedule: "13 00 * * *"` as default in values.yaml