### PR TITLE
Block KakologArchives/KakologArchives

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -129,7 +129,7 @@ parquetAndInfo:
   maxDatasetSize: "5_000_000_000"
   maxRowGroupByteSizeForCopy: "500_000_000"
   # See https://observablehq.com/@huggingface/blocked-datasets
-  blockedDatasets: "Graphcore/gqa,Graphcore/gqa-lxmert,Graphcore/vqa,Graphcore/vqa-lxmert,echarlaix/gqa-lxmert,echarlaix/vqa,echarlaix/vqa-lxmert"
+  blockedDatasets: "Graphcore/gqa,Graphcore/gqa-lxmert,Graphcore/vqa,Graphcore/vqa-lxmert,echarlaix/gqa-lxmert,echarlaix/vqa,echarlaix/vqa-lxmert,KakologArchives/KakologArchives"
   supportedDatasets: ""
   noMaxSizeLimitDatasets: "Open-Orca/OpenOrca"
 


### PR DESCRIPTION
Has tons of data files and is updated every day.

12k commits already in
https://huggingface.co/datasets/KakologArchives/KakologArchives/tree/refs%2Fconvert%2Fparquet

Let's block it until we have a better way of handling big datasets with frequent updates