### PR TITLE
Fix rows error response

### DIFF
--- a/libs/libapi/src/libapi/utils.py
+++ b/libs/libapi/src/libapi/utils.py
@@ -15,6 +15,11 @@ from libcommon.exceptions import CustomError
 from libcommon.orchestrator import DatasetOrchestrator
 from libcommon.processing_graph import ProcessingGraph, ProcessingStep
 from libcommon.rows_utils import transform_rows
+from libcommon.simple_cache import (
+    CACHED_RESPONSE_NOT_FOUND,
+    CacheEntry,
+    get_best_response,
+)
 from libcommon.storage import StrPath
 from libcommon.utils import Priority, RowItem, orjson_dumps
 from libcommon.viewer_utils.asset import glob_rows_in_assets_dir
@@ -135,6 +140,43 @@ def try_backfill_dataset_then_raise(
     else:
         # no pending job: the cache entry will not be created
         raise ResponseNotFoundError("Not found.")
+
+
+def get_cache_entry_from_steps(
+    processing_steps: List[ProcessingStep],
+    dataset: str,
+    config: Optional[str],
+    split: Optional[str],
+    processing_graph: ProcessingGraph,
+    cache_max_days: int,
+    hf_endpoint: str,
+    hf_token: Optional[str] = None,
+    hf_timeout_seconds: Optional[float] = None,
+) -> CacheEntry:
+    """Gets the cache from the first successful step in the processing steps list.
+    If no successful result is found, it will return the last one even if it's an error,
+    Checks if job is still in progress by each processing step in case of no entry found.
+    Raises:
+        - [`~utils.ResponseNotFoundError`]
+          if no result is found.
+        - [`~utils.ResponseNotReadyError`]
+          if the response is not ready yet.
+
+    Returns: the cached record
+    """
+    kinds = [processing_step.cache_kind for processing_step in processing_steps]
+    best_response = get_best_response(kinds=kinds, dataset=dataset, config=config, split=split)
+    if "error_code" in best_response.response and best_response.response["error_code"] == CACHED_RESPONSE_NOT_FOUND:
+        try_backfill_dataset_then_raise(
+            processing_steps=processing_steps,
+            processing_graph=processing_graph,
+            dataset=dataset,
+            hf_endpoint=hf_endpoint,
+            hf_timeout_seconds=hf_timeout_seconds,
+            hf_token=hf_token,
+            cache_max_days=cache_max_days,
+        )
+    return best_response.response
 
 
 Endpoint = Callable[[Request], Coroutine[Any, Any, Response]]

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -357,6 +357,10 @@ class CacheEntryWithDetails(CacheEntry):
     details: Mapping[str, str]
 
 
+class CachedArtifactNotFoundError(Exception):
+    pass
+
+
 class CachedArtifactError(Exception):
     kind: str
     dataset: str
@@ -524,6 +528,8 @@ def get_previous_step_or_raise(
 ) -> BestResponse:
     """Get the previous step from the cache, or raise an exception if it failed."""
     best_response = get_best_response(kinds=kinds, dataset=dataset, config=config, split=split)
+    if "error_code" in best_response.response and best_response.response["error_code"] == CACHED_RESPONSE_NOT_FOUND:
+        raise CachedArtifactNotFoundError()
     if best_response.response["http_status"] != HTTPStatus.OK:
         raise CachedArtifactError(
             message="The previous step failed.",

--- a/services/api/src/api/routes/endpoint.py
+++ b/services/api/src/api/routes/endpoint.py
@@ -15,18 +15,13 @@ from libapi.exceptions import (
 from libapi.utils import (
     Endpoint,
     are_valid_parameters,
+    get_cache_entry_from_steps,
     get_json_api_error_response,
     get_json_error_response,
     get_json_ok_response,
-    try_backfill_dataset_then_raise,
 )
 from libcommon.processing_graph import InputType, ProcessingGraph, ProcessingStep
 from libcommon.prometheus import StepProfiler
-from libcommon.simple_cache import (
-    CACHED_RESPONSE_NOT_FOUND,
-    CacheEntry,
-    get_best_response,
-)
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -55,43 +50,6 @@ class EndpointsDefinition:
             }
             for endpoint, processing_step_names_by_input_type in processing_step_names_by_input_type_and_endpoint
         }
-
-
-def get_cache_entry_from_steps(
-    processing_steps: List[ProcessingStep],
-    dataset: str,
-    config: Optional[str],
-    split: Optional[str],
-    processing_graph: ProcessingGraph,
-    cache_max_days: int,
-    hf_endpoint: str,
-    hf_token: Optional[str] = None,
-    hf_timeout_seconds: Optional[float] = None,
-) -> CacheEntry:
-    """Gets the cache from the first successful step in the processing steps list.
-    If no successful result is found, it will return the last one even if it's an error,
-    Checks if job is still in progress by each processing step in case of no entry found.
-    Raises:
-        - [`~utils.ResponseNotFoundError`]
-          if no result is found.
-        - [`~utils.ResponseNotReadyError`]
-          if the response is not ready yet.
-
-    Returns: the cached record
-    """
-    kinds = [processing_step.cache_kind for processing_step in processing_steps]
-    best_response = get_best_response(kinds=kinds, dataset=dataset, config=config, split=split)
-    if "error_code" in best_response.response and best_response.response["error_code"] == CACHED_RESPONSE_NOT_FOUND:
-        try_backfill_dataset_then_raise(
-            processing_steps=processing_steps,
-            processing_graph=processing_graph,
-            dataset=dataset,
-            hf_endpoint=hf_endpoint,
-            hf_timeout_seconds=hf_timeout_seconds,
-            hf_token=hf_token,
-            cache_max_days=cache_max_days,
-        )
-    return best_response.response
 
 
 # TODO: remove once full scan is implemented for spawning urls scan

--- a/services/api/tests/routes/test_endpoint.py
+++ b/services/api/tests/routes/test_endpoint.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 from unittest.mock import patch
 
 from libapi.exceptions import ResponseNotReadyError
+from libapi.utils import get_cache_entry_from_steps
 from libcommon.config import ProcessingGraphConfig
 from libcommon.processing_graph import ProcessingGraph
 from libcommon.queue import Queue
@@ -12,7 +13,7 @@ from libcommon.simple_cache import upsert_response
 from pytest import raises
 
 from api.config import AppConfig, EndpointConfig
-from api.routes.endpoint import EndpointsDefinition, get_cache_entry_from_steps
+from api.routes.endpoint import EndpointsDefinition
 
 CACHE_MAX_DAYS = 90
 

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -26,19 +26,14 @@ from libapi.utils import (
     Endpoint,
     are_valid_parameters,
     clean_cached_assets,
+    get_cache_entry_from_steps,
     get_json_api_error_response,
     get_json_error_response,
     get_json_ok_response,
     to_rows_list,
-    try_backfill_dataset_then_raise,
 )
-from libcommon.processing_graph import ProcessingGraph, ProcessingStep
+from libcommon.processing_graph import ProcessingGraph
 from libcommon.prometheus import StepProfiler
-from libcommon.simple_cache import (
-    CACHED_RESPONSE_NOT_FOUND,
-    CacheEntry,
-    get_best_response,
-)
 from libcommon.storage import StrPath, init_dir
 from libcommon.utils import PaginatedResponse
 from libcommon.viewer_utils.features import (
@@ -114,42 +109,6 @@ def full_text_search(index_file_location: str, query: str, offset: int, length: 
     pa_table = query_result.arrow()
     con.close()
     return (num_rows_total, pa_table)
-
-
-def get_cache_entry_from_steps(
-    processing_steps: List[ProcessingStep],
-    dataset: str,
-    config: Optional[str],
-    split: Optional[str],
-    processing_graph: ProcessingGraph,
-    cache_max_days: int,
-    hf_endpoint: str,
-    hf_token: Optional[str] = None,
-    hf_timeout_seconds: Optional[float] = None,
-) -> CacheEntry:
-    """Gets the cache from the first successful step in the processing steps list.
-    If no successful result is found, it will return the last one even if it's an error,
-    Checks if job is still in progress by each processing step in case of no entry found.
-    Raises:
-        - [`~utils.ResponseNotFoundError`]
-          if no result is found.
-        - [`~utils.ResponseNotReadyError`]
-          if the response is not ready yet.
-    Returns: the cached record
-    """
-    kinds = [processing_step.cache_kind for processing_step in processing_steps]
-    best_response = get_best_response(kinds=kinds, dataset=dataset, config=config, split=split)
-    if "error_code" in best_response.response and best_response.response["error_code"] == CACHED_RESPONSE_NOT_FOUND:
-        try_backfill_dataset_then_raise(
-            processing_steps=processing_steps,
-            processing_graph=processing_graph,
-            dataset=dataset,
-            hf_endpoint=hf_endpoint,
-            hf_timeout_seconds=hf_timeout_seconds,
-            hf_token=hf_token,
-            cache_max_days=cache_max_days,
-        )
-    return best_response.response
 
 
 def create_response(


### PR DESCRIPTION
Fix for rows issue in https://github.com/huggingface/datasets-server/issues/1661
When cache parquet failed, it returned 404 instead of 500. Now, it returns the detailed error as in /search.

 