### PR TITLE
Enable audio in the Dataset Viewer pagination

### DIFF
--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -6,7 +6,7 @@ import random
 from typing import List, Literal, Optional, Union
 
 import pyarrow as pa
-from datasets import Audio, Features, Value
+from datasets import Features, Value
 from fsspec.implementations.http import HTTPFileSystem
 from libapi.authentication import auth_check
 from libapi.exceptions import (
@@ -45,7 +45,7 @@ MAX_ROWS = 100
 ALL_COLUMNS_SUPPORTED_DATASETS_ALLOW_LIST: Union[Literal["all"], List[str]] = ["arabic_speech_corpus"]  # for testing
 
 # audio still has some errors when librosa is imported
-UNSUPPORTED_FEATURES = [Value("binary"), Audio()]
+UNSUPPORTED_FEATURES = [Value("binary")]
 
 
 def create_response(


### PR DESCRIPTION
It's now working at correct speed, e.g. https://huggingface.co/datasets/arabic_speech_corpus/viewer/clean/train?p=1 takes only a few seconds. It was only enabled on this dataset for testing purposes.

Following #1788 

Fixes (hopefully once and for all) https://github.com/huggingface/datasets-server/issues/1255