### PR TITLE
Adding parent validation at job runner level

### DIFF
--- a/libs/libcommon/src/libcommon/exceptions.py
+++ b/libs/libcommon/src/libcommon/exceptions.py
@@ -74,8 +74,9 @@ class CustomError(LoggedError):
 
 CacheableErrorCode = Literal[
     "CacheDirectoryNotInitializedError",
-    "ConfigNamesError",
     "ComputationError",
+    "ConfigNamesError",
+    "ConfigNotFoundError",
     "CreateCommitError",
     "DatasetInBlockListError",
     "DatasetInfoHubRequestError",
@@ -151,6 +152,19 @@ class ConfigNamesError(CacheableError):
 
     def __init__(self, message: str, cause: Optional[BaseException] = None):
         super().__init__(message, HTTPStatus.INTERNAL_SERVER_ERROR, "ConfigNamesError", cause, True)
+
+
+class ConfigNotFoundError(CacheableError):
+    """The config does not exist."""
+
+    def __init__(self, message: str, cause: Optional[BaseException] = None):
+        super().__init__(
+            message=message,
+            status_code=HTTPStatus.NOT_FOUND,
+            code="ConfigNotFoundError",
+            cause=cause,
+            disclose_cause=False,
+        )
 
 
 class CreateCommitError(CacheableError):

--- a/services/worker/src/worker/job_runners/config/config_job_runner.py
+++ b/services/worker/src/worker/job_runners/config/config_job_runner.py
@@ -12,6 +12,7 @@ from worker.job_runners._job_runner_with_datasets_cache import (
     JobRunnerWithDatasetsCache,
 )
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
+from worker.utils import check_config_exists
 
 
 class ConfigJobRunner(DatasetJobRunner):
@@ -27,6 +28,7 @@ class ConfigJobRunner(DatasetJobRunner):
         if job_info["params"]["config"] is None:
             raise ParameterMissingError("'config' parameter is required")
         self.config = job_info["params"]["config"]
+        check_config_exists(dataset=self.dataset, config=self.config)
 
 
 class ConfigJobRunnerWithDatasetsCache(JobRunnerWithDatasetsCache, ConfigJobRunner):

--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -29,7 +29,6 @@ from tqdm import tqdm
 from worker.config import AppConfig, DescriptiveStatisticsConfig
 from worker.dtos import CompleteJobResult
 from worker.job_runners.split.split_job_runner import SplitJobRunnerWithCache
-from worker.utils import check_split_exists
 
 REPO_TYPE = "dataset"
 
@@ -303,7 +302,6 @@ def compute_descriptive_statistics_response(
     """
 
     logging.info(f"Compute descriptive statistics for {dataset=}, {config=}, {split=}")
-    check_split_exists(dataset=dataset, config=config, split=split)
 
     config_parquet_and_info_step = "config-parquet-and-info"
     parquet_and_info_best_response = get_previous_step_or_raise(

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -41,7 +41,6 @@ from worker.job_runners.split.split_job_runner import SplitJobRunnerWithCache
 from worker.utils import (
     HF_HUB_HTTP_ERROR_RETRY_SLEEPS,
     LOCK_GIT_BRANCH_RETRY_SLEEPS,
-    check_split_exists,
     create_branch,
     hf_hub_url,
     retry,
@@ -97,7 +96,6 @@ def compute_index_rows(
     committer_hf_token: Optional[str],
 ) -> DuckdbIndexWithFeatures:
     logging.info(f"get split-duckdb-index for dataset={dataset} config={config} split={split}")
-    check_split_exists(dataset=dataset, config=config, split=split)
 
     # get parquet urls and dataset_info
     config_parquet_and_info_step = "config-parquet-and-info"

--- a/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
@@ -32,12 +32,7 @@ from libcommon.viewer_utils.features import get_cell_value, to_features_list
 from worker.config import AppConfig, FirstRowsConfig
 from worker.dtos import CompleteJobResult, JobRunnerInfo, SplitFirstRowsResponse
 from worker.job_runners.split.split_job_runner import SplitJobRunnerWithDatasetsCache
-from worker.utils import (
-    check_split_exists,
-    create_truncated_row_items,
-    get_json_size,
-    get_rows_or_raise,
-)
+from worker.utils import create_truncated_row_items, get_json_size, get_rows_or_raise
 
 
 def transform_rows(
@@ -140,8 +135,6 @@ def compute_first_rows_response(
           If the split rows could not be obtained using the datasets library in normal mode.
     """
     logging.info(f"get first-rows for dataset={dataset} config={config} split={split}")
-    # first ensure the tuple (dataset, config, split) exists on the Hub
-    check_split_exists(dataset=dataset, config=config, split=split)
     # get the features
     try:
         info = get_dataset_config_info(

--- a/services/worker/src/worker/job_runners/split/split_job_runner.py
+++ b/services/worker/src/worker/job_runners/split/split_job_runner.py
@@ -13,6 +13,7 @@ from worker.job_runners._job_runner_with_datasets_cache import (
     JobRunnerWithDatasetsCache,
 )
 from worker.job_runners.config.config_job_runner import ConfigJobRunner
+from worker.utils import check_split_exists
 
 
 class SplitJobRunner(ConfigJobRunner):
@@ -28,6 +29,7 @@ class SplitJobRunner(ConfigJobRunner):
         if job_info["params"]["split"] is None:
             raise ParameterMissingError("'split' parameter is required")
         self.split = job_info["params"]["split"]
+        check_split_exists(dataset=self.dataset, config=self.config, split=self.split)
 
 
 class SplitJobRunnerWithDatasetsCache(JobRunnerWithDatasetsCache, SplitJobRunner):

--- a/services/worker/tests/job_runners/config/test_config_job_runner.py
+++ b/services/worker/tests/job_runners/config/test_config_job_runner.py
@@ -1,14 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The HuggingFace Authors.
 
+from http import HTTPStatus
+from typing import Optional
+
 import pytest
 from libcommon.exceptions import CustomError
 from libcommon.processing_graph import ProcessingStep
+from libcommon.resources import CacheMongoResource
+from libcommon.simple_cache import upsert_response
 from libcommon.utils import Priority
 
 from worker.config import AppConfig
 from worker.dtos import CompleteJobResult
 from worker.job_runners.config.config_job_runner import ConfigJobRunner
+
+
+@pytest.fixture(autouse=True)
+def cache_mongo_resource_autouse(cache_mongo_resource: CacheMongoResource) -> CacheMongoResource:
+    return cache_mongo_resource
 
 
 class DummyConfigJobRunner(ConfigJobRunner):
@@ -45,23 +55,64 @@ def test_failed_creation(test_processing_step: ProcessingStep, app_config: AppCo
     assert exc_info.value.code == "ParameterMissingError"
 
 
-def test_success_creation(test_processing_step: ProcessingStep, app_config: AppConfig) -> None:
-    assert (
-        DummyConfigJobRunner(
-            job_info={
-                "job_id": "job_id",
-                "type": test_processing_step.job_type,
-                "params": {
-                    "dataset": "dataset",
-                    "revision": "revision",
-                    "config": "config",
-                    "split": None,
-                },
-                "priority": Priority.NORMAL,
-                "difficulty": 50,
-            },
-            processing_step=test_processing_step,
-            app_config=app_config,
-        )
-        is not None
+@pytest.mark.parametrize(
+    "upsert_config,exception_name",
+    [
+        ("config", None),
+        ("other_config", "ConfigNotFoundError"),
+    ],
+)
+def test_creation(
+    test_processing_step: ProcessingStep,
+    app_config: AppConfig,
+    upsert_config: str,
+    exception_name: Optional[str],
+) -> None:
+    dataset, config = "dataset", "config"
+
+    upsert_response(
+        kind="dataset-config-names",
+        dataset=dataset,
+        content={"config_names": [{"dataset": dataset, "config": upsert_config}]},
+        http_status=HTTPStatus.OK,
     )
+
+    if exception_name is None:
+        assert (
+            DummyConfigJobRunner(
+                job_info={
+                    "job_id": "job_id",
+                    "type": test_processing_step.job_type,
+                    "params": {
+                        "dataset": dataset,
+                        "revision": "revision",
+                        "config": config,
+                        "split": None,
+                    },
+                    "priority": Priority.NORMAL,
+                    "difficulty": 50,
+                },
+                processing_step=test_processing_step,
+                app_config=app_config,
+            )
+            is not None
+        )
+    else:
+        with pytest.raises(CustomError) as exc_info:
+            DummyConfigJobRunner(
+                job_info={
+                    "job_id": "job_id",
+                    "type": test_processing_step.job_type,
+                    "params": {
+                        "dataset": dataset,
+                        "revision": "revision",
+                        "config": config,
+                        "split": None,
+                    },
+                    "priority": Priority.NORMAL,
+                    "difficulty": 50,
+                },
+                processing_step=test_processing_step,
+                app_config=app_config,
+            )
+        assert exc_info.value.code == exception_name

--- a/services/worker/tests/job_runners/config/test_info.py
+++ b/services/worker/tests/job_runners/config/test_info.py
@@ -156,6 +156,14 @@ def get_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return ConfigInfoJobRunner(
             job_info={
                 "type": ConfigInfoJobRunner.get_job_type(),

--- a/services/worker/tests/job_runners/config/test_is_valid.py
+++ b/services/worker/tests/job_runners/config/test_is_valid.py
@@ -123,6 +123,14 @@ def get_job_runner(
     ) -> ConfigIsValidJobRunner:
         processing_step_name = ConfigIsValidJobRunner.get_job_type()
         processing_graph = ProcessingGraph(app_config.processing_graph.specification)
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return ConfigIsValidJobRunner(
             job_info={
                 "type": ConfigIsValidJobRunner.get_job_type(),

--- a/services/worker/tests/job_runners/config/test_opt_in_out_urls_count.py
+++ b/services/worker/tests/job_runners/config/test_opt_in_out_urls_count.py
@@ -46,6 +46,14 @@ def get_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return ConfigOptInOutUrlsCountJobRunner(
             job_info={
                 "type": ConfigOptInOutUrlsCountJobRunner.get_job_type(),

--- a/services/worker/tests/job_runners/config/test_parquet.py
+++ b/services/worker/tests/job_runners/config/test_parquet.py
@@ -51,6 +51,14 @@ def get_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return ConfigParquetJobRunner(
             job_info={
                 "type": ConfigParquetJobRunner.get_job_type(),

--- a/services/worker/tests/job_runners/config/test_parquet_metadata.py
+++ b/services/worker/tests/job_runners/config/test_parquet_metadata.py
@@ -67,6 +67,14 @@ def get_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return ConfigParquetMetadataJobRunner(
             job_info={
                 "type": ConfigParquetMetadataJobRunner.get_job_type(),

--- a/services/worker/tests/job_runners/config/test_size.py
+++ b/services/worker/tests/job_runners/config/test_size.py
@@ -49,6 +49,14 @@ def get_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return ConfigSizeJobRunner(
             job_info={
                 "type": ConfigSizeJobRunner.get_job_type(),

--- a/services/worker/tests/job_runners/config/test_split_names_from_info.py
+++ b/services/worker/tests/job_runners/config/test_split_names_from_info.py
@@ -44,6 +44,14 @@ def get_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return ConfigSplitNamesFromInfoJobRunner(
             job_info={
                 "type": ConfigSplitNamesFromInfoJobRunner.get_job_type(),

--- a/services/worker/tests/job_runners/config/test_split_names_from_streaming.py
+++ b/services/worker/tests/job_runners/config/test_split_names_from_streaming.py
@@ -2,12 +2,14 @@
 # Copyright 2022 The HuggingFace Authors.
 
 from dataclasses import replace
+from http import HTTPStatus
 from typing import Callable
 
 import pytest
 from libcommon.exceptions import CustomError, DatasetManualDownloadError
 from libcommon.processing_graph import ProcessingGraph
 from libcommon.resources import CacheMongoResource, QueueMongoResource
+from libcommon.simple_cache import upsert_response
 from libcommon.utils import Priority
 
 from worker.config import AppConfig
@@ -44,6 +46,14 @@ def get_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return ConfigSplitNamesFromStreamingJobRunner(
             job_info={
                 "type": ConfigSplitNamesFromStreamingJobRunner.get_job_type(),

--- a/services/worker/tests/job_runners/split/test_descriptive_statistics.py
+++ b/services/worker/tests/job_runners/split/test_descriptive_statistics.py
@@ -270,18 +270,8 @@ def test_compute(
         "big": hub_responses_big,
     }
     dataset = hub_datasets[hub_dataset_name]["name"]
-    config_names_response = hub_datasets[hub_dataset_name]["config_names_response"]
     splits_response = hub_datasets[hub_dataset_name]["splits_response"]
     config, split = splits_response["splits"][0]["config"], splits_response["splits"][0]["split"]
-
-    # upsert_response("dataset-config-names", dataset=dataset, http_status=HTTPStatus.OK, content=config_names_response)
-    # upsert_response(
-    #     "config-split-names-from-info",
-    #     dataset=dataset,
-    #     config=config,
-    #     http_status=HTTPStatus.OK,
-    #     content=splits_response,
-    # )
 
     # computing and pushing real parquet files because we need them for stats computation
     parquet_job_runner = get_parquet_and_info_job_runner(dataset, config, app_config)

--- a/services/worker/tests/job_runners/split/test_descriptive_statistics.py
+++ b/services/worker/tests/job_runners/split/test_descriptive_statistics.py
@@ -58,6 +58,22 @@ def get_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
+        upsert_response(
+            kind="config-split-names-from-streaming",
+            dataset=dataset,
+            config=config,
+            content={"splits": [{"dataset": dataset, "config": config, "split": split}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return SplitDescriptiveStatisticsJobRunner(
             job_info={
                 "type": SplitDescriptiveStatisticsJobRunner.get_job_type(),
@@ -101,6 +117,14 @@ def get_parquet_and_info_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return ConfigParquetAndInfoJobRunner(
             job_info={
                 "type": ConfigParquetAndInfoJobRunner.get_job_type(),
@@ -250,14 +274,14 @@ def test_compute(
     splits_response = hub_datasets[hub_dataset_name]["splits_response"]
     config, split = splits_response["splits"][0]["config"], splits_response["splits"][0]["split"]
 
-    upsert_response("dataset-config-names", dataset=dataset, http_status=HTTPStatus.OK, content=config_names_response)
-    upsert_response(
-        "config-split-names-from-info",
-        dataset=dataset,
-        config=config,
-        http_status=HTTPStatus.OK,
-        content=splits_response,
-    )
+    # upsert_response("dataset-config-names", dataset=dataset, http_status=HTTPStatus.OK, content=config_names_response)
+    # upsert_response(
+    #     "config-split-names-from-info",
+    #     dataset=dataset,
+    #     config=config,
+    #     http_status=HTTPStatus.OK,
+    #     content=splits_response,
+    # )
 
     # computing and pushing real parquet files because we need them for stats computation
     parquet_job_runner = get_parquet_and_info_job_runner(dataset, config, app_config)

--- a/services/worker/tests/job_runners/split/test_duckdb_index.py
+++ b/services/worker/tests/job_runners/split/test_duckdb_index.py
@@ -67,6 +67,22 @@ def get_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
+        upsert_response(
+            kind="config-split-names-from-streaming",
+            dataset=dataset,
+            config=config,
+            content={"splits": [{"dataset": dataset, "config": config, "split": split}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return SplitDuckDbIndexJobRunner(
             job_info={
                 "type": SplitDuckDbIndexJobRunner.get_job_type(),
@@ -110,6 +126,14 @@ def get_parquet_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return ConfigParquetAndInfoJobRunner(
             job_info={
                 "type": ConfigParquetAndInfoJobRunner.get_job_type(),
@@ -164,21 +188,6 @@ def test_compute(
     splits_response = hub_datasets[hub_dataset_name]["splits_response"]
     split = "train"
     partial = hub_dataset_name.startswith("partial_")
-
-    upsert_response(
-        "dataset-config-names",
-        dataset=dataset,
-        http_status=HTTPStatus.OK,
-        content=config_names,
-    )
-
-    upsert_response(
-        "config-split-names-from-streaming",
-        dataset=dataset,
-        config=config,
-        http_status=HTTPStatus.OK,
-        content=splits_response,
-    )
 
     app_config = (
         app_config

--- a/services/worker/tests/job_runners/split/test_duckdb_index.py
+++ b/services/worker/tests/job_runners/split/test_duckdb_index.py
@@ -183,9 +183,7 @@ def test_compute(
         "gated": hub_responses_gated_duckdb_index,
     }
     dataset = hub_datasets[hub_dataset_name]["name"]
-    config_names = hub_datasets[hub_dataset_name]["config_names_response"]
     config = hub_datasets[hub_dataset_name]["config_names_response"]["config_names"][0]["config"]
-    splits_response = hub_datasets[hub_dataset_name]["splits_response"]
     split = "train"
     partial = hub_dataset_name.startswith("partial_")
 

--- a/services/worker/tests/job_runners/split/test_first_rows_from_parquet.py
+++ b/services/worker/tests/job_runners/split/test_first_rows_from_parquet.py
@@ -56,6 +56,22 @@ def get_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
+        upsert_response(
+            kind="config-split-names-from-streaming",
+            dataset=dataset,
+            config=config,
+            content={"splits": [{"dataset": dataset, "config": config, "split": split}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return SplitFirstRowsFromParquetJobRunner(
             job_info={
                 "type": SplitFirstRowsFromParquetJobRunner.get_job_type(),

--- a/services/worker/tests/job_runners/split/test_image_url_columns.py
+++ b/services/worker/tests/job_runners/split/test_image_url_columns.py
@@ -46,6 +46,22 @@ def get_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
+        upsert_response(
+            kind="config-split-names-from-streaming",
+            dataset=dataset,
+            config=config,
+            content={"splits": [{"dataset": dataset, "config": config, "split": split}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return SplitImageUrlColumnsJobRunner(
             job_info={
                 "type": SplitImageUrlColumnsJobRunner.get_job_type(),

--- a/services/worker/tests/job_runners/split/test_is_valid.py
+++ b/services/worker/tests/job_runners/split/test_is_valid.py
@@ -117,6 +117,22 @@ def get_job_runner(
     ) -> SplitIsValidJobRunner:
         processing_step_name = SplitIsValidJobRunner.get_job_type()
         processing_graph = ProcessingGraph(app_config.processing_graph.specification)
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
+        upsert_response(
+            kind="config-split-names-from-streaming",
+            dataset=dataset,
+            config=config,
+            content={"splits": [{"dataset": dataset, "config": config, "split": split}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return SplitIsValidJobRunner(
             job_info={
                 "type": SplitIsValidJobRunner.get_job_type(),

--- a/services/worker/tests/job_runners/split/test_opt_in_out_urls_count.py
+++ b/services/worker/tests/job_runners/split/test_opt_in_out_urls_count.py
@@ -48,6 +48,22 @@ def get_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
+        upsert_response(
+            kind="config-split-names-from-streaming",
+            dataset=dataset,
+            config=config,
+            content={"splits": [{"dataset": dataset, "config": config, "split": split}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return SplitOptInOutUrlsCountJobRunner(
             job_info={
                 "type": SplitOptInOutUrlsCountJobRunner.get_job_type(),

--- a/services/worker/tests/job_runners/split/test_opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/tests/job_runners/split/test_opt_in_out_urls_scan_from_streaming.py
@@ -64,6 +64,22 @@ def get_job_runner(
                 },
             }
         )
+
+        upsert_response(
+            kind="dataset-config-names",
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+        )
+
+        upsert_response(
+            kind="config-split-names-from-streaming",
+            dataset=dataset,
+            config=config,
+            content={"splits": [{"dataset": dataset, "config": config, "split": split}]},
+            http_status=HTTPStatus.OK,
+        )
+
         return SplitOptInOutUrlsScanJobRunner(
             job_info={
                 "type": SplitOptInOutUrlsScanJobRunner.get_job_type(),

--- a/services/worker/tests/job_runners/split/test_split_job_runner.py
+++ b/services/worker/tests/job_runners/split/test_split_job_runner.py
@@ -1,14 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The HuggingFace Authors.
 
+from http import HTTPStatus
+from typing import Optional
+
 import pytest
 from libcommon.exceptions import CustomError
 from libcommon.processing_graph import ProcessingStep
+from libcommon.resources import CacheMongoResource
+from libcommon.simple_cache import upsert_response
 from libcommon.utils import Priority
 
 from worker.config import AppConfig
 from worker.dtos import CompleteJobResult
 from worker.job_runners.split.split_job_runner import SplitJobRunner
+
+
+@pytest.fixture(autouse=True)
+def cache_mongo_resource_autouse(cache_mongo_resource: CacheMongoResource) -> CacheMongoResource:
+    return cache_mongo_resource
 
 
 class DummySplitJobRunner(SplitJobRunner):
@@ -46,23 +56,74 @@ def test_failed_creation(test_processing_step: ProcessingStep, app_config: AppCo
     assert exc_info.value.code == "ParameterMissingError"
 
 
-def test_success_creation(test_processing_step: ProcessingStep, app_config: AppConfig) -> None:
-    assert (
-        DummySplitJobRunner(
-            job_info={
-                "job_id": "job_id",
-                "type": test_processing_step.job_type,
-                "params": {
-                    "dataset": "dataset",
-                    "revision": "revision",
-                    "config": "config",
-                    "split": "split",
-                },
-                "priority": Priority.NORMAL,
-                "difficulty": 50,
-            },
-            processing_step=test_processing_step,
-            app_config=app_config,
-        )
-        is not None
+@pytest.mark.parametrize(
+    "upsert_config,upsert_split,exception_name",
+    [
+        ("config", "split", None),
+        ("config", "other_split", "SplitNotFoundError"),
+        ("other_config", "split", "ConfigNotFoundError"),
+    ],
+)
+def test_creation(
+    test_processing_step: ProcessingStep,
+    app_config: AppConfig,
+    upsert_config: str,
+    upsert_split: str,
+    exception_name: Optional[str],
+) -> None:
+    dataset, config, split = "dataset", "config", "split"
+
+    upsert_response(
+        kind="dataset-config-names",
+        dataset=dataset,
+        content={"config_names": [{"dataset": dataset, "config": upsert_config}]},
+        http_status=HTTPStatus.OK,
     )
+
+    upsert_response(
+        kind="config-split-names-from-streaming",
+        dataset=dataset,
+        config=config,
+        content={"splits": [{"dataset": dataset, "config": upsert_config, "split": upsert_split}]},
+        http_status=HTTPStatus.OK,
+    )
+
+    if exception_name is None:
+        assert (
+            DummySplitJobRunner(
+                job_info={
+                    "job_id": "job_id",
+                    "type": test_processing_step.job_type,
+                    "params": {
+                        "dataset": dataset,
+                        "revision": "revision",
+                        "config": config,
+                        "split": split,
+                    },
+                    "priority": Priority.NORMAL,
+                    "difficulty": 50,
+                },
+                processing_step=test_processing_step,
+                app_config=app_config,
+            )
+            is not None
+        )
+    else:
+        with pytest.raises(CustomError) as exc_info:
+            DummySplitJobRunner(
+                job_info={
+                    "job_id": "job_id",
+                    "type": test_processing_step.job_type,
+                    "params": {
+                        "dataset": dataset,
+                        "revision": "revision",
+                        "config": config,
+                        "split": split,
+                    },
+                    "priority": Priority.NORMAL,
+                    "difficulty": 50,
+                },
+                processing_step=test_processing_step,
+                app_config=app_config,
+            )
+        assert exc_info.value.code == exception_name

--- a/services/worker/tests/job_runners/split/test_split_job_runner.py
+++ b/services/worker/tests/job_runners/split/test_split_job_runner.py
@@ -36,6 +36,13 @@ class DummySplitJobRunner(SplitJobRunner):
 
 @pytest.mark.parametrize("config,split", [(None, None), (None, "split"), ("config", None)])
 def test_failed_creation(test_processing_step: ProcessingStep, app_config: AppConfig, config: str, split: str) -> None:
+    upsert_response(
+        kind="dataset-config-names",
+        dataset="dataset",
+        content={"config_names": [{"dataset": "dataset", "config": config}]},
+        http_status=HTTPStatus.OK,
+    )
+
     with pytest.raises(CustomError) as exc_info:
         DummySplitJobRunner(
             job_info={


### PR DESCRIPTION
Before, we were adding split validation in some job runners, but we should to it in all according to their granularity.
**Config** level should validate that the config exists in the dataset.
**Split** level should validate that the split exists in the config and that the config exists in the dataset.

**Example:**
When trying to `force-refresh` for step `split-first-rows-from-parquet` for dataset=ColumbiaNLP/FLUTE config=ColumbiaNLP--FLUTE split=train it failed with error:
`404, message='Not Found', url=URL('https://huggingface.co/datasets/ColumbiaNLP/FLUTE/resolve/refs%2Fconvert%2Fparquet/ColumbiaNLP--FLUTE/train/0000.parquet')
`
But it is wrong because the config no longer exists for the dataset and it should have thrown a SplitNotFoundError.

Related to https://github.com/huggingface/datasets-server/issues/1696 but meanwhile we could at least validate that config and split exist before processing.
