### PR TITLE
Fix typo in SplitFirstRowsFromParquetJobRunner

### DIFF
--- a/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
@@ -153,7 +153,7 @@ def compute_first_rows_response(
 class SplitFirstRowsFromParquetJobRunner(SplitJobRunner):
     assets_directory: StrPath
     first_rows_config: FirstRowsConfig
-    indexed: Indexer
+    indexer: Indexer
 
     @staticmethod
     def get_job_type() -> str:


### PR DESCRIPTION
Fix typo in `SplitFirstRowsFromParquetJobRunner`.