### PR TITLE
Download parquet in split-duckdb-index

### DIFF
--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -190,6 +190,13 @@ def hub_gated_csv(csv_path: str) -> Iterator[str]:
 
 
 @pytest.fixture(scope="session")
+def hub_gated_duckdb_index(datasets: Mapping[str, Dataset]) -> Iterator[str]:
+    repo_id = create_hub_dataset_repo(prefix="duckdb_index_gated", dataset=datasets["duckdb_index"], gated="auto")
+    yield repo_id
+    delete_hub_dataset_repo(repo_id=repo_id)
+
+
+@pytest.fixture(scope="session")
 def hub_public_jsonl(jsonl_path: str) -> Iterator[str]:
     repo_id = create_hub_dataset_repo(prefix="jsonl", file_paths=[jsonl_path])
     yield repo_id
@@ -840,6 +847,17 @@ def hub_responses_duckdb_index(hub_public_duckdb_index: str) -> HubDatasetTest:
         "parquet_and_info_response": create_parquet_and_info_response(
             dataset=hub_public_duckdb_index, data_type="csv"
         ),
+    }
+
+
+@pytest.fixture
+def hub_responses_gated_duckdb_index(hub_gated_duckdb_index: str) -> HubDatasetTest:
+    return {
+        "name": hub_gated_duckdb_index,
+        "config_names_response": create_config_names_response(hub_gated_duckdb_index),
+        "splits_response": create_splits_response(hub_gated_duckdb_index),
+        "first_rows_response": create_first_rows_response(hub_gated_duckdb_index, TEXT_cols, TEXT_rows),
+        "parquet_and_info_response": create_parquet_and_info_response(dataset=hub_gated_duckdb_index, data_type="csv"),
     }
 
 

--- a/services/worker/tests/job_runners/split/test_duckdb_index.py
+++ b/services/worker/tests/job_runners/split/test_duckdb_index.py
@@ -127,6 +127,7 @@ def get_parquet_job_runner(
     "hub_dataset_name,max_parquet_size_bytes,expected_error_code",
     [
         ("duckdb_index", None, None),
+        ("gated", None, None),
         ("duckdb_index", 1_000, "SplitWithTooBigParquetError"),  # parquet size is 2812
         ("public", None, "NoIndexableColumnsError"),  # dataset does not have string columns to index
     ],
@@ -137,11 +138,16 @@ def test_compute(
     app_config: AppConfig,
     hub_responses_public: HubDatasetTest,
     hub_responses_duckdb_index: HubDatasetTest,
+    hub_responses_gated_duckdb_index: HubDatasetTest,
     hub_dataset_name: str,
     max_parquet_size_bytes: Optional[int],
     expected_error_code: str,
 ) -> None:
-    hub_datasets = {"public": hub_responses_public, "duckdb_index": hub_responses_duckdb_index}
+    hub_datasets = {
+        "public": hub_responses_public,
+        "duckdb_index": hub_responses_duckdb_index,
+        "gated": hub_responses_gated_duckdb_index,
+    }
     dataset = hub_datasets[hub_dataset_name]["name"]
     config_names = hub_datasets[hub_dataset_name]["config_names_response"]
     config = hub_datasets[hub_dataset_name]["config_names_response"]["config_names"][0]["config"]
@@ -175,10 +181,7 @@ def test_compute(
     parquet_response = parquet_job_runner.compute()
     config_parquet = parquet_response.content
 
-    # simulate more than one parquet file to index
-    extra_parquet_file = config_parquet["parquet_files"][0]
-    config_parquet["parquet_files"].append(extra_parquet_file)
-
+    # TODO: simulate more than one parquet file to index
     upsert_response(
         "config-parquet-and-info",
         dataset=dataset,
@@ -207,7 +210,7 @@ def test_compute(
         job_runner.post_compute()
 
         # download locally duckdb index file
-        duckdb_file = requests.get(url)
+        duckdb_file = requests.get(url, headers={"authorization": f"Bearer {app_config.common.hf_token}"})
         with open(file_name, "wb") as f:
             f.write(duckdb_file.content)
 
@@ -219,7 +222,7 @@ def test_compute(
         record_count = con.sql("SELECT COUNT(*) FROM data;").fetchall()
         assert record_count is not None
         assert isinstance(record_count, list)
-        assert record_count[0] == (10,)  # dataset has 5 rows but since parquet file was duplicate it is 10
+        assert record_count[0] == (5,)
 
         # perform a search to validate fts feature
         query = "Lord Vader"


### PR DESCRIPTION
Fixes https://github.com/huggingface/datasets-server/issues/1686
Using hf_download instead of loading parquet files to duckdb directly.
