### PR TITLE
Fix empty datasets

### DIFF
--- a/services/worker/src/worker/job_runners/config/size.py
+++ b/services/worker/src/worker/job_runners/config/size.py
@@ -55,8 +55,8 @@ def compute_config_size_response(dataset: str, config: str) -> ConfigSizeRespons
                     for x in content["parquet_files"]
                     if x["config"] == config and x["split"] == split_info["name"]
                 ),
-                "num_bytes_memory": split_info["num_bytes"],
-                "num_rows": split_info["num_examples"],
+                "num_bytes_memory": split_info["num_bytes"] if "num_bytes" in split_info else 0,
+                "num_rows": split_info["num_examples"] if "num_examples" in split_info else 0,
                 "num_columns": num_columns,
             }
             for split_info in config_info["splits"].values()
@@ -67,9 +67,7 @@ def compute_config_size_response(dataset: str, config: str) -> ConfigSizeRespons
                 "config": config,
                 "num_bytes_original_files": config_info.get("download_size"),
                 "num_bytes_parquet_files": sum(split_size["num_bytes_parquet_files"] for split_size in split_sizes),
-                "num_bytes_memory": sum(
-                    split_size["num_bytes_memory"] for split_size in split_sizes
-                ),  # or "num_bytes_memory": config_dataset_info["dataset_size"],
+                "num_bytes_memory": sum(split_size["num_bytes_memory"] for split_size in split_sizes),
                 "num_rows": sum(split_size["num_rows"] for split_size in split_sizes),
                 "num_columns": num_columns,
             }

--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -329,7 +329,7 @@ def compute_descriptive_statistics_response(
     if not split_parquet_files:
         raise ParquetResponseEmptyError("No parquet files found.")
     features = dataset_info.get("features")
-    if not features:
+    if features is None:
         raise PreviousStepFormatError(
             f"Previous step '{config_parquet_and_info_step}' did not return the expected content: "
             "no features found in 'dataset_info'. "


### PR DESCRIPTION
Two fixes to remove the erroneous `PreviousStepFormatError` for empty datasets. See `nicaplz/autotrain-data-autogpt` for example.