### PR TITLE
Fix zipped audio extension in streaming

### DIFF
--- a/libs/libcommon/src/libcommon/viewer_utils/features.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/features.py
@@ -114,7 +114,8 @@ def audio(
         )
 
     if "path" in value and isinstance(value["path"], str):
-        audio_file_extension = os.path.splitext(value["path"])[1]
+        # .split("::")[0] for chained URLs like zip://audio.wav::https://foo.bar/data.zip
+        audio_file_extension = os.path.splitext(value["path"].split("::")[0])[1]
         if not audio_file_extension:
             raise ValueError(
                 f"An audio sample should have a 'path' with a valid extension but got '{audio_file_extension}'."


### PR DESCRIPTION
The audio file extension was not inferred correctly when we stream the first rows.

Indeed in some cases the audio file path can be

```
zip://audio.wav::https://foo.bar/data.zip
```

fix https://huggingface.co/datasets/ccmusic-database/acapella_eval/discussions/3