### PR TITLE
Temporarily delete cache metric index

### DIFF
--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -144,7 +144,6 @@ class CacheTotalMetricDocument(Document):
     meta = {
         "collection": CACHE_METRICS_COLLECTION,
         "db_alias": CACHE_MONGOENGINE_ALIAS,
-        "indexes": [("kind", "http_status", "error_code")],
     }
     objects = QuerySetManager["CacheTotalMetricDocument"]()
 


### PR DESCRIPTION
It will be added again in the next deploy as:
```
{
"fields":["kind", "http_status", "error_code"],
"unique": True
}
```
(In another PR)