### PR TITLE
Validate job runner

### DIFF
--- a/services/worker/src/worker/job_manager.py
+++ b/services/worker/src/worker/job_manager.py
@@ -105,6 +105,7 @@ class JobManager:
 
     def run_job(self) -> JobResult:
         try:
+            self.job_runner.validate()
             job_result: JobResult = self.process()
         except Exception:
             job_result = {

--- a/services/worker/src/worker/job_runner.py
+++ b/services/worker/src/worker/job_runner.py
@@ -46,3 +46,10 @@ class JobRunner(ABC):
     def post_compute(self) -> None:
         """Hook method called after the compute method."""
         pass
+
+    def validate(self) -> None:
+        """
+        Validate that this job should be run.
+        It should raise an error if e.g. the config/split of the dataset to process doesn't exist.
+        """
+        pass

--- a/services/worker/src/worker/job_runners/config/config_job_runner.py
+++ b/services/worker/src/worker/job_runners/config/config_job_runner.py
@@ -28,6 +28,8 @@ class ConfigJobRunner(DatasetJobRunner):
         if job_info["params"]["config"] is None:
             raise ParameterMissingError("'config' parameter is required")
         self.config = job_info["params"]["config"]
+
+    def validate(self) -> None:
         check_config_exists(dataset=self.dataset, config=self.config)
 
 

--- a/services/worker/src/worker/job_runners/split/split_job_runner.py
+++ b/services/worker/src/worker/job_runners/split/split_job_runner.py
@@ -29,6 +29,8 @@ class SplitJobRunner(ConfigJobRunner):
         if job_info["params"]["split"] is None:
             raise ParameterMissingError("'split' parameter is required")
         self.split = job_info["params"]["split"]
+
+    def validate(self) -> None:
         check_split_exists(dataset=self.dataset, config=self.config, split=self.split)
 
 

--- a/services/worker/tests/job_runners/config/test_config_job_runner.py
+++ b/services/worker/tests/job_runners/config/test_config_job_runner.py
@@ -51,7 +51,7 @@ def test_failed_creation(test_processing_step: ProcessingStep, app_config: AppCo
             },
             processing_step=test_processing_step,
             app_config=app_config,
-        )
+        ).validate()
     assert exc_info.value.code == "ParameterMissingError"
 
 

--- a/services/worker/tests/job_runners/config/test_config_job_runner.py
+++ b/services/worker/tests/job_runners/config/test_config_job_runner.py
@@ -78,25 +78,22 @@ def test_creation(
     )
 
     if exception_name is None:
-        assert (
-            DummyConfigJobRunner(
-                job_info={
-                    "job_id": "job_id",
-                    "type": test_processing_step.job_type,
-                    "params": {
-                        "dataset": dataset,
-                        "revision": "revision",
-                        "config": config,
-                        "split": None,
-                    },
-                    "priority": Priority.NORMAL,
-                    "difficulty": 50,
+        DummyConfigJobRunner(
+            job_info={
+                "job_id": "job_id",
+                "type": test_processing_step.job_type,
+                "params": {
+                    "dataset": dataset,
+                    "revision": "revision",
+                    "config": config,
+                    "split": None,
                 },
-                processing_step=test_processing_step,
-                app_config=app_config,
-            )
-            is not None
-        )
+                "priority": Priority.NORMAL,
+                "difficulty": 50,
+            },
+            processing_step=test_processing_step,
+            app_config=app_config,
+        ).validate()
     else:
         with pytest.raises(CustomError) as exc_info:
             DummyConfigJobRunner(
@@ -114,5 +111,5 @@ def test_creation(
                 },
                 processing_step=test_processing_step,
                 app_config=app_config,
-            )
+            ).validate()
         assert exc_info.value.code == exception_name

--- a/services/worker/tests/job_runners/split/test_first_rows_from_streaming.py
+++ b/services/worker/tests/job_runners/split/test_first_rows_from_streaming.py
@@ -168,10 +168,12 @@ def test_number_rows(
     )
 
     if exception_name is None:
+        job_runner.validate()
         result = job_runner.compute().content
         assert result == expected_first_rows_response
     else:
         with pytest.raises(Exception) as exc_info:
+            job_runner.validate()
             job_runner.compute()
         assert exc_info.typename == exception_name
 

--- a/services/worker/tests/job_runners/split/test_split_job_runner.py
+++ b/services/worker/tests/job_runners/split/test_split_job_runner.py
@@ -96,25 +96,22 @@ def test_creation(
     )
 
     if exception_name is None:
-        assert (
-            DummySplitJobRunner(
-                job_info={
-                    "job_id": "job_id",
-                    "type": test_processing_step.job_type,
-                    "params": {
-                        "dataset": dataset,
-                        "revision": "revision",
-                        "config": config,
-                        "split": split,
-                    },
-                    "priority": Priority.NORMAL,
-                    "difficulty": 50,
+        DummySplitJobRunner(
+            job_info={
+                "job_id": "job_id",
+                "type": test_processing_step.job_type,
+                "params": {
+                    "dataset": dataset,
+                    "revision": "revision",
+                    "config": config,
+                    "split": split,
                 },
-                processing_step=test_processing_step,
-                app_config=app_config,
-            )
-            is not None
-        )
+                "priority": Priority.NORMAL,
+                "difficulty": 50,
+            },
+            processing_step=test_processing_step,
+            app_config=app_config,
+        ).validate()
     else:
         with pytest.raises(CustomError) as exc_info:
             DummySplitJobRunner(
@@ -132,5 +129,5 @@ def test_creation(
                 },
                 processing_step=test_processing_step,
                 app_config=app_config,
-            )
+            ).validate()
         assert exc_info.value.code == exception_name

--- a/services/worker/tests/job_runners/split/test_split_job_runner.py
+++ b/services/worker/tests/job_runners/split/test_split_job_runner.py
@@ -59,7 +59,7 @@ def test_failed_creation(test_processing_step: ProcessingStep, app_config: AppCo
             },
             processing_step=test_processing_step,
             app_config=app_config,
-        )
+        ).validate()
     assert exc_info.value.code == "ParameterMissingError"
 
 


### PR DESCRIPTION
We should be able to create an invalid job runners (e.g. for tests but most importantly because we need to do it to kill zombie jobs). Therefore I moved the check_config_exists() validation check to a dedicated `.validate()` method that is called only when the job will be run.

This should fix the kill_zombies failures that make all our workers crash in loop now.