### PR TITLE
Factorize getting the request parameters length and offset

### DIFF
--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -2868,7 +2868,7 @@
                   "negative-offset": {
                     "summary": "The offset must be positive.",
                     "value": {
-                      "error": "Offset must be positive"
+                      "error": "Parameter 'offset' must be positive"
                     }
                   },
                   "negative-length": {
@@ -3227,7 +3227,7 @@
                   "negative-offset": {
                     "summary": "The offset must be positive.",
                     "value": {
-                      "error": "Offset must be positive"
+                      "error": "Parameter 'offset' must be positive"
                     }
                   },
                   "negative-length": {

--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -2876,6 +2876,12 @@
                     "value": {
                       "error": "Parameter 'length' must be positive"
                     }
+                  },
+                  "too-large-length": {
+                    "summary": "The length must not be too large.",
+                    "value": {
+                      "error": "Parameter 'length' must not be greater than 100"
+                    }
                   }
                 }
               }
@@ -3234,6 +3240,12 @@
                     "summary": "The length must be positive.",
                     "value": {
                       "error": "Parameter 'length' must be positive"
+                    }
+                  },
+                  "too-large-length": {
+                    "summary": "The length must not be too large.",
+                    "value": {
+                      "error": "Parameter 'length' must not be greater than 100"
                     }
                   }
                 }
@@ -3838,6 +3850,12 @@
                     "summary": "The length must be positive.",
                     "value": {
                       "error": "Parameter 'length' must be positive"
+                    }
+                  },
+                  "too-large-length": {
+                    "summary": "The length must not be too large.",
+                    "value": {
+                      "error": "Parameter 'length' must not be greater than 100"
                     }
                   }
                 }

--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -2874,7 +2874,7 @@
                   "negative-length": {
                     "summary": "The length must be positive.",
                     "value": {
-                      "error": "Length must be positive"
+                      "error": "Parameter 'length' must be positive"
                     }
                   }
                 }
@@ -3233,7 +3233,7 @@
                   "negative-length": {
                     "summary": "The length must be positive.",
                     "value": {
-                      "error": "Length must be positive"
+                      "error": "Parameter 'length' must be positive"
                     }
                   }
                 }

--- a/libs/libapi/src/libapi/request.py
+++ b/libs/libapi/src/libapi/request.py
@@ -1,0 +1,10 @@
+from starlette.requests import Request
+
+from libapi.exceptions import InvalidParameterError
+
+
+def get_request_parameter_offset(request: Request) -> int:
+    offset = int(request.query_params.get("offset", 0))
+    if offset < 0:
+        raise InvalidParameterError(message="Parameter 'offset' must be positive")
+    return offset

--- a/libs/libapi/src/libapi/request.py
+++ b/libs/libapi/src/libapi/request.py
@@ -1,6 +1,16 @@
+from libcommon.utils import MAX_NUM_ROWS_PER_PAGE
 from starlette.requests import Request
 
 from libapi.exceptions import InvalidParameterError
+
+
+def get_request_parameter_length(request: Request) -> int:
+    length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
+    if length < 0:
+        raise InvalidParameterError("Parameter 'length' must be positive")
+    elif length > MAX_NUM_ROWS_PER_PAGE:
+        raise InvalidParameterError(f"Parameter 'length' must not be greater than {MAX_NUM_ROWS_PER_PAGE}")
+    return length
 
 
 def get_request_parameter_offset(request: Request) -> int:

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -196,7 +196,7 @@ def create_rows_endpoint(
 def get_request_parameter_length(request: Request) -> int:
     length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
     if length < 0:
-        raise InvalidParameterError("Length must be positive")
+        raise InvalidParameterError("Parameter 'length' must be positive")
     if length > MAX_NUM_ROWS_PER_PAGE:
-        raise InvalidParameterError(f"Parameter 'length' must not be bigger than {MAX_NUM_ROWS_PER_PAGE}")
+        raise InvalidParameterError(f"Parameter 'length' must not be greater than {MAX_NUM_ROWS_PER_PAGE}")
     return length

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -13,6 +13,7 @@ from libapi.exceptions import (
     MissingRequiredParameterError,
     UnexpectedApiError,
 )
+from libapi.request import get_request_parameter_offset
 from libapi.response import create_response
 from libapi.utils import (
     Endpoint,
@@ -196,10 +197,3 @@ def create_rows_endpoint(
                     return get_json_api_error_response(error=error, max_age=max_age_short, revision=revision)
 
     return rows_endpoint
-
-
-def get_request_parameter_offset(request):
-    offset = int(request.query_params.get("offset", 0))
-    if offset < 0:
-        raise InvalidParameterError(message="Parameter 'offset' must be positive")
-    return offset

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -85,9 +85,7 @@ def create_rows_endpoint(
                     split = request.query_params.get("split")
                     if not dataset or not config or not split or not are_valid_parameters([dataset, config, split]):
                         raise MissingRequiredParameterError("Parameter 'dataset', 'config' and 'split' are required")
-                    offset = int(request.query_params.get("offset", 0))
-                    if offset < 0:
-                        raise InvalidParameterError(message="Offset must be positive")
+                    offset = get_request_parameter_offset(request)
                     length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
                     if length < 0:
                         raise InvalidParameterError("Length must be positive")
@@ -198,3 +196,10 @@ def create_rows_endpoint(
                     return get_json_api_error_response(error=error, max_age=max_age_short, revision=revision)
 
     return rows_endpoint
+
+
+def get_request_parameter_offset(request):
+    offset = int(request.query_params.get("offset", 0))
+    if offset < 0:
+        raise InvalidParameterError(message="Offset must be positive")
+    return offset

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -9,11 +9,10 @@ from fsspec.implementations.http import HTTPFileSystem
 from libapi.authentication import auth_check
 from libapi.exceptions import (
     ApiError,
-    InvalidParameterError,
     MissingRequiredParameterError,
     UnexpectedApiError,
 )
-from libapi.request import get_request_parameter_offset
+from libapi.request import get_request_parameter_length, get_request_parameter_offset
 from libapi.response import create_response
 from libapi.utils import (
     Endpoint,
@@ -30,7 +29,6 @@ from libcommon.prometheus import StepProfiler
 from libcommon.s3_client import S3Client
 from libcommon.simple_cache import CachedArtifactError, CachedArtifactNotFoundError
 from libcommon.storage import StrPath
-from libcommon.utils import MAX_NUM_ROWS_PER_PAGE
 from libcommon.viewer_utils.asset import update_last_modified_date_of_rows_in_assets_dir
 from libcommon.viewer_utils.features import UNSUPPORTED_FEATURES
 from starlette.requests import Request
@@ -191,12 +189,3 @@ def create_rows_endpoint(
                     return get_json_api_error_response(error=error, max_age=max_age_short, revision=revision)
 
     return rows_endpoint
-
-
-def get_request_parameter_length(request: Request) -> int:
-    length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
-    if length < 0:
-        raise InvalidParameterError("Parameter 'length' must be positive")
-    if length > MAX_NUM_ROWS_PER_PAGE:
-        raise InvalidParameterError(f"Parameter 'length' must not be greater than {MAX_NUM_ROWS_PER_PAGE}")
-    return length

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -201,5 +201,5 @@ def create_rows_endpoint(
 def get_request_parameter_offset(request):
     offset = int(request.query_params.get("offset", 0))
     if offset < 0:
-        raise InvalidParameterError(message="Offset must be positive")
+        raise InvalidParameterError(message="Parameter 'offset' must be positive")
     return offset

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -87,13 +87,7 @@ def create_rows_endpoint(
                     if not dataset or not config or not split or not are_valid_parameters([dataset, config, split]):
                         raise MissingRequiredParameterError("Parameter 'dataset', 'config' and 'split' are required")
                     offset = get_request_parameter_offset(request)
-                    length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
-                    if length < 0:
-                        raise InvalidParameterError("Length must be positive")
-                    if length > MAX_NUM_ROWS_PER_PAGE:
-                        raise InvalidParameterError(
-                            f"Parameter 'length' must not be bigger than {MAX_NUM_ROWS_PER_PAGE}"
-                        )
+                    length = get_request_parameter_length(request)
                     logging.info(
                         f"/rows, dataset={dataset}, config={config}, split={split}, offset={offset}, length={length}"
                     )
@@ -197,3 +191,12 @@ def create_rows_endpoint(
                     return get_json_api_error_response(error=error, max_age=max_age_short, revision=revision)
 
     return rows_endpoint
+
+
+def get_request_parameter_length(request: Request) -> int:
+    length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
+    if length < 0:
+        raise InvalidParameterError("Length must be positive")
+    if length > MAX_NUM_ROWS_PER_PAGE:
+        raise InvalidParameterError(f"Parameter 'length' must not be bigger than {MAX_NUM_ROWS_PER_PAGE}")
+    return length

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -102,13 +102,7 @@ def create_filter_endpoint(
                         )
                     validate_where_parameter(where)
                     offset = get_request_parameter_offset(request)
-                    length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
-                    if length < 0:
-                        raise InvalidParameterError("Parameter 'length' must be positive")
-                    elif length > MAX_NUM_ROWS_PER_PAGE:
-                        raise InvalidParameterError(
-                            f"Parameter 'length' must not be bigger than {MAX_NUM_ROWS_PER_PAGE}"
-                        )
+                    length = get_request_parameter_length(request)
                     logger.info(
                         f'/filter, dataset={dataset}, config={config}, split={split}, where="{where}",'
                         f" offset={offset}, length={length}"
@@ -235,3 +229,12 @@ def execute_filter_query(
 def validate_where_parameter(where: str) -> None:
     if SQL_INVALID_SYMBOLS_PATTERN.search(where):
         raise InvalidParameterError(message="Parameter 'where' contains invalid symbols")
+
+
+def get_request_parameter_length(request: Request) -> int:
+    length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
+    if length < 0:
+        raise InvalidParameterError("Parameter 'length' must be positive")
+    elif length > MAX_NUM_ROWS_PER_PAGE:
+        raise InvalidParameterError(f"Parameter 'length' must not be bigger than {MAX_NUM_ROWS_PER_PAGE}")
+    return length

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -236,5 +236,5 @@ def get_request_parameter_length(request: Request) -> int:
     if length < 0:
         raise InvalidParameterError("Parameter 'length' must be positive")
     elif length > MAX_NUM_ROWS_PER_PAGE:
-        raise InvalidParameterError(f"Parameter 'length' must not be bigger than {MAX_NUM_ROWS_PER_PAGE}")
+        raise InvalidParameterError(f"Parameter 'length' must not be greater than {MAX_NUM_ROWS_PER_PAGE}")
     return length

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -20,6 +20,7 @@ from libapi.exceptions import (
     InvalidParameterError,
     MissingRequiredParameterError,
 )
+from libapi.request import get_request_parameter_offset
 from libapi.response import ROW_IDX_COLUMN, create_response
 from libapi.utils import (
     Endpoint,
@@ -234,10 +235,3 @@ def execute_filter_query(
 def validate_where_parameter(where: str) -> None:
     if SQL_INVALID_SYMBOLS_PATTERN.search(where):
         raise InvalidParameterError(message="Parameter 'where' contains invalid symbols")
-
-
-def get_request_parameter_offset(request):
-    offset = int(request.query_params.get("offset", 0))
-    if offset < 0:
-        raise InvalidParameterError(message="Parameter 'offset' must be positive")
-    return offset

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -20,7 +20,7 @@ from libapi.exceptions import (
     InvalidParameterError,
     MissingRequiredParameterError,
 )
-from libapi.request import get_request_parameter_offset
+from libapi.request import get_request_parameter_length, get_request_parameter_offset
 from libapi.response import ROW_IDX_COLUMN, create_response
 from libapi.utils import (
     Endpoint,
@@ -35,7 +35,6 @@ from libcommon.processing_graph import ProcessingGraph
 from libcommon.prometheus import StepProfiler
 from libcommon.s3_client import S3Client
 from libcommon.storage import StrPath
-from libcommon.utils import MAX_NUM_ROWS_PER_PAGE
 from libcommon.viewer_utils.features import get_supported_unsupported_columns
 from starlette.requests import Request
 from starlette.responses import Response
@@ -229,12 +228,3 @@ def execute_filter_query(
 def validate_where_parameter(where: str) -> None:
     if SQL_INVALID_SYMBOLS_PATTERN.search(where):
         raise InvalidParameterError(message="Parameter 'where' contains invalid symbols")
-
-
-def get_request_parameter_length(request: Request) -> int:
-    length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
-    if length < 0:
-        raise InvalidParameterError("Parameter 'length' must be positive")
-    elif length > MAX_NUM_ROWS_PER_PAGE:
-        raise InvalidParameterError(f"Parameter 'length' must not be greater than {MAX_NUM_ROWS_PER_PAGE}")
-    return length

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -100,9 +100,7 @@ def create_filter_endpoint(
                             "Parameters 'dataset', 'config', 'split' and 'where' are required"
                         )
                     validate_where_parameter(where)
-                    offset = int(request.query_params.get("offset", 0))
-                    if offset < 0:
-                        raise InvalidParameterError(message="Parameter 'offset' must be positive")
+                    offset = get_request_parameter_offset(request)
                     length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
                     if length < 0:
                         raise InvalidParameterError("Parameter 'length' must be positive")
@@ -236,3 +234,10 @@ def execute_filter_query(
 def validate_where_parameter(where: str) -> None:
     if SQL_INVALID_SYMBOLS_PATTERN.search(where):
         raise InvalidParameterError(message="Parameter 'where' contains invalid symbols")
+
+
+def get_request_parameter_offset(request):
+    offset = int(request.query_params.get("offset", 0))
+    if offset < 0:
+        raise InvalidParameterError(message="Parameter 'offset' must be positive")
+    return offset

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -162,9 +162,7 @@ def create_search_endpoint(
                             "Parameter 'dataset', 'config', 'split' and 'query' are required"
                         )
 
-                    offset = int(request.query_params.get("offset", 0))
-                    if offset < 0:
-                        raise InvalidParameterError(message="Offset must be positive")
+                    offset = get_request_parameter_offset(request)
 
                     length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
                     if length < 0:
@@ -269,3 +267,10 @@ def create_search_endpoint(
                     return get_json_api_error_response(error=error, max_age=max_age_short, revision=revision)
 
     return search_endpoint
+
+
+def get_request_parameter_offset(request):
+    offset = int(request.query_params.get("offset", 0))
+    if offset < 0:
+        raise InvalidParameterError(message="Offset must be positive")
+    return offset

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -272,5 +272,5 @@ def create_search_endpoint(
 def get_request_parameter_offset(request):
     offset = int(request.query_params.get("offset", 0))
     if offset < 0:
-        raise InvalidParameterError(message="Offset must be positive")
+        raise InvalidParameterError(message="Parameter 'offset' must be positive")
     return offset

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -21,6 +21,7 @@ from libapi.exceptions import (
     SearchFeatureNotAvailableError,
     UnexpectedApiError,
 )
+from libapi.request import get_request_parameter_offset
 from libapi.response import ROW_IDX_COLUMN
 from libapi.utils import (
     Endpoint,
@@ -267,10 +268,3 @@ def create_search_endpoint(
                     return get_json_api_error_response(error=error, max_age=max_age_short, revision=revision)
 
     return search_endpoint
-
-
-def get_request_parameter_offset(request):
-    offset = int(request.query_params.get("offset", 0))
-    if offset < 0:
-        raise InvalidParameterError(message="Parameter 'offset' must be positive")
-    return offset

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -165,13 +165,7 @@ def create_search_endpoint(
 
                     offset = get_request_parameter_offset(request)
 
-                    length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
-                    if length < 0:
-                        raise InvalidParameterError("Length must be positive")
-                    if length > MAX_NUM_ROWS_PER_PAGE:
-                        raise InvalidParameterError(
-                            f"Parameter 'length' must not be bigger than {MAX_NUM_ROWS_PER_PAGE}"
-                        )
+                    length = get_request_parameter_length(request)
 
                 with StepProfiler(method="search_endpoint", step="check authentication"):
                     # if auth_check fails, it will raise an exception that will be caught below
@@ -268,3 +262,12 @@ def create_search_endpoint(
                     return get_json_api_error_response(error=error, max_age=max_age_short, revision=revision)
 
     return search_endpoint
+
+
+def get_request_parameter_length(request: Request) -> int:
+    length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
+    if length < 0:
+        raise InvalidParameterError("Length must be positive")
+    if length > MAX_NUM_ROWS_PER_PAGE:
+        raise InvalidParameterError(f"Parameter 'length' must not be bigger than {MAX_NUM_ROWS_PER_PAGE}")
+    return length

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -267,7 +267,7 @@ def create_search_endpoint(
 def get_request_parameter_length(request: Request) -> int:
     length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
     if length < 0:
-        raise InvalidParameterError("Length must be positive")
+        raise InvalidParameterError("Parameter 'length' must be positive")
     if length > MAX_NUM_ROWS_PER_PAGE:
-        raise InvalidParameterError(f"Parameter 'length' must not be bigger than {MAX_NUM_ROWS_PER_PAGE}")
+        raise InvalidParameterError(f"Parameter 'length' must not be greater than {MAX_NUM_ROWS_PER_PAGE}")
     return length

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -16,12 +16,11 @@ from libapi.duckdb import (
 )
 from libapi.exceptions import (
     ApiError,
-    InvalidParameterError,
     MissingRequiredParameterError,
     SearchFeatureNotAvailableError,
     UnexpectedApiError,
 )
-from libapi.request import get_request_parameter_offset
+from libapi.request import get_request_parameter_length, get_request_parameter_offset
 from libapi.response import ROW_IDX_COLUMN
 from libapi.utils import (
     Endpoint,
@@ -262,12 +261,3 @@ def create_search_endpoint(
                     return get_json_api_error_response(error=error, max_age=max_age_short, revision=revision)
 
     return search_endpoint
-
-
-def get_request_parameter_length(request: Request) -> int:
-    length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
-    if length < 0:
-        raise InvalidParameterError("Parameter 'length' must be positive")
-    if length > MAX_NUM_ROWS_PER_PAGE:
-        raise InvalidParameterError(f"Parameter 'length' must not be greater than {MAX_NUM_ROWS_PER_PAGE}")
-    return length


### PR DESCRIPTION
Factorize getting the request parameters `length` and `offset` from the service routes (/rows, /search and /filter) to `libapi`.
Additionally, align their error messages.