### PR TITLE
fix: 🐛 fix the optional types in OpenAPI

### DIFF
--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -1043,7 +1043,7 @@
         }
       },
       "SizeResponse": {
-        "$oneOf": [
+        "oneOf": [
           {
             "$ref": "#/components/schemas/DatasetSizeResponse"
           },

--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -1043,7 +1043,7 @@
         }
       },
       "SizeResponse": {
-        "$anyOf": [
+        "$oneOf": [
           {
             "$ref": "#/components/schemas/DatasetSizeResponse"
           },

--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -806,9 +806,7 @@
           "config": {
             "type": "string"
           },
-          "split": {
-            "type": ["string", "null"]
-          }
+          "split": { "anyOf": [{ "type": "string" }, { "type": "null" }] }
         }
       },
       "PreviousJobs": {
@@ -1055,9 +1053,7 @@
           "has_urls_columns": {
             "type": "boolean"
           },
-          "full_scan": {
-            "type": ["boolean", "null"]
-          }
+          "full_scan": { "anyOf": [{ "type": "boolean" }, { "type": "null" }] }
         }
       },
       "ColumnType": {

--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -982,19 +982,16 @@
           }
         }
       },
-      "SizeResponse": {
+      "DatasetSizeResponse": {
         "type": "object",
-        "required": ["size", "partial"],
+        "required": ["size", "pending", "failed", "partial"],
         "properties": {
           "size": {
             "type": "object",
-            "required": ["splits"],
+            "required": ["dataset", "configs", "splits"],
             "properties": {
               "dataset": {
                 "$ref": "#/components/schemas/DatasetSize"
-              },
-              "config": {
-                "$ref": "#/components/schemas/ConfigSize"
               },
               "configs": {
                 "type": "array",
@@ -1020,6 +1017,40 @@
             "$ref": "#/components/schemas/Partial"
           }
         }
+      },
+      "ConfigSizeResponse": {
+        "type": "object",
+        "required": ["size", "partial"],
+        "properties": {
+          "size": {
+            "type": "object",
+            "required": ["config", "splits"],
+            "properties": {
+              "config": {
+                "$ref": "#/components/schemas/ConfigSize"
+              },
+              "splits": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SplitSize"
+                }
+              }
+            }
+          },
+          "partial": {
+            "$ref": "#/components/schemas/Partial"
+          }
+        }
+      },
+      "SizeResponse": {
+        "$anyOf": [
+          {
+            "$ref": "#/components/schemas/DatasetSizeResponse"
+          },
+          {
+            "$ref": "#/components/schemas/ConfigSizeResponse"
+          }
+        ]
       },
       "OptInOutUrlsCountResponse": {
         "type": "object",


### PR DESCRIPTION
I made these changes by looking at how the Typescript types are created with https://github.com/oazapfts/oazapfts (that we use on the Hub).