### PR TITLE
Block cyberharem

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -137,7 +137,7 @@ parquetAndInfo:
   maxDatasetSize: "5_000_000_000"
   maxRowGroupByteSizeForCopy: "500_000_000"
   # See https://observablehq.com/@huggingface/blocked-datasets
-  blockedDatasets: "Graphcore/gqa,Graphcore/gqa-lxmert,Graphcore/vqa,Graphcore/vqa-lxmert,echarlaix/gqa-lxmert,echarlaix/vqa,echarlaix/vqa-lxmert,KakologArchives/KakologArchives,open-llm-leaderboard/*"
+  blockedDatasets: "Graphcore/gqa,Graphcore/gqa-lxmert,Graphcore/vqa,Graphcore/vqa-lxmert,echarlaix/gqa-lxmert,echarlaix/vqa,echarlaix/vqa-lxmert,KakologArchives/KakologArchives,open-llm-leaderboard/*,CyberHarem/*"
   supportedDatasets: ""
   noMaxSizeLimitDatasets: "Open-Orca/OpenOrca"
 


### PR DESCRIPTION
Re-appyling https://github.com/huggingface/datasets-server/pull/1791 since the author didn't add the NFAA tag

This will disable the preview for all the future datasets.
I'll also delete the cached previews for the existing datasets from this namespace.

cc @giadilli 