### PR TITLE
Lower maxRowGroupByteSizeForCopy

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -135,7 +135,7 @@ firstRows:
 
 parquetAndInfo:
   maxDatasetSize: "5_000_000_000"
-  maxRowGroupByteSizeForCopy: "500_000_000"
+  maxRowGroupByteSizeForCopy: "300_000_000"
   # See https://observablehq.com/@huggingface/blocked-datasets
   blockedDatasets: "Graphcore/gqa,Graphcore/gqa-lxmert,Graphcore/vqa,Graphcore/vqa-lxmert,echarlaix/gqa-lxmert,echarlaix/vqa,echarlaix/vqa-lxmert,KakologArchives/KakologArchives,open-llm-leaderboard/*,CyberHarem/*"
   noMaxSizeLimitDatasets: "Open-Orca/OpenOrca"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -211,7 +211,7 @@ parquetAndInfo:
   # the maximum number of external files of the datasets. Bigger datasets, or datasets without that information, are partially streamed to get parquet files up to `maxDatasetSize` bytes.
   maxExternalDataFiles: "10_000"
   # the maximum size in bytes of the row groups of parquet datasets that are copied to the target revision. Bigger datasets, or datasets without that information, are partially streamed to get parquet files up to `maxDatasetSize` bytes.
-  maxRowGroupByteSizeForCopy: "100_000_000"
+  maxRowGroupByteSizeForCopy: "300_000_000"
   # comma-separated list of datasets that are fully converted to parquet (no partial conversion).
   noMaxSizeLimitDatasets: ""
   # the git revision of the dataset to use to prepare the parquet files. Defaults to `main`.


### PR DESCRIPTION
As proposed by @lhoestq, this PR reduces the value of `maxRowGroupByteSizeForCopy` from 500_000_000 to 300_000_000, so that it is compatible with `maxArrowDataInMemory` (300_000_000).

This should fix the `UnexpectedApiError` that we have in some full viewer pages.

Fix #1795.