### PR TITLE
Delete unnecessary condition on expected_error_code

### DIFF
--- a/e2e/tests/test_11_api.py
+++ b/e2e/tests/test_11_api.py
@@ -68,8 +68,6 @@ def test_endpoint(
     input_type: Literal["all", "dataset", "config", "split"],
 ) -> None:
     auth: AuthType = "none"
-    expected_status_code: int = 200
-    expected_error_code = None
     # TODO: add dataset with various splits, or various configs
     dataset = hf_public_dataset_repo_csv_data
     config, split = get_default_config_split()
@@ -86,8 +84,8 @@ def test_endpoint(
 
     poll_until_ready_and_assert(
         relative_url=relative_url,
-        expected_status_code=expected_status_code,
-        expected_error_code=expected_error_code,
+        expected_status_code=200,
+        expected_error_code=None,
         headers=headers,
         check_x_revision=input_type != "all",
     )

--- a/e2e/tests/test_11_api.py
+++ b/e2e/tests/test_11_api.py
@@ -98,8 +98,6 @@ def test_rows_endpoint(
     hf_public_dataset_repo_csv_data: str,
 ) -> None:
     auth: AuthType = "none"
-    expected_status_code: int = 200
-    expected_error_code = None
     # TODO: add dataset with various splits, or various configs
     dataset = hf_public_dataset_repo_csv_data
     config, split = get_default_config_split()
@@ -109,31 +107,30 @@ def test_rows_endpoint(
     length = 10
     rows_response = poll_until_ready_and_assert(
         relative_url=f"/rows?dataset={dataset}&config={config}&split={split}&offset={offset}&length={length}",
-        expected_status_code=expected_status_code,
-        expected_error_code=expected_error_code,
+        expected_status_code=200,
+        expected_error_code=None,
         headers=headers,
         check_x_revision=True,
     )
-    if not expected_error_code:
-        content = rows_response.json()
-        assert "rows" in content, rows_response
-        assert "features" in content, rows_response
-        rows = content["rows"]
-        features = content["features"]
-        assert isinstance(rows, list), rows
-        assert isinstance(features, list), features
-        assert len(rows) == 3, rows
-        assert rows[0] == {
-            "row_idx": 1,
-            "row": {
-                "col_1": "Vader turns round and round in circles as his ship spins into space.",
-                "col_2": 1,
-                "col_3": 1.0,
-            },
-            "truncated_cells": [],
-        }, rows[0]
-        assert features == [
-            {"feature_idx": 0, "name": "col_1", "type": {"dtype": "string", "_type": "Value"}},
-            {"feature_idx": 1, "name": "col_2", "type": {"dtype": "int64", "_type": "Value"}},
-            {"feature_idx": 2, "name": "col_3", "type": {"dtype": "float64", "_type": "Value"}},
-        ], features
+    content = rows_response.json()
+    assert "rows" in content, rows_response
+    assert "features" in content, rows_response
+    rows = content["rows"]
+    features = content["features"]
+    assert isinstance(rows, list), rows
+    assert isinstance(features, list), features
+    assert len(rows) == 3, rows
+    assert rows[0] == {
+        "row_idx": 1,
+        "row": {
+            "col_1": "Vader turns round and round in circles as his ship spins into space.",
+            "col_2": 1,
+            "col_3": 1.0,
+        },
+        "truncated_cells": [],
+    }, rows[0]
+    assert features == [
+        {"feature_idx": 0, "name": "col_1", "type": {"dtype": "string", "_type": "Value"}},
+        {"feature_idx": 1, "name": "col_2", "type": {"dtype": "int64", "_type": "Value"}},
+        {"feature_idx": 2, "name": "col_3", "type": {"dtype": "float64", "_type": "Value"}},
+    ], features

--- a/e2e/tests/test_11_api.py
+++ b/e2e/tests/test_11_api.py
@@ -84,8 +84,6 @@ def test_endpoint(
 
     poll_until_ready_and_assert(
         relative_url=relative_url,
-        expected_status_code=200,
-        expected_error_code=None,
         headers=headers,
         check_x_revision=input_type != "all",
     )
@@ -105,8 +103,6 @@ def test_rows_endpoint(
     length = 10
     rows_response = poll_until_ready_and_assert(
         relative_url=f"/rows?dataset={dataset}&config={config}&split={split}&offset={offset}&length={length}",
-        expected_status_code=200,
-        expected_error_code=None,
         headers=headers,
         check_x_revision=True,
     )

--- a/e2e/tests/test_14_statistics.py
+++ b/e2e/tests/test_14_statistics.py
@@ -16,8 +16,6 @@ def test_statistics_endpoint(
     headers = auth_headers[auth]
     statistics_response = poll_until_ready_and_assert(
         relative_url=f"/statistics?dataset={dataset}&config={config}&split={split}",
-        expected_status_code=200,
-        expected_error_code=None,
         headers=headers,
         check_x_revision=True,
     )

--- a/e2e/tests/test_14_statistics.py
+++ b/e2e/tests/test_14_statistics.py
@@ -10,16 +10,14 @@ def test_statistics_endpoint(
     hf_public_dataset_repo_csv_data: str,
 ) -> None:
     auth: AuthType = "none"
-    expected_status_code: int = 200
-    expected_error_code = None
     # TODO: add dataset with various splits, or various configs
     dataset = hf_public_dataset_repo_csv_data
     config, split = get_default_config_split()
     headers = auth_headers[auth]
     statistics_response = poll_until_ready_and_assert(
         relative_url=f"/statistics?dataset={dataset}&config={config}&split={split}",
-        expected_status_code=expected_status_code,
-        expected_error_code=expected_error_code,
+        expected_status_code=200,
+        expected_error_code=None,
         headers=headers,
         check_x_revision=True,
     )

--- a/e2e/tests/test_52_search.py
+++ b/e2e/tests/test_52_search.py
@@ -22,8 +22,6 @@ def test_search_endpoint(
         relative_url=(
             f"/search?dataset={dataset}&config={config}&split={split}&offset={offset}&length={length}&query={query}"
         ),
-        expected_status_code=200,
-        expected_error_code=None,
         headers=headers,
         check_x_revision=True,
     )

--- a/e2e/tests/test_52_search.py
+++ b/e2e/tests/test_52_search.py
@@ -10,8 +10,6 @@ def test_search_endpoint(
     hf_public_dataset_repo_csv_data: str,
 ) -> None:
     auth: AuthType = "none"
-    expected_status_code: int = 200
-    expected_error_code = None
     # TODO: add dataset with various splits, or various configs
     dataset = hf_public_dataset_repo_csv_data
     config, split = get_default_config_split()
@@ -24,41 +22,40 @@ def test_search_endpoint(
         relative_url=(
             f"/search?dataset={dataset}&config={config}&split={split}&offset={offset}&length={length}&query={query}"
         ),
-        expected_status_code=expected_status_code,
-        expected_error_code=expected_error_code,
+        expected_status_code=200,
+        expected_error_code=None,
         headers=headers,
         check_x_revision=True,
     )
-    if not expected_error_code:
-        content = search_response.json()
-        assert "rows" in content, search_response
-        assert "features" in content, search_response
-        assert "num_rows_total" in content, search_response
-        assert "num_rows_per_page" in content, search_response
-        rows = content["rows"]
-        features = content["features"]
-        num_rows_total = content["num_rows_total"]
-        num_rows_per_page = content["num_rows_per_page"]
-        assert isinstance(rows, list), rows
-        assert isinstance(features, list), features
-        assert num_rows_total == 3
-        assert num_rows_per_page == 100
-        assert rows[0] == {
-            "row_idx": 2,
-            "row": {"col_1": "We count thirty Rebel ships, Lord Vader.", "col_2": 2, "col_3": 2.0},
-            "truncated_cells": [],
-        }, rows[0]
-        assert rows[1] == {
-            "row_idx": 3,
-            "row": {
-                "col_1": "The wingman spots the pirateship coming at him and warns the Dark Lord",
-                "col_2": 3,
-                "col_3": 3.0,
-            },
-            "truncated_cells": [],
-        }, rows[1]
-        assert features == [
-            {"feature_idx": 0, "name": "col_1", "type": {"dtype": "string", "_type": "Value"}},
-            {"feature_idx": 1, "name": "col_2", "type": {"dtype": "int64", "_type": "Value"}},
-            {"feature_idx": 2, "name": "col_3", "type": {"dtype": "float64", "_type": "Value"}},
-        ], features
+    content = search_response.json()
+    assert "rows" in content, search_response
+    assert "features" in content, search_response
+    assert "num_rows_total" in content, search_response
+    assert "num_rows_per_page" in content, search_response
+    rows = content["rows"]
+    features = content["features"]
+    num_rows_total = content["num_rows_total"]
+    num_rows_per_page = content["num_rows_per_page"]
+    assert isinstance(rows, list), rows
+    assert isinstance(features, list), features
+    assert num_rows_total == 3
+    assert num_rows_per_page == 100
+    assert rows[0] == {
+        "row_idx": 2,
+        "row": {"col_1": "We count thirty Rebel ships, Lord Vader.", "col_2": 2, "col_3": 2.0},
+        "truncated_cells": [],
+    }, rows[0]
+    assert rows[1] == {
+        "row_idx": 3,
+        "row": {
+            "col_1": "The wingman spots the pirateship coming at him and warns the Dark Lord",
+            "col_2": 3,
+            "col_3": 3.0,
+        },
+        "truncated_cells": [],
+    }, rows[1]
+    assert features == [
+        {"feature_idx": 0, "name": "col_1", "type": {"dtype": "string", "_type": "Value"}},
+        {"feature_idx": 1, "name": "col_2", "type": {"dtype": "int64", "_type": "Value"}},
+        {"feature_idx": 2, "name": "col_3", "type": {"dtype": "float64", "_type": "Value"}},
+    ], features

--- a/e2e/tests/utils.py
+++ b/e2e/tests/utils.py
@@ -155,8 +155,8 @@ def log(response: Response, url: str = URL, relative_url: Optional[str] = None, 
 
 def poll_until_ready_and_assert(
     relative_url: str,
-    expected_status_code: int,
-    expected_error_code: Optional[str],
+    expected_status_code: int = 200,
+    expected_error_code: Optional[str] = None,
     headers: Optional[Headers] = None,
     url: str = URL,
     check_x_revision: bool = False,


### PR DESCRIPTION
As reported by @AndreaFrancis (see: https://github.com/huggingface/datasets-server/pull/1418#discussion_r1340621923), the condition on `expected_error_code` can be removed because it equals `None`.