### PR TITLE
fix: split-descriptive-statistics fails for datasets with list features

### DIFF
--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -367,12 +367,14 @@ def compute_descriptive_statistics_response(
     stats: List[StatisticsPerColumnItem] = []
     num_examples = dataset_info["splits"][split]["num_examples"]
     categorical_features = {
-        feature_name: feature for feature_name, feature in features.items() if feature.get("_type") == "ClassLabel"
+        feature_name: feature
+        for feature_name, feature in features.items()
+        if isinstance(feature, dict) and feature.get("_type") == "ClassLabel"
     }
     numerical_features = {
         feature_name: feature
         for feature_name, feature in features.items()
-        if feature.get("_type") == "Value" and feature.get("dtype") in NUMERICAL_DTYPES
+        if isinstance(feature, dict) and feature.get("_type") == "Value" and feature.get("dtype") in NUMERICAL_DTYPES
     }
     if not categorical_features and not numerical_features:
         raise NoSupportedFeaturesError(


### PR DESCRIPTION
While reviewing https://github.com/huggingface/datasets-server/issues/1443 I found that for the first error AttributeError, there is a minor bug in split-descriptive-statistics, it fails when features include list (sequences).
After this fix, we should force-refresh cached records for:
```
db.cachedResponsesBlue.countDocuments({error_code:"UnexpectedError", "details.copied_from_artifact":{$exists:false}, "details.cause_exception":"AttributeError",kind:"split-descriptive-statistics"})
9748

```