### PR TITLE
Adding back incremental queue metrics

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -200,8 +200,8 @@ backfill:
 
 queueMetricsCollector:
   action: "collect-queue-metrics"
-  schedule: "*/2 * * * *"
-  # every two minutes
+  schedule: "*/10 * * * *"
+  # every ten minutes, then it will be changed to default
   nodeSelector: {}
   resources:
     requests:

--- a/e2e/tests/test_31_admin_metrics.py
+++ b/e2e/tests/test_31_admin_metrics.py
@@ -31,10 +31,11 @@ def test_metrics() -> None:
 
     metric_names = set(metrics.keys())
 
-    # the queue metrics are computed by the background jobs. Here, in the e2e tests, we don't run them,
+    # the queue metrics are computed each time a job is created and processed
+    # they should exists at least for some of jobs types
     for queue in ["dataset-config-names", "split-first-rows-from-streaming", "dataset-parquet"]:
         # eg. 'queue_jobs_total{pid="10",queue="split-first-rows-from-streaming",status="started"}'
-        assert not has_metric(
+        assert has_metric(
             name="queue_jobs_total",
             labels={"pid": "[0-9]*", "queue": queue, "status": "started"},
             metric_names=metric_names,

--- a/jobs/cache_maintenance/src/cache_maintenance/queue_metrics.py
+++ b/jobs/cache_maintenance/src/cache_maintenance/queue_metrics.py
@@ -12,7 +12,14 @@ def collect_queue_metrics(processing_graph: ProcessingGraph) -> None:
     queue = Queue()
     for processing_step in processing_graph.get_processing_steps():
         for status, new_total in queue.get_jobs_count_by_status(job_type=processing_step.job_type).items():
-            JobTotalMetricDocument.objects(job_type=processing_step.job_type, status=status).upsert_one(
-                total=new_total
-            )
+            job_type = processing_step.job_type
+            query_set = JobTotalMetricDocument.objects(job_type=job_type, status=status)
+            current_metric = query_set.first()
+            if current_metric is not None:
+                current_total = current_metric.total
+                logging.info(
+                    f"{job_type=} {status=} current_total={current_total} new_total="
+                    f"{new_total} difference={int(new_total)-current_total}"  # type: ignore
+                )
+            query_set.upsert_one(total=new_total)
     logging.info("queue metrics have been collected")

--- a/jobs/cache_maintenance/tests/test_collect_queue_metrics.py
+++ b/jobs/cache_maintenance/tests/test_collect_queue_metrics.py
@@ -23,7 +23,7 @@ def test_collect_queue_metrics() -> None:
         split="split",
         difficulty=50,
     )
-    assert JobTotalMetricDocument.objects().count() == 0
+    assert JobTotalMetricDocument.objects().count() == 1
 
     collect_queue_metrics(processing_graph=processing_graph)
 

--- a/libs/libcommon/tests/test_queue.py
+++ b/libs/libcommon/tests/test_queue.py
@@ -15,9 +15,18 @@ import pytest
 import pytz
 
 from libcommon.constants import QUEUE_TTL_SECONDS
-from libcommon.queue import EmptyQueueError, JobDocument, Lock, Queue, lock
+from libcommon.queue import (
+    EmptyQueueError,
+    JobDocument,
+    JobTotalMetricDocument,
+    Lock,
+    Queue,
+    lock,
+)
 from libcommon.resources import QueueMongoResource
 from libcommon.utils import Priority, Status, get_datetime
+
+from .utils import assert_metric
 
 
 def get_old_datetime() -> datetime:
@@ -38,12 +47,16 @@ def test_add_job() -> None:
     test_difficulty = 50
     # get the queue
     queue = Queue()
+    assert JobTotalMetricDocument.objects().count() == 0
     # add a job
     job1 = queue.add_job(job_type=test_type, dataset=test_dataset, revision=test_revision, difficulty=test_difficulty)
+    assert_metric(job_type=test_type, status=Status.WAITING, total=1)
 
     # a second call adds a second waiting job
     job2 = queue.add_job(job_type=test_type, dataset=test_dataset, revision=test_revision, difficulty=test_difficulty)
     assert queue.is_job_in_process(job_type=test_type, dataset=test_dataset, revision=test_revision)
+    assert_metric(job_type=test_type, status=Status.WAITING, total=2)
+
     # get and start a job the second one should have been picked
     job_info = queue.start_job()
     assert job2.reload().status == Status.STARTED
@@ -52,6 +65,8 @@ def test_add_job() -> None:
     assert job_info["params"]["revision"] == test_revision
     assert job_info["params"]["config"] is None
     assert job_info["params"]["split"] is None
+    assert_metric(job_type=test_type, status=Status.WAITING, total=1)
+    assert_metric(job_type=test_type, status=Status.STARTED, total=1)
 
     # and the first job should have been cancelled
     assert job1.reload().status == Status.CANCELLED
@@ -60,6 +75,9 @@ def test_add_job() -> None:
     # (there are no limits to the number of waiting jobs)
     job3 = queue.add_job(job_type=test_type, dataset=test_dataset, revision=test_revision, difficulty=test_difficulty)
     assert job3.status == Status.WAITING
+    assert_metric(job_type=test_type, status=Status.WAITING, total=2)
+    assert_metric(job_type=test_type, status=Status.STARTED, total=1)
+
     with pytest.raises(EmptyQueueError):
         # but: it's not possible to start two jobs with the same arguments
         queue.start_job()
@@ -67,16 +85,28 @@ def test_add_job() -> None:
     queue.finish_job(job_id=job_info["job_id"], is_success=True)
     # the queue is not empty
     assert queue.is_job_in_process(job_type=test_type, dataset=test_dataset, revision=test_revision)
+    assert_metric(job_type=test_type, status=Status.WAITING, total=2)
+    assert_metric(job_type=test_type, status=Status.STARTED, total=0)
+    assert_metric(job_type=test_type, status=Status.SUCCESS, total=1)
 
     # process the third job
     job_info = queue.start_job()
     other_job_id = ("1" if job_info["job_id"][0] == "0" else "0") + job_info["job_id"][1:]
+    assert_metric(job_type=test_type, status=Status.WAITING, total=1)
+    assert_metric(job_type=test_type, status=Status.STARTED, total=1)
+    assert_metric(job_type=test_type, status=Status.SUCCESS, total=1)
 
     # trying to finish another job fails silently (with a log)
     queue.finish_job(job_id=other_job_id, is_success=True)
+    assert_metric(job_type=test_type, status=Status.WAITING, total=1)
+    assert_metric(job_type=test_type, status=Status.STARTED, total=1)
+    assert_metric(job_type=test_type, status=Status.SUCCESS, total=1)
 
     # finish it
     queue.finish_job(job_id=job_info["job_id"], is_success=True)
+    assert_metric(job_type=test_type, status=Status.WAITING, total=1)
+    assert_metric(job_type=test_type, status=Status.STARTED, total=0)
+    assert_metric(job_type=test_type, status=Status.SUCCESS, total=2)
 
     # the queue is empty
     assert not queue.is_job_in_process(job_type=test_type, dataset=test_dataset, revision=test_revision)
@@ -106,6 +136,7 @@ def test_cancel_jobs_by_job_id(
     for job_id in list(set(jobs_ids + job_ids_to_cancel)):
         job = queue.add_job(job_type=test_type, dataset=job_id, revision="test_revision", difficulty=test_difficulty)
         waiting_jobs += 1
+        assert_metric(job_type=test_type, status=Status.WAITING, total=waiting_jobs)
         if job_id in job_ids_to_cancel:
             real_job_id = job.info()["job_id"]
             real_job_ids_to_cancel.append(real_job_id)
@@ -114,14 +145,18 @@ def test_cancel_jobs_by_job_id(
             job.delete()
 
     queue.start_job()
+    assert_metric(job_type=test_type, status=Status.WAITING, total=1)
+    assert_metric(job_type=test_type, status=Status.STARTED, total=1)
     canceled_number = queue.cancel_jobs_by_job_id(job_ids=real_job_ids_to_cancel)
     assert canceled_number == expected_canceled_number
+    assert_metric(job_type=test_type, status=Status.CANCELLED, total=expected_canceled_number)
 
 
 def test_cancel_jobs_by_job_id_wrong_format() -> None:
     queue = Queue()
 
     assert queue.cancel_jobs_by_job_id(job_ids=["not_a_valid_job_id"]) == 0
+    assert JobTotalMetricDocument.objects().count() == 0
 
 
 def check_job(queue: Queue, expected_dataset: str, expected_split: str, expected_priority: Priority) -> None:

--- a/libs/libcommon/tests/utils.py
+++ b/libs/libcommon/tests/utils.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 
 from libcommon.orchestrator import DatasetBackfillPlan
 from libcommon.processing_graph import Artifact, ProcessingGraph
-from libcommon.queue import Queue
+from libcommon.queue import JobTotalMetricDocument, Queue
 from libcommon.simple_cache import upsert_response
 from libcommon.utils import JobInfo, Priority
 
@@ -364,3 +364,9 @@ def artifact_id_to_job_info(artifact_id: str) -> JobInfo:
         priority=Priority.NORMAL,
         difficulty=DIFFICULTY,
     )
+
+
+def assert_metric(job_type: str, status: str, total: int) -> None:
+    metric = JobTotalMetricDocument.objects(job_type=job_type, status=status).first()
+    assert metric is not None
+    assert metric.total == total


### PR DESCRIPTION
Now that the queue is working well, add back incremental queue metrics.
Note.- A rollback was done in this PR https://github.com/huggingface/datasets-server/pull/1698/files
