### PR TITLE
Block open-llm-leaderboard

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -129,7 +129,7 @@ parquetAndInfo:
   maxDatasetSize: "5_000_000_000"
   maxRowGroupByteSizeForCopy: "500_000_000"
   # See https://observablehq.com/@huggingface/blocked-datasets
-  blockedDatasets: "Graphcore/gqa,Graphcore/gqa-lxmert,Graphcore/vqa,Graphcore/vqa-lxmert,echarlaix/gqa-lxmert,echarlaix/vqa,echarlaix/vqa-lxmert,KakologArchives/KakologArchives"
+  blockedDatasets: "Graphcore/gqa,Graphcore/gqa-lxmert,Graphcore/vqa,Graphcore/vqa-lxmert,echarlaix/gqa-lxmert,echarlaix/vqa,echarlaix/vqa-lxmert,KakologArchives/KakologArchives,open-llm-leaderboard/*"
   supportedDatasets: ""
   noMaxSizeLimitDatasets: "Open-Orca/OpenOrca"
 

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 from contextlib import ExitStack
+from fnmatch import fnmatch
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from types import TracebackType
@@ -192,17 +193,20 @@ def raise_if_blocked(
             by a `/`.
         blocked_datasets (`List[str]`):
             The list of blocked datasets. If empty, no dataset is blocked.
+            Patterns are supported, e.g. "open-llm-leaderboard/*"
+
     Returns:
         `None`
     Raises the following errors:
         - [`libcommon.exceptions.DatasetInBlockListError`]
           If the dataset is in the list of blocked datasets.
     """
-    if dataset in blocked_datasets:
-        raise DatasetInBlockListError(
-            "The parquet conversion has been disabled for this dataset for now. Please open an issue in"
-            " https://github.com/huggingface/datasets-server if you want this dataset to be supported."
-        )
+    for blocked_dataset in blocked_datasets:
+        if fnmatch(dataset, blocked_dataset):
+            raise DatasetInBlockListError(
+                "The parquet conversion has been disabled for this dataset for now. Please open an issue in"
+                " https://github.com/huggingface/datasets-server if you want this dataset to be supported."
+            )
 
 
 def is_parquet_builder_with_hub_files(builder: DatasetBuilder) -> bool:


### PR DESCRIPTION
The 800+ datasets with 60+ configs each have been updated which has filled up the queue to the point that the other datasets are not processed as fast as they should.

Blocking them for now, until we have a better way to handle them