### PR TITLE
remove indexable columns limitation in split-duckdb-index

### DIFF
--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -58,6 +58,9 @@ from mongodb_migration.migrations._20230703110100_cache_add_partial_field_in_con
 from mongodb_migration.migrations._20230705160600_queue_job_add_difficulty import (
     MigrationQueueAddDifficultyToJob,
 )
+from mongodb_migration.migrations._20230926095900_cache_add_has_fts_field_in_split_duckdb_index import (
+    MigrationAddHasFTSToSplitDuckdbIndexCacheResponse,
+)
 from mongodb_migration.renaming_migrations import (
     CacheRenamingMigration,
     QueueRenamingMigration,
@@ -261,5 +264,9 @@ class MigrationsCollector:
                 description="drop queue metrics collection",
                 alias=METRICS_MONGOENGINE_ALIAS,
                 collection_name=QUEUE_METRICS_COLLECTION,
+            ),
+            MigrationAddHasFTSToSplitDuckdbIndexCacheResponse(
+                version="20230926095900",
+                description="add 'has_fts' field for 'split-duckdb-index' cache records",
             ),
         ]

--- a/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230926095900_cache_add_has_fts_field_in_split_duckdb_index.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/migrations/_20230926095900_cache_add_has_fts_field_in_split_duckdb_index.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 The HuggingFace Authors.
+
+import logging
+
+from libcommon.constants import CACHE_COLLECTION_RESPONSES, CACHE_MONGOENGINE_ALIAS
+from libcommon.simple_cache import CachedResponseDocument
+from mongoengine.connection import get_db
+
+from mongodb_migration.check import check_documents
+from mongodb_migration.migration import Migration
+
+
+# connection already occurred in the main.py (caveat: we use globals)
+class MigrationAddHasFTSToSplitDuckdbIndexCacheResponse(Migration):
+    def up(self) -> None:
+        # See https://docs.mongoengine.org/guide/migration.html#example-1-addition-of-a-field
+        logging.info(
+            "If missing, add the 'has_fts' field with the default value (True) to the cached results of"
+            " split-duckdb-index"
+        )
+        db = get_db(CACHE_MONGOENGINE_ALIAS)
+        db[CACHE_COLLECTION_RESPONSES].update_many(
+            {
+                "kind": "split-duckdb-index",
+                "http_status": 200,
+                "content.has_fts": {"$exists": False},
+            },
+            {"$set": {"content.has_fts": True}},
+        )
+
+    def down(self) -> None:
+        logging.info("Remove the 'has_fts' field from all the cached results")
+        db = get_db(CACHE_MONGOENGINE_ALIAS)
+        db[CACHE_COLLECTION_RESPONSES].update_many(
+            {
+                "kind": "split-duckdb-index",
+                "http_status": 200,
+            },
+            {"$unset": {"content.has_fts": ""}},
+        )
+
+    def validate(self) -> None:
+        logging.info("Ensure that a random selection of cached results have the 'has_fts' field")
+
+        check_documents(DocCls=CachedResponseDocument, sample_size=10)

--- a/jobs/mongodb_migration/tests/migrations/test_20230926095900_cache_add_has_fts_field_in_split_duckdb_index.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20230926095900_cache_add_has_fts_field_in_split_duckdb_index.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 The HuggingFace Authors.
+from typing import Any
+
+from libcommon.constants import CACHE_COLLECTION_RESPONSES, CACHE_MONGOENGINE_ALIAS
+from libcommon.resources import MongoResource
+from mongoengine.connection import get_db
+
+from mongodb_migration.migrations._20230926095900_cache_add_has_fts_field_in_split_duckdb_index import (
+    MigrationAddHasFTSToSplitDuckdbIndexCacheResponse,
+)
+
+
+def assert_has_fts_field(dataset: str, kind: str) -> None:
+    db = get_db(CACHE_MONGOENGINE_ALIAS)
+    entry = db[CACHE_COLLECTION_RESPONSES].find_one({"dataset": dataset, "kind": kind})
+    assert entry is not None
+    assert entry["content"]["has_fts"] is True
+
+
+def assert_unchanged(dataset: str, kind: str) -> None:
+    db = get_db(CACHE_MONGOENGINE_ALIAS)
+    entry = db[CACHE_COLLECTION_RESPONSES].find_one({"dataset": dataset, "kind": kind})
+    assert entry is not None
+    assert "has_fts" not in entry["content"]
+
+
+def test_cache_add_has_fts(mongo_host: str) -> None:
+    with MongoResource(database="test_cache_add_has_fts", host=mongo_host, mongoengine_alias="cache"):
+        db = get_db(CACHE_MONGOENGINE_ALIAS)
+        cache: list[dict[str, Any]] = [
+            {
+                "config": "default",
+                "dataset": "dataset",
+                "kind": "split-duckdb-index",
+                "split": "train",
+                "content": {
+                    "dataset": "dataset",
+                    "config": "default",
+                    "split": "train",
+                    "url": "https://huggingface.co/.../index.duckdb",
+                    "filename": "index.duckdb",
+                    "size": 5038,
+                },
+                "http_status": 200,
+                "job_runner_version": 3,
+                "progress": None,
+            },
+            {
+                "config": "default",
+                "dataset": "dataset_with_error",
+                "kind": "split-duckdb-index",
+                "split": "train",
+                "content": {"error": "error"},
+                "details": {
+                    "error": "error",
+                    "cause_exception": "UnexpextedError",
+                    "cause_message": "error",
+                    "cause_traceback": ["Traceback"],
+                },
+                "error_code": "UnexpectedError",
+                "http_status": 500,
+                "job_runner_version": 3,
+                "progress": None,
+            },
+        ]
+
+        db[CACHE_COLLECTION_RESPONSES].insert_many(cache)
+
+        migration = MigrationAddHasFTSToSplitDuckdbIndexCacheResponse(
+            version="20230926095900",
+            description="add features field to split-duckdb-index",
+        )
+        migration.up()
+
+        assert_has_fts_field("dataset", kind="split-duckdb-index")
+        assert_unchanged("dataset_with_error", kind="split-duckdb-index")
+
+        migration.down()
+        assert_unchanged("dataset", kind="split-duckdb-index")
+        assert_unchanged("dataset_with_error", kind="split-duckdb-index")
+
+        db[CACHE_COLLECTION_RESPONSES].drop()

--- a/libs/libapi/src/libapi/exceptions.py
+++ b/libs/libapi/src/libapi/exceptions.py
@@ -23,6 +23,7 @@ ApiErrorCode = Literal[
     "MissingRequiredParameter",
     "ResponseNotFound",
     "ResponseNotReady",
+    "SearchFeatureNotAvailableError",
     "TransformRowsProcessingError",
     "UnexpectedApiError",
 ]
@@ -106,6 +107,13 @@ class ResponseNotReadyError(ApiError):
 
     def __init__(self, message: str):
         super().__init__(message, HTTPStatus.INTERNAL_SERVER_ERROR, "ResponseNotReady")
+
+
+class SearchFeatureNotAvailableError(ApiError):
+    """The split does not have search feature enabled."""
+
+    def __init__(self, message: str, cause: Optional[BaseException] = None):
+        super().__init__(message, HTTPStatus.BAD_REQUEST, "SearchFeatureNotAvailableError", cause, True)
 
 
 class TransformRowsProcessingError(ApiError):

--- a/libs/libcommon/src/libcommon/exceptions.py
+++ b/libs/libcommon/src/libcommon/exceptions.py
@@ -104,7 +104,6 @@ CacheableErrorCode = Literal[
     "JobManagerExceededMaximumDurationError",
     "LockedDatasetTimeoutError",
     "MissingSpawningTokenError",
-    "NoIndexableColumnsError",
     "NoSupportedFeaturesError",
     "NormalRowsError",
     "ParameterMissingError",
@@ -398,13 +397,6 @@ class NormalRowsError(CacheableError):
 
     def __init__(self, message: str, cause: Optional[BaseException] = None):
         super().__init__(message, HTTPStatus.INTERNAL_SERVER_ERROR, "NormalRowsError", cause, True)
-
-
-class NoIndexableColumnsError(CacheableError):
-    """The split does not have string columns to index."""
-
-    def __init__(self, message: str, cause: Optional[BaseException] = None):
-        super().__init__(message, HTTPStatus.NOT_IMPLEMENTED, "NoIndexableColumnsError", cause, True)
 
 
 class NoSupportedFeaturesError(CacheableError):

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -20,6 +20,7 @@ from libapi.exceptions import (
     ApiError,
     InvalidParameterError,
     MissingRequiredParameterError,
+    SearchFeatureNotAvailableError,
     UnexpectedApiError,
 )
 from libapi.utils import (
@@ -241,6 +242,8 @@ def create_search_endpoint(
                             error_code=error_code,
                             revision=revision,
                         )
+                    if content["has_fts"] is not True:
+                        raise SearchFeatureNotAvailableError("The split does not have search feature enabled.")
 
                 with StepProfiler(method="search_endpoint", step="download index file if missing"):
                     file_name = content["filename"]

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -24,7 +24,6 @@ from libcommon.exceptions import (
     DatasetNotFoundError,
     DuckDBIndexFileNotFoundError,
     LockedDatasetTimeoutError,
-    NoIndexableColumnsError,
     ParquetResponseEmptyError,
     PreviousStepFormatError,
     SplitWithTooBigParquetError,
@@ -62,6 +61,7 @@ HUB_DOWNLOAD_CACHE_FOLDER = "cache"
 
 class DuckdbIndexWithFeatures(SplitHubFile):
     features: Optional[dict[str, Any]]
+    has_fts: bool
 
 
 def get_indexable_columns(features: Features) -> list[str]:
@@ -137,8 +137,6 @@ def compute_index_rows(
         indexable_columns = ",".join(
             '"' + column + '"' for column in get_indexable_columns(Features.from_dict(copy.deepcopy(features)))
         )
-        if not indexable_columns:
-            raise NoIndexableColumnsError("No string columns available to index.")
 
     except KeyError as e:
         raise PreviousStepFormatError(
@@ -180,11 +178,13 @@ def compute_index_rows(
     logging.debug(create_command_sql)
     con.sql(create_command_sql)
 
-    # TODO: by default, 'porter' stemmer is being used, use a specific one by dataset language in the future
-    # see https://duckdb.org/docs/extensions/full_text_search.html for more details about 'stemmer' parameter
-    create_index_sql = CREATE_INDEX_COMMAND.format(columns=indexable_columns)
-    logging.debug(create_index_sql)
-    con.sql(create_index_sql)
+    is_indexable = len(indexable_columns) > 0
+    if is_indexable:
+        # TODO: by default, 'porter' stemmer is being used, use a specific one by dataset language in the future
+        # see https://duckdb.org/docs/extensions/full_text_search.html for more details about 'stemmer' parameter
+        create_index_sql = CREATE_INDEX_COMMAND.format(columns=indexable_columns)
+        logging.debug(create_index_sql)
+        con.sql(create_index_sql)
     con.close()
 
     hf_api = HfApi(endpoint=hf_endpoint, token=hf_token)
@@ -279,6 +279,7 @@ def compute_index_rows(
         filename=Path(repo_file.rfilename).name,
         size=repo_file.size,
         features=features,
+        has_fts=is_indexable,
     )
 
 

--- a/services/worker/src/worker/job_runners/split/is_valid.py
+++ b/services/worker/src/worker/job_runners/split/is_valid.py
@@ -5,7 +5,10 @@ import logging
 
 from libcommon.constants import PROCESSING_STEP_SPLIT_IS_VALID_VERSION
 from libcommon.processing_graph import ProcessingGraph, ProcessingStep
-from libcommon.simple_cache import has_any_successful_response
+from libcommon.simple_cache import (
+    get_previous_step_or_raise,
+    has_any_successful_response,
+)
 from libcommon.utils import JobInfo
 
 from worker.config import AppConfig
@@ -50,12 +53,19 @@ def compute_is_valid_response(
         split=split,
         kinds=[step.cache_kind for step in processing_graph.get_processing_steps_enables_preview()],
     )
-    search = has_any_successful_response(
-        dataset=dataset,
-        config=config,
-        split=split,
-        kinds=[step.cache_kind for step in processing_graph.get_processing_steps_enables_search()],
-    )
+
+    try:
+        duckdb_response = get_previous_step_or_raise(
+            kinds=["split-duckdb-index"],
+            dataset=dataset,
+            config=config,
+            split=split,
+        )
+        search_content = duckdb_response.response["content"]
+        search = search_content["has_fts"]
+    except:
+        search = False
+
     return IsValidResponse(viewer=viewer, preview=preview, search=search)
 
 

--- a/services/worker/src/worker/job_runners/split/is_valid.py
+++ b/services/worker/src/worker/job_runners/split/is_valid.py
@@ -63,7 +63,7 @@ def compute_is_valid_response(
         )
         search_content = duckdb_response.response["content"]
         search = search_content["has_fts"]
-    except:
+    except Exception:
         search = False
 
     return IsValidResponse(viewer=viewer, preview=preview, search=search)

--- a/services/worker/tests/job_runners/split/test_is_valid.py
+++ b/services/worker/tests/job_runners/split/test_is_valid.py
@@ -54,7 +54,15 @@ UPSTREAM_RESPONSE_SPLIT_DUCKDB_INDEX: UpstreamResponse = UpstreamResponse(
     config=CONFIG,
     split=SPLIT,
     http_status=HTTPStatus.OK,
-    content={},
+    content={"has_fts": True},
+)
+UPSTREAM_RESPONSE_SPLIT_DUCKDB_INDEX_ONLY_DATA: UpstreamResponse = UpstreamResponse(
+    kind="split-duckdb-index",
+    dataset=DATASET,
+    config=CONFIG,
+    split=SPLIT,
+    http_status=HTTPStatus.OK,
+    content={"has_fts": False},
 )
 UPSTREAM_RESPONSE_CONFIG_SIZE_ERROR: UpstreamResponse = UpstreamResponse(
     kind="config-size", dataset=DATASET, config=CONFIG, http_status=HTTPStatus.INTERNAL_SERVER_ERROR, content={}
@@ -210,6 +218,12 @@ def get_job_runner(
                 UPSTREAM_RESPONSE_SPLIT_DUCKDB_INDEX,
             ],
             EXPECTED_SEARCH_OK,
+        ),
+        (
+            [
+                UPSTREAM_RESPONSE_SPLIT_DUCKDB_INDEX_ONLY_DATA,
+            ],
+            EXPECTED_ERROR,
         ),
         (
             [


### PR DESCRIPTION
Needed for https://github.com/huggingface/datasets-server/pull/1418
Option 1: Since we need all the split datasets with the duckdb file for /filter, I propose just removing the limitation in the job runner as a noninvasive change.

Pending:

- [X] update tests
- [X] migration to add default field as has_fts=True for the existing cache records with status 200 


~~Option 2:~~
~~As an alternative, I think we could split the tasks into two separate runners:~~
~~- split-duckdb-data: in charge of data ingestion for the duckdb file only.~~
~~- split-duck-index: in charge of indexing the existing table only if indexable columns exist (might need to first download the previous one and generate a new one + the index).~~
~~But there could be open questions: Will we keep only one file in the repo? Should we have two separate files in the repo? (one for data and another for data+index)?~~