### PR TITLE
feat: 🎸 reduce the max ram

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -347,14 +347,14 @@ workers:
     workerJobTypesOnly: ""
     nodeSelector:
       role-datasets-server-worker: "true"
-    replicas: 64
+    replicas: 80
     resources:
       requests:
         cpu: 1
-        memory: "16Gi"
+        memory: "14Gi"
       limits:
         cpu: 2
-        memory: "16Gi"
+        memory: "14Gi"
     tolerations: []
   - deployName: "light"
     workerDifficultyMax: 40


### PR DESCRIPTION
because the nodes have 32GB RAM, and we cannot fit 2x 16GB due to the small overhead kubenetes requires aside of the pods.

cc @lhoestq 