### PR TITLE
Less rows workers and less uvicorn workers

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -307,10 +307,11 @@ rows:
   # Number of uvicorn workers for running the application
   # (2 x $num_cores) + 1
   # https://docs.gunicorn.org/en/stable/design.html#how-many-workers
-  uvicornNumWorkers: "9"
+  # but we only set to 2 to avoid OOM
+  uvicornNumWorkers: "2"
   nodeSelector:
     role-datasets-server-rows: "true"
-  replicas: 20
+  replicas: 12
   service:
     type: NodePort
   resources:


### PR DESCRIPTION
Following https://github.com/huggingface/datasets-server/pull/1769

since deployed failed again because there are no nodes available. Sureley because /rows can't run on nodes made for dataset workers.

I also reduced the amount of uvicorn workers in case it was the reason the pods were OOMing (too many parallel calls)