### PR TITLE
Rollback queue incremental metrics

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -191,8 +191,8 @@ backfill:
 
 queueMetricsCollector:
   action: "collect-queue-metrics"
-  schedule: "*/10 * * * *"
-  # every ten minutes, then it will be changed to default
+  schedule: "*/2 * * * *"
+  # every two minutes
   nodeSelector: {}
   resources:
     requests:

--- a/e2e/tests/test_31_admin_metrics.py
+++ b/e2e/tests/test_31_admin_metrics.py
@@ -31,11 +31,10 @@ def test_metrics() -> None:
 
     metric_names = set(metrics.keys())
 
-    # the queue metrics are computed each time a job is created and processed
-    # they should exists at least for some of jobs types
+    # the queue metrics are computed by the background jobs. Here, in the e2e tests, we don't run them,
     for queue in ["dataset-config-names", "split-first-rows-from-streaming", "dataset-parquet"]:
         # eg. 'queue_jobs_total{pid="10",queue="split-first-rows-from-streaming",status="started"}'
-        assert has_metric(
+        assert not has_metric(
             name="queue_jobs_total",
             labels={"pid": "[0-9]*", "queue": queue, "status": "started"},
             metric_names=metric_names,

--- a/jobs/cache_maintenance/src/cache_maintenance/queue_metrics.py
+++ b/jobs/cache_maintenance/src/cache_maintenance/queue_metrics.py
@@ -12,14 +12,7 @@ def collect_queue_metrics(processing_graph: ProcessingGraph) -> None:
     queue = Queue()
     for processing_step in processing_graph.get_processing_steps():
         for status, new_total in queue.get_jobs_count_by_status(job_type=processing_step.job_type).items():
-            job_type = processing_step.job_type
-            query_set = JobTotalMetricDocument.objects(job_type=job_type, status=status)
-            current_metric = query_set.first()
-            if current_metric is not None:
-                current_total = current_metric.total
-                logging.info(
-                    f"{job_type=} {status=} current_total={current_total} new_total="
-                    f"{new_total} difference={int(new_total)-current_total}"  # type: ignore
-                )
-            query_set.upsert_one(total=new_total)
+            JobTotalMetricDocument.objects(job_type=processing_step.job_type, status=status).upsert_one(
+                total=new_total
+            )
     logging.info("queue metrics have been collected")

--- a/jobs/cache_maintenance/tests/test_collect_queue_metrics.py
+++ b/jobs/cache_maintenance/tests/test_collect_queue_metrics.py
@@ -23,10 +23,11 @@ def test_collect_queue_metrics() -> None:
         split="split",
         difficulty=50,
     )
+    assert JobTotalMetricDocument.objects().count() == 0
 
     collect_queue_metrics(processing_graph=processing_graph)
 
-    job_metrics = JobTotalMetricDocument.objects()
+    job_metrics = JobTotalMetricDocument.objects().all()
     assert job_metrics
     assert len(job_metrics) == len(Status)  # One by each job state, see libcommon.queue.get_jobs_count_by_status
     waiting_job = next((job for job in job_metrics if job.status == "waiting"), None)

--- a/libs/libcommon/tests/test_orchestrator.py
+++ b/libs/libcommon/tests/test_orchestrator.py
@@ -8,7 +8,7 @@ import pytest
 
 from libcommon.orchestrator import AfterJobPlan, DatasetOrchestrator
 from libcommon.processing_graph import Artifact, ProcessingGraph
-from libcommon.queue import JobDocument, JobTotalMetricDocument, Queue
+from libcommon.queue import JobDocument, Queue
 from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.simple_cache import CachedResponseDocument, upsert_response_params
 from libcommon.utils import JobOutput, JobResult, Priority, Status
@@ -36,9 +36,7 @@ from .utils import (
     STEP_DA,
     STEP_DC,
     STEP_DD,
-    STEP_DG,
     artifact_id_to_job_info,
-    assert_metric,
 )
 
 CACHE_MAX_DAYS = 90
@@ -111,7 +109,6 @@ def test_after_job_plan_delete() -> None:
     # create two jobs for DG, and none for DH
     # one job should be deleted for DG, and one should be created for DH
     Queue().create_jobs([artifact_id_to_job_info(ARTIFACT_DG)] * 2)
-    assert_metric(job_type=STEP_DG, status=Status.WAITING, total=2)
 
     after_job_plan = AfterJobPlan(
         processing_graph=PROCESSING_GRAPH_PARALLEL,
@@ -243,7 +240,6 @@ def test_set_revision_handle_existing_jobs(
 ) -> None:
     # create two pending jobs for DA
     Queue().create_jobs([artifact_id_to_job_info(ARTIFACT_DA)] * 2)
-    assert_metric(job_type=STEP_DA, status=Status.WAITING, total=2)
     dataset_orchestrator = DatasetOrchestrator(dataset=DATASET_NAME, processing_graph=processing_graph)
     dataset_orchestrator.set_revision(
         revision=REVISION_NAME, priority=Priority.NORMAL, error_codes_to_retry=[], cache_max_days=CACHE_MAX_DAYS
@@ -282,6 +278,5 @@ def test_has_pending_ancestor_jobs(
     expected_has_pending_ancestor_jobs: bool,
 ) -> None:
     Queue().create_jobs([artifact_id_to_job_info(artifact) for artifact in pending_artifacts])
-    assert len(pending_artifacts) == JobTotalMetricDocument.objects().count()
     dataset_orchestrator = DatasetOrchestrator(dataset=DATASET_NAME, processing_graph=processing_graph)
     assert dataset_orchestrator.has_pending_ancestor_jobs(processing_step_names) == expected_has_pending_ancestor_jobs

--- a/libs/libcommon/tests/utils.py
+++ b/libs/libcommon/tests/utils.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 
 from libcommon.orchestrator import DatasetBackfillPlan
 from libcommon.processing_graph import Artifact, ProcessingGraph
-from libcommon.queue import JobTotalMetricDocument, Queue
+from libcommon.queue import Queue
 from libcommon.simple_cache import upsert_response
 from libcommon.utils import JobInfo, Priority
 
@@ -364,9 +364,3 @@ def artifact_id_to_job_info(artifact_id: str) -> JobInfo:
         priority=Priority.NORMAL,
         difficulty=DIFFICULTY,
     )
-
-
-def assert_metric(job_type: str, status: str, total: int) -> None:
-    metric = JobTotalMetricDocument.objects(job_type=job_type, status=status).first()
-    assert metric is not None
-    assert metric.total == total


### PR DESCRIPTION
Currently, queue metrics are getting wrong values and sometimes negative.
It could be related to an issue with jobs being processed more than one time by different workers https://github.com/huggingface/datasets-server/issues/1467.
Rollbacking incremental queue metrics until job processing issues have been solved.
![Screenshot from 2023-08-17 12-14-22](https://github.com/huggingface/datasets-server/assets/5564745/dc0a0722-eeb3-46eb-927e-7155dc53bae3)

Note that I changed the cron schedule back to two minutes (as it was before https://github.com/huggingface/datasets-server/pull/1684)