### PR TITLE
feat(chart): remove external dns for staging env

### DIFF
--- a/chart/env/staging.yaml
+++ b/chart/env/staging.yaml
@@ -216,7 +216,6 @@ ingress:
         - "datasets-server.us.dev.moon.huggingface.tech"
   annotations:
     # Link to Route53 - we could set any subdomain to us.dev.moon.huggingface.tech (common zone to the k8s cluster)
-    external-dns.alpha.kubernetes.io/hostname: "datasets-server.us.dev.moon.huggingface.tech"
     alb.ingress.kubernetes.io/load-balancer-name: "hub-datasets-server-staging"
     alb.ingress.kubernetes.io/tags: "Env=staging,Project=datasets-server,Terraform=true"
     alb.ingress.kubernetes.io/healthcheck-path: "/healthcheck"


### PR DESCRIPTION
We are now using Cloudfront to serve it, and expose assets from S3