### PR TITLE
fix: remove file in cached-assets even if not uploaded

### DIFF
--- a/libs/libcommon/src/libcommon/viewer_utils/asset.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/asset.py
@@ -103,8 +103,6 @@ def upload_asset_file(
         object_key = f"{s3_folder_name}/{url_dir_path}/{filename}"
         if overwrite or not s3_client.exists(object_key):
             s3_client.upload(str(file_path), object_key)
-            logging.debug(f"{object_key=} has been uploaded")
-            os.remove(file_path)
 
 
 def create_asset_file(
@@ -154,6 +152,7 @@ def create_asset_file(
             s3_client=s3_client,
             s3_folder_name=s3_folder_name,
         )
+        os.remove(file_path)
 
     return asset_file
 

--- a/libs/libcommon/tests/viewer_utils/test_assets.py
+++ b/libs/libcommon/tests/viewer_utils/test_assets.py
@@ -1,4 +1,5 @@
 import io
+import os
 from collections.abc import Mapping
 from io import BytesIO
 
@@ -15,6 +16,8 @@ from libcommon.viewer_utils.asset import create_audio_file, create_image_file
 
 
 def test_create_image_file_with_s3_storage(datasets: Mapping[str, Dataset], cached_assets_directory: StrPath) -> None:
+    # ensure directory is emtpy
+    assert len(os.listdir(cached_assets_directory)) == 0
     dataset = datasets["image"]
     with mock_s3():
         bucket_name = "bucket"
@@ -59,6 +62,8 @@ def test_create_image_file_with_s3_storage(datasets: Mapping[str, Dataset], cach
 
         image = PILImage.open(io.BytesIO(body))
         assert image is not None
+    # ensure directory remains emtpy after file uploading
+    assert len(os.listdir(cached_assets_directory)) == 0
 
 
 def test_create_audio_file_with_s3_storage(datasets: Mapping[str, Dataset], cached_assets_directory: StrPath) -> None:


### PR DESCRIPTION
Local files remain in local cached-assets when they already exist on the bucket, we should remove them anyway.
I will improve the logic in another PR: create files ONLY when they don't exist on the bucket.

 