### PR TITLE
Increase heavy workers ram

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -391,10 +391,10 @@ workers:
     resources:
       requests:
         cpu: 2
-        memory: "29Gi"
+        memory: "34Gi"
       limits:
         cpu: 2
-        memory: "29Gi"
+        memory: "34Gi"
     tolerations: []
   - deployName: "medium"
     workerDifficultyMax: 70


### PR DESCRIPTION
With 29GB it still OOMs on some mC4 configs like `af`