### PR TITLE
Support audio in rows and search

### DIFF
--- a/libs/libcommon/src/libcommon/rows_utils.py
+++ b/libs/libcommon/src/libcommon/rows_utils.py
@@ -1,13 +1,43 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The HuggingFace Authors.
 
-from typing import List, Optional
+from functools import partial
+from typing import List, Optional, Tuple
 
 from datasets import Features
+from tqdm.contrib.concurrent import thread_map
 
 from libcommon.storage import StrPath
 from libcommon.utils import Row
 from libcommon.viewer_utils.features import get_cell_value
+
+
+def _transform_row(
+    row_idx_and_row: Tuple[int, Row],
+    dataset: str,
+    config: str,
+    split: str,
+    features: Features,
+    cached_assets_base_url: str,
+    cached_assets_directory: StrPath,
+    offset: int,
+    row_idx_column: Optional[str],
+) -> Row:
+    row_idx, row = row_idx_and_row
+    return {
+        featureName: get_cell_value(
+            dataset=dataset,
+            config=config,
+            split=split,
+            row_idx=offset + row_idx if row_idx_column is None else row[row_idx_column],
+            cell=row[featureName] if featureName in row else None,
+            featureName=featureName,
+            fieldType=fieldType,
+            assets_base_url=cached_assets_base_url,
+            assets_directory=cached_assets_directory,
+        )
+        for (featureName, fieldType) in features.items()
+    }
 
 
 def transform_rows(
@@ -21,20 +51,20 @@ def transform_rows(
     offset: int,
     row_idx_column: Optional[str],
 ) -> List[Row]:
-    return [
-        {
-            featureName: get_cell_value(
-                dataset=dataset,
-                config=config,
-                split=split,
-                row_idx=offset + row_idx if row_idx_column is None else row[row_idx_column],
-                cell=row[featureName] if featureName in row else None,
-                featureName=featureName,
-                fieldType=fieldType,
-                assets_base_url=cached_assets_base_url,
-                assets_directory=cached_assets_directory,
-            )
-            for (featureName, fieldType) in features.items()
-        }
-        for row_idx, row in enumerate(rows)
-    ]
+    fn = partial(
+        _transform_row,
+        dataset=dataset,
+        config=config,
+        split=split,
+        features=features,
+        assets_base_url=cached_assets_base_url,
+        assets_directory=cached_assets_directory,
+        offset=offset,
+        row_idx_column=row_idx_column,
+    )
+    if "Audio(" in str(features):
+        # use multithreading to parallelize audio files processing
+        # (we use pydub which might spawn one ffmpeg process per conversion)
+        return thread_map(fn, enumerate(rows), description="transform_rows(audio)")
+    else:
+        return [fn((row_idx, row)) for row_idx, row in enumerate(rows)]

--- a/libs/libcommon/src/libcommon/rows_utils.py
+++ b/libs/libcommon/src/libcommon/rows_utils.py
@@ -65,6 +65,6 @@ def transform_rows(
     if "Audio(" in str(features):
         # use multithreading to parallelize audio files processing
         # (we use pydub which might spawn one ffmpeg process per conversion)
-        return thread_map(fn, enumerate(rows), description="transform_rows(audio)")  # type: ignore
+        return thread_map(fn, enumerate(rows), desc=f"transform_rows(audio) for {dataset}", total=len(rows))  # type: ignore
     else:
         return [fn((row_idx, row)) for row_idx, row in enumerate(rows)]

--- a/libs/libcommon/src/libcommon/rows_utils.py
+++ b/libs/libcommon/src/libcommon/rows_utils.py
@@ -18,8 +18,8 @@ def _transform_row(
     config: str,
     split: str,
     features: Features,
-    cached_assets_base_url: str,
-    cached_assets_directory: StrPath,
+    assets_base_url: str,
+    assets_directory: StrPath,
     offset: int,
     row_idx_column: Optional[str],
 ) -> Row:
@@ -33,8 +33,8 @@ def _transform_row(
             cell=row[featureName] if featureName in row else None,
             featureName=featureName,
             fieldType=fieldType,
-            assets_base_url=cached_assets_base_url,
-            assets_directory=cached_assets_directory,
+            assets_base_url=assets_base_url,
+            assets_directory=assets_directory,
         )
         for (featureName, fieldType) in features.items()
     }

--- a/libs/libcommon/src/libcommon/rows_utils.py
+++ b/libs/libcommon/src/libcommon/rows_utils.py
@@ -65,6 +65,6 @@ def transform_rows(
     if "Audio(" in str(features):
         # use multithreading to parallelize audio files processing
         # (we use pydub which might spawn one ffmpeg process per conversion)
-        return thread_map(fn, enumerate(rows), description="transform_rows(audio)")
+        return thread_map(fn, enumerate(rows), description="transform_rows(audio)")  # type: ignore
     else:
         return [fn((row_idx, row)) for row_idx, row in enumerate(rows)]

--- a/libs/libcommon/src/libcommon/rows_utils.py
+++ b/libs/libcommon/src/libcommon/rows_utils.py
@@ -64,7 +64,7 @@ def transform_rows(
     )
     if "Audio(" in str(features):
         # use multithreading to parallelize audio files processing
-        # (we use pydub which might spawn one ffmpeg process per conversion)
+        # (we use pydub which might spawn one ffmpeg process per conversion, which releases the GIL)
         desc = f"transform_rows(audio) for {dataset}"
         return thread_map(fn, enumerate(rows), desc=desc, total=len(rows))  # type: ignore
     else:

--- a/libs/libcommon/src/libcommon/rows_utils.py
+++ b/libs/libcommon/src/libcommon/rows_utils.py
@@ -65,6 +65,7 @@ def transform_rows(
     if "Audio(" in str(features):
         # use multithreading to parallelize audio files processing
         # (we use pydub which might spawn one ffmpeg process per conversion)
-        return thread_map(fn, enumerate(rows), desc=f"transform_rows(audio) for {dataset}", total=len(rows))  # type: ignore
+        desc = f"transform_rows(audio) for {dataset}"
+        return thread_map(fn, enumerate(rows), desc=desc, total=len(rows))  # type: ignore
     else:
         return [fn((row_idx, row)) for row_idx, row in enumerate(rows)]

--- a/libs/libcommon/src/libcommon/viewer_utils/asset.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/asset.py
@@ -103,21 +103,18 @@ class AudioSource(TypedDict):
     type: str
 
 
-def create_audio_files(
+def create_audio_file(
     dataset: str,
     config: str,
     split: str,
     row_idx: int,
     column: str,
-    array: ndarray,  # type: ignore
-    sampling_rate: int,
+    audio_file_path: str,
     assets_base_url: str,
-    filename_base: str,
+    filename: str,
     assets_directory: StrPath,
     overwrite: bool = True,
 ) -> List[AudioSource]:
-    wav_filename = f"{filename_base}.wav"
-    mp3_filename = f"{filename_base}.mp3"
     dir_path, url_dir_path = create_asset_dir(
         dataset=dataset,
         config=config,
@@ -127,14 +124,11 @@ def create_audio_files(
         assets_directory=assets_directory,
     )
     makedirs(dir_path, ASSET_DIR_MODE, exist_ok=True)
-    wav_file_path = dir_path / wav_filename
-    mp3_file_path = dir_path / mp3_filename
-    if overwrite or not wav_file_path.exists():
-        soundfile.write(wav_file_path, array, sampling_rate)
-    if overwrite or not mp3_file_path.exists():
-        segment = AudioSegment.from_wav(wav_file_path)
-        segment.export(mp3_file_path, format="mp3")
+    file_path = dir_path / filename
+    if overwrite or not file_path.exists():
+        # might spawn a process to convert the audio file using ffmpeg 
+        segment: AudioSegment = AudioSegment.from_file(audio_file_path)
+        segment.export(file_path, format="mp3")
     return [
-        {"src": f"{assets_base_url}/{url_dir_path}/{mp3_filename}", "type": "audio/mpeg"},
-        {"src": f"{assets_base_url}/{url_dir_path}/{wav_filename}", "type": "audio/wav"},
+        {"src": f"{assets_base_url}/{url_dir_path}/{filename}", "type": "audio/mpeg"},
     ]

--- a/libs/libcommon/src/libcommon/viewer_utils/asset.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/asset.py
@@ -7,9 +7,7 @@ from os import makedirs
 from pathlib import Path
 from typing import Generator, List, Tuple, TypedDict
 
-import soundfile  # type:ignore
-from numpy import ndarray
-from PIL import Image  # type: ignore
+from PIL import Image
 from pydub import AudioSegment  # type:ignore
 
 from libcommon.storage import StrPath

--- a/libs/libcommon/src/libcommon/viewer_utils/asset.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/asset.py
@@ -126,7 +126,7 @@ def create_audio_file(
     makedirs(dir_path, ASSET_DIR_MODE, exist_ok=True)
     file_path = dir_path / filename
     if overwrite or not file_path.exists():
-        # might spawn a process to convert the audio file using ffmpeg 
+        # might spawn a process to convert the audio file using ffmpeg
         segment: AudioSegment = AudioSegment.from_file(audio_file_path)
         segment.export(file_path, format="mp3")
     return [

--- a/libs/libcommon/src/libcommon/viewer_utils/asset.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/asset.py
@@ -7,7 +7,7 @@ from os import makedirs
 from pathlib import Path
 from typing import Generator, List, Tuple, TypedDict
 
-from PIL import Image
+from PIL import Image  # type: ignore
 from pydub import AudioSegment  # type:ignore
 
 from libcommon.storage import StrPath

--- a/libs/libcommon/src/libcommon/viewer_utils/features.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/features.py
@@ -23,8 +23,7 @@ from datasets import (
     Value,
 )
 from datasets.features.features import FeatureType, _visit
-from numpy import ndarray
-from PIL import Image as PILImage  # type: ignore
+from PIL import Image as PILImage
 
 from libcommon.storage import StrPath
 from libcommon.utils import FeatureItem
@@ -112,7 +111,7 @@ def audio(
             f"but got {str(value)[:300]}{'...' if len(str(value)) > 300 else ''}"
         )
     if "path" in value and isinstance(value["path"], str):
-        tmp_file_suffix = os.path.splitext(value["path"])
+        tmp_file_suffix = os.path.splitext(value["path"])[1]
     else:
         tmp_file_suffix = None
     with NamedTemporaryFile("wb", suffix=tmp_file_suffix) as tmp_audio_file:

--- a/libs/libcommon/src/libcommon/viewer_utils/features.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/features.py
@@ -65,6 +65,13 @@ def image(
         return None
     if isinstance(value, dict) and value.get("bytes"):
         value = PILImage.open(BytesIO(value["bytes"]))
+    elif (
+        isinstance(value, dict)
+        and "path" in value
+        and isinstance(value["path"], str)
+        and os.path.exists(value["path"])
+    ):
+        value = PILImage.open(value["path"])
     if not isinstance(value, PILImage.Image):
         raise TypeError(
             "Image cell must be a PIL image or an encoded dict of an image, "

--- a/libs/libcommon/src/libcommon/viewer_utils/features.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/features.py
@@ -23,7 +23,7 @@ from datasets import (
     Value,
 )
 from datasets.features.features import FeatureType, _visit
-from PIL import Image as PILImage
+from PIL import Image as PILImage  # type: ignore
 
 from libcommon.storage import StrPath
 from libcommon.utils import FeatureItem

--- a/libs/libcommon/tests/viewer_utils/test_features.py
+++ b/libs/libcommon/tests/viewer_utils/test_features.py
@@ -135,11 +135,7 @@ def test_value(
                 {
                     "src": "http://localhost/assets/dataset/--/config/split/7/col/audio.mp3",
                     "type": "audio/mpeg",
-                },
-                {
-                    "src": "http://localhost/assets/dataset/--/config/split/7/col/audio.wav",
-                    "type": "audio/wav",
-                },
+                }
             ],
             "Audio",
         ),
@@ -188,19 +184,11 @@ def test_value(
                         "src": "http://localhost/assets/dataset/--/config/split/7/col/audio-1d100e9.mp3",
                         "type": "audio/mpeg",
                     },
-                    {
-                        "src": "http://localhost/assets/dataset/--/config/split/7/col/audio-1d100e9.wav",
-                        "type": "audio/wav",
-                    },
                 ],
                 [
                     {
                         "src": "http://localhost/assets/dataset/--/config/split/7/col/audio-1d300ea.mp3",
                         "type": "audio/mpeg",
-                    },
-                    {
-                        "src": "http://localhost/assets/dataset/--/config/split/7/col/audio-1d300ea.wav",
-                        "type": "audio/wav",
                     },
                 ],
             ],
@@ -230,19 +218,11 @@ def test_value(
                         "src": "http://localhost/assets/dataset/--/config/split/7/col/audio-1d100e9.mp3",
                         "type": "audio/mpeg",
                     },
-                    {
-                        "src": "http://localhost/assets/dataset/--/config/split/7/col/audio-1d100e9.wav",
-                        "type": "audio/wav",
-                    },
                 ],
                 [
                     {
                         "src": "http://localhost/assets/dataset/--/config/split/7/col/audio-1d300ea.mp3",
                         "type": "audio/mpeg",
-                    },
-                    {
-                        "src": "http://localhost/assets/dataset/--/config/split/7/col/audio-1d300ea.wav",
-                        "type": "audio/wav",
                     },
                 ],
             ],
@@ -271,19 +251,11 @@ def test_value(
                                 "src": "http://localhost/assets/dataset/--/config/split/7/col/audio-18360330.mp3",
                                 "type": "audio/mpeg",
                             },
-                            {
-                                "src": "http://localhost/assets/dataset/--/config/split/7/col/audio-18360330.wav",
-                                "type": "audio/wav",
-                            },
                         ],
                         [
                             {
                                 "src": "http://localhost/assets/dataset/--/config/split/7/col/audio-18380331.mp3",
                                 "type": "audio/mpeg",
-                            },
-                            {
-                                "src": "http://localhost/assets/dataset/--/config/split/7/col/audio-18380331.wav",
-                                "type": "audio/wav",
                             },
                         ],
                     ]

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -6,7 +6,7 @@ import random
 from typing import List, Literal, Optional, Union
 
 import pyarrow as pa
-from datasets import Audio, Features, Value
+from datasets import Features, Value
 from fsspec.implementations.http import HTTPFileSystem
 from libapi.authentication import auth_check
 from libapi.exceptions import (

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -44,7 +44,7 @@ MAX_ROWS = 100
 ALL_COLUMNS_SUPPORTED_DATASETS_ALLOW_LIST: Union[Literal["all"], List[str]] = ["arabic_speech_corpus"]  # for testing
 
 # audio still has some errors when librosa is imported
-UNSUPPORTED_FEATURES = [Value("binary"), Audio()]
+UNSUPPORTED_FEATURES = [Value("binary")]
 
 
 def create_response(

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -6,7 +6,7 @@ import random
 from typing import List, Literal, Optional, Union
 
 import pyarrow as pa
-from datasets import Features, Value
+from datasets import Audio, Features, Value
 from fsspec.implementations.http import HTTPFileSystem
 from libapi.authentication import auth_check
 from libapi.exceptions import (
@@ -44,7 +44,7 @@ MAX_ROWS = 100
 ALL_COLUMNS_SUPPORTED_DATASETS_ALLOW_LIST: Union[Literal["all"], List[str]] = ["arabic_speech_corpus"]  # for testing
 
 # audio still has some errors when librosa is imported
-UNSUPPORTED_FEATURES = [Value("binary")]
+UNSUPPORTED_FEATURES = [Value("binary"), Audio()]
 
 
 def create_response(

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Tuple
 
 import duckdb
 import pyarrow as pa
-from datasets import Audio, Features, Value
+from datasets import Features, Value
 from huggingface_hub import hf_hub_download
 from libapi.authentication import auth_check
 from libapi.exceptions import (

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 
 ROW_IDX_COLUMN = "__hf_index_id"
 MAX_ROWS = 100
-UNSUPPORTED_FEATURES = [Value("binary"), Audio()]
+UNSUPPORTED_FEATURES = [Value("binary")]
 
 FTS_COMMAND_COUNT = (
     "SELECT COUNT(*) FROM (SELECT __hf_index_id, fts_main_data.match_bm25(__hf_index_id, ?) AS __hf_fts_score FROM"

--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -567,10 +567,6 @@ def get_AUDIO_rows(dataset: str) -> Any:
                     "src": f"http://localhost/assets/{dataset}/--/{config}/{split}/0/col/audio.mp3",
                     "type": "audio/mpeg",
                 },
-                {
-                    "src": f"http://localhost/assets/{dataset}/--/{config}/{split}/0/col/audio.wav",
-                    "type": "audio/wav",
-                },
             ]
         }
     ]


### PR DESCRIPTION
Using this code I can run `to_rows_list` in less than 2sec on 100 wav files of 1.5MB (from 20sec before).
I chose to stop converting to WAV and only send the MP3 file to the user, and to parallelize the audio conversions.

This should enable the viewer on audio datasets for both /rows and /search :)
Though to try this feature on /rows I first enabled it on `arabic_speech_corpus` and will enable it on all datasets if it works fine

Note: this can probably be improved later, e.g. by avoiding unnecessary conversions