### PR TITLE
Add blockedDatasets variable

### DIFF
--- a/chart/templates/_env/_envWorker.tpl
+++ b/chart/templates/_env/_envWorker.tpl
@@ -2,6 +2,8 @@
 # Copyright 2022 The HuggingFace Authors.
 
 {{- define "envWorker" -}}
+- name: WORKER_BLOCKED_DATASETS
+  value: {{ .Values.worker.blockedDatasets | quote}}
 - name: WORKER_CONTENT_MAX_BYTES
   value: {{ .Values.worker.contentMaxBytes | quote}}
 - name: WORKER_HEARTBEAT_INTERVAL_SECONDS

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -158,6 +158,8 @@ metrics:
   mongoDatabase: "datasets_server_metrics"
 
 worker:
+  # comma-separated list of blocked datasets (e.g. if not supported by the Hub). No jobs will be processed for those datasets.
+  blockedDatasets: "alexandrainst/nota"
   # maximum size in bytes of the response content computed by a worker
   contentMaxBytes: "10_000_000"
   # the time interval between two heartbeats. Each heartbeat updates the job "last_heartbeat" field in the queue.

--- a/services/worker/src/worker/config.py
+++ b/services/worker/src/worker/config.py
@@ -15,6 +15,7 @@ from libcommon.config import (
     QueueConfig,
 )
 
+WORKER_BLOCKED_DATASETS: List[str] = []
 WORKER_CONTENT_MAX_BYTES = 10_000_000
 WORKER_DIFFICULTY_MAX = None
 WORKER_DIFFICULTY_MIN = None
@@ -36,6 +37,7 @@ def get_empty_str_list() -> List[str]:
 
 @dataclass(frozen=True)
 class WorkerConfig:
+    blocked_datasets: List[str] = field(default_factory=WORKER_BLOCKED_DATASETS.copy)
     content_max_bytes: int = WORKER_CONTENT_MAX_BYTES
     difficulty_max: Optional[int] = WORKER_DIFFICULTY_MAX
     difficulty_min: Optional[int] = WORKER_DIFFICULTY_MIN
@@ -58,6 +60,7 @@ class WorkerConfig:
         env = Env(expand_vars=True)
         with env.prefixed("WORKER_"):
             return cls(
+                blocked_datasets=env.list(name="BLOCKED_DATASETS", default=WORKER_BLOCKED_DATASETS.copy),
                 content_max_bytes=env.int(name="CONTENT_MAX_BYTES", default=WORKER_CONTENT_MAX_BYTES),
                 difficulty_max=env.int(name="DIFFICULTY_MAX", default=WORKER_DIFFICULTY_MAX),
                 difficulty_min=env.int(name="DIFFICULTY_MIN", default=WORKER_DIFFICULTY_MIN),

--- a/services/worker/src/worker/config.py
+++ b/services/worker/src/worker/config.py
@@ -60,7 +60,7 @@ class WorkerConfig:
         env = Env(expand_vars=True)
         with env.prefixed("WORKER_"):
             return cls(
-                blocked_datasets=env.list(name="BLOCKED_DATASETS", default=WORKER_BLOCKED_DATASETS.copy),
+                blocked_datasets=env.list(name="BLOCKED_DATASETS", default=WORKER_BLOCKED_DATASETS.copy()),
                 content_max_bytes=env.int(name="CONTENT_MAX_BYTES", default=WORKER_CONTENT_MAX_BYTES),
                 difficulty_max=env.int(name="DIFFICULTY_MAX", default=WORKER_DIFFICULTY_MAX),
                 difficulty_min=env.int(name="DIFFICULTY_MIN", default=WORKER_DIFFICULTY_MIN),

--- a/services/worker/src/worker/job_manager.py
+++ b/services/worker/src/worker/job_manager.py
@@ -147,6 +147,14 @@ class JobManager:
         self,
     ) -> JobResult:
         self.info(f"compute {self}")
+        if self.job_info["params"]["dataset"] in self.worker_config.blocked_datasets:
+            self.debug(f"the dataset={self.job_params['dataset']} is blocked, don't update the cache")
+            return {
+                "job_info": self.job_info,
+                "job_runner_version": self.job_runner.get_job_runner_version(),
+                "is_success": False,
+                "output": None,
+            }
         try:
             try:
                 self.job_runner.pre_compute()


### PR DESCRIPTION
and block `alexandrainst/nota`, see [internal slack thread](https://huggingface.slack.com/archives/C04L6P8KNQ5/p1693548446825959)

The idea is to never process anything for blocked datasets. I also chose to not store anything in the cache in this case