### PR TITLE
More memory for workers

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -276,10 +276,10 @@ admin:
   resources:
     requests:
       cpu: 1
-      memory: "512Mi"
+      memory: "1Gi"
     limits:
       cpu: 4
-      memory: "4Gi"
+      memory: "8Gi"
 
 hf:
   timeoutSeconds: "1.5"

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -352,10 +352,10 @@ workers:
     resources:
       requests:
         cpu: 1
-        memory: "8Gi"
+        memory: "16Gi"
       limits:
         cpu: 2
-        memory: "8Gi"
+        memory: "16Gi"
     tolerations: []
   -
     deployName: "light"

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -348,7 +348,7 @@ workers:
     workerJobTypesOnly: ""
     nodeSelector:
       role-datasets-server-worker: "true"
-    replicas: 100
+    replicas: 64
     resources:
       requests:
         cpu: 1
@@ -365,7 +365,7 @@ workers:
     workerJobTypesOnly: ""
     nodeSelector:
       role-datasets-server-worker-light: "true"
-    replicas: 50
+    replicas: 32
     resources:
       requests:
         cpu: 200m


### PR DESCRIPTION
8GB -> 16GB

Fixes (hopefully) https://github.com/huggingface/datasets-server/issues/1758

Idk what kind of pods we have though, we might have to double check it's not too much

It should be enough to perform the indexing of datasets (up to 5GB which is the max)