### PR TITLE
Add TTL for unicity_id locks

### DIFF
--- a/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230825170200_lock_add_ttl.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230825170200_lock_add_ttl.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 The HuggingFace Authors.
+
+import logging
+
+from libcommon.constants import QUEUE_COLLECTION_LOCKS, QUEUE_MONGOENGINE_ALIAS
+from libcommon.queue import Lock
+from mongoengine.connection import get_db
+
+from mongodb_migration.check import check_documents
+from mongodb_migration.migration import Migration
+
+
+# connection already occurred in the main.py (caveat: we use globals)
+class MigrationAddTtlToQueueLock(Migration):
+    def up(self) -> None:
+        # See https://docs.mongoengine.org/guide/migration.html#example-1-addition-of-a-field
+        logging.info("If missing, add the ttl field to the locks")
+        db = get_db(QUEUE_MONGOENGINE_ALIAS)
+        db[QUEUE_COLLECTION_LOCKS].update_many(
+            {"ttl": {"$exists": False}}, [{"$set": {"ttl": None}}]  # type: ignore
+        )
+
+    def down(self) -> None:
+        logging.info("Remove the ttl field from all the locks")
+        db = get_db(QUEUE_MONGOENGINE_ALIAS)
+        db[QUEUE_COLLECTION_LOCKS].update_many({}, {"$unset": {"ttl": ""}})
+
+    def validate(self) -> None:
+        logging.info("Ensure that a random selection of locks have the 'ttl' field")
+
+        check_documents(DocCls=Lock, sample_size=10)

--- a/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230825170200_lock_add_ttl.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230825170200_lock_add_ttl.py
@@ -17,9 +17,7 @@ class MigrationAddTtlToQueueLock(Migration):
         # See https://docs.mongoengine.org/guide/migration.html#example-1-addition-of-a-field
         logging.info("If missing, add the ttl field to the locks")
         db = get_db(QUEUE_MONGOENGINE_ALIAS)
-        db[QUEUE_COLLECTION_LOCKS].update_many(
-            {"ttl": {"$exists": False}}, [{"$set": {"ttl": None}}]  # type: ignore
-        )
+        db[QUEUE_COLLECTION_LOCKS].update_many({"ttl": {"$exists": False}}, [{"$set": {"ttl": None}}])  # type: ignore
 
     def down(self) -> None:
         logging.info("Remove the ttl field from all the locks")

--- a/jobs/mongodb_migration/tests/migrations/test_20230825170200_lock_add_ttl.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230825170200_lock_add_ttl.py
@@ -12,7 +12,7 @@ from mongodb_migration.migrations._20230825170200_lock_add_ttl import (
 )
 
 
-def assert_ttl(key: str, ttl: Optional[str]) -> None:
+def assert_ttl(key: str, ttl: Optional[int]) -> None:
     db = get_db(QUEUE_MONGOENGINE_ALIAS)
     entry = db[QUEUE_COLLECTION_LOCKS].find_one({"key": key})
     assert entry is not None

--- a/jobs/mongodb_migration/tests/migrations/test_20230825170200_lock_add_ttl.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230825170200_lock_add_ttl.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+from typing import Optional
+
+from libcommon.constants import QUEUE_COLLECTION_LOCKS, QUEUE_MONGOENGINE_ALIAS
+from libcommon.resources import MongoResource
+from mongoengine.connection import get_db
+
+from mongodb_migration.migrations._20230825170200_lock_add_ttl import (
+    MigrationAddTtlToQueueLock,
+)
+
+
+def assert_ttl(key: str, ttl: Optional[str]) -> None:
+    db = get_db(QUEUE_MONGOENGINE_ALIAS)
+    entry = db[QUEUE_COLLECTION_LOCKS].find_one({"key": key})
+    assert entry is not None
+    if ttl is None:
+        assert "ttl" not in entry or entry["ttl"] is None
+    else:
+        assert entry["ttl"] == ttl
+
+
+def test_lock_add_ttl(mongo_host: str) -> None:
+    with MongoResource(database="test_lock_add_ttl", host=mongo_host, mongoengine_alias="queue"):
+        db = get_db(QUEUE_MONGOENGINE_ALIAS)
+        db[QUEUE_COLLECTION_LOCKS].insert_many(
+            [
+                {
+                    "key": "key1",
+                    "owner": "job_id1",
+                    "created_at": "2022-01-01T00:00:00.000000Z",
+                },
+                {
+                    "key": "key2",
+                    "owner": None,
+                    "created_at": "2022-01-01T00:00:00.000000Z",
+                },
+                {
+                    "key": "key3",
+                    "owner": "job_id3",
+                    "ttl": 600,
+                    "created_at": "2022-01-01T00:00:00.000000Z",
+                },
+            ]
+        )
+
+        migration = MigrationAddTtlToQueueLock(
+            version="20230825170200",
+            description="add ttl field to locks",
+        )
+        migration.up()
+
+        assert_ttl("key1", None)
+        assert_ttl("key2", None)
+        assert_ttl("key3", 600)
+
+        migration.down()
+        assert_ttl("key1", None)
+        assert_ttl("key2", None)
+        assert_ttl("key3", None)
+
+        db[QUEUE_COLLECTION_LOCKS].drop()


### PR DESCRIPTION
Added the `ttl` parameter to `lock()`.

(ony supported value is 600 though, which is the value of the TTL index in mongo - but this extendable for later if needed)



Close https://github.com/huggingface/datasets-server/issues/1727