### PR TITLE
Do not pass None headers in e2e tests

### DIFF
--- a/e2e/tests/test_11_api.py
+++ b/e2e/tests/test_11_api.py
@@ -62,16 +62,13 @@ def test_auth_e2e(
     ],
 )
 def test_endpoint(
-    auth_headers: AuthHeaders,
     hf_public_dataset_repo_csv_data: str,
     endpoint: str,
     input_type: Literal["all", "dataset", "config", "split"],
 ) -> None:
-    auth: AuthType = "none"
     # TODO: add dataset with various splits, or various configs
     dataset = hf_public_dataset_repo_csv_data
     config, split = get_default_config_split()
-    headers = auth_headers[auth]
 
     # asking for the dataset will launch the jobs, without the need of a webhook
     relative_url = endpoint
@@ -84,26 +81,19 @@ def test_endpoint(
 
     poll_until_ready_and_assert(
         relative_url=relative_url,
-        headers=headers,
         check_x_revision=input_type != "all",
     )
 
 
-def test_rows_endpoint(
-    auth_headers: AuthHeaders,
-    hf_public_dataset_repo_csv_data: str,
-) -> None:
-    auth: AuthType = "none"
+def test_rows_endpoint(hf_public_dataset_repo_csv_data: str) -> None:
     # TODO: add dataset with various splits, or various configs
     dataset = hf_public_dataset_repo_csv_data
     config, split = get_default_config_split()
-    headers = auth_headers[auth]
     # ensure the /rows endpoint works as well
     offset = 1
     length = 10
     rows_response = poll_until_ready_and_assert(
         relative_url=f"/rows?dataset={dataset}&config={config}&split={split}&offset={offset}&length={length}",
-        headers=headers,
         check_x_revision=True,
     )
     content = rows_response.json()

--- a/e2e/tests/test_14_statistics.py
+++ b/e2e/tests/test_14_statistics.py
@@ -1,22 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The HuggingFace Authors.
 
-from .fixtures.hub import AuthHeaders, AuthType
 from .utils import get_default_config_split, poll_until_ready_and_assert
 
 
-def test_statistics_endpoint(
-    auth_headers: AuthHeaders,
-    hf_public_dataset_repo_csv_data: str,
-) -> None:
-    auth: AuthType = "none"
+def test_statistics_endpoint(hf_public_dataset_repo_csv_data: str) -> None:
     # TODO: add dataset with various splits, or various configs
     dataset = hf_public_dataset_repo_csv_data
     config, split = get_default_config_split()
-    headers = auth_headers[auth]
     statistics_response = poll_until_ready_and_assert(
         relative_url=f"/statistics?dataset={dataset}&config={config}&split={split}",
-        headers=headers,
         check_x_revision=True,
     )
 

--- a/e2e/tests/test_52_search.py
+++ b/e2e/tests/test_52_search.py
@@ -1,19 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The HuggingFace Authors.
 
-from .fixtures.hub import AuthHeaders, AuthType
 from .utils import get_default_config_split, poll_until_ready_and_assert
 
 
-def test_search_endpoint(
-    auth_headers: AuthHeaders,
-    hf_public_dataset_repo_csv_data: str,
-) -> None:
-    auth: AuthType = "none"
+def test_search_endpoint(hf_public_dataset_repo_csv_data: str) -> None:
     # TODO: add dataset with various splits, or various configs
     dataset = hf_public_dataset_repo_csv_data
     config, split = get_default_config_split()
-    headers = auth_headers[auth]
     # ensure the /search endpoint works as well
     offset = 1
     length = 2
@@ -22,7 +16,6 @@ def test_search_endpoint(
         relative_url=(
             f"/search?dataset={dataset}&config={config}&split={split}&offset={offset}&length={length}&query={query}"
         ),
-        headers=headers,
         check_x_revision=True,
     )
     content = search_response.json()

--- a/e2e/tests/test_53_filter.py
+++ b/e2e/tests/test_53_filter.py
@@ -1,18 +1,12 @@
 import pytest
 
-from .fixtures.hub import AuthHeaders, AuthType
 from .utils import get_default_config_split, poll_until_ready_and_assert
 
 
-def test_filter_endpoint(
-    auth_headers: AuthHeaders,
-    hf_public_dataset_repo_csv_data: str,
-) -> None:
-    auth: AuthType = "none"
+def test_filter_endpoint(hf_public_dataset_repo_csv_data: str) -> None:
     # TODO: add dataset with various splits, or various configs
     dataset = hf_public_dataset_repo_csv_data
     config, split = get_default_config_split()
-    headers = auth_headers[auth]
     offset = 1
     length = 2
     where = "col_4='B'"
@@ -20,7 +14,6 @@ def test_filter_endpoint(
         relative_url=(
             f"/filter?dataset={dataset}&config={config}&split={split}&offset={offset}&length={length}&where={where}"
         ),
-        headers=headers,
         check_x_revision=True,
     )
     content = filter_response.json()

--- a/e2e/tests/utils.py
+++ b/e2e/tests/utils.py
@@ -29,14 +29,10 @@ Headers = Mapping[str, str]
 
 
 def get(relative_url: str, headers: Optional[Headers] = None, url: str = URL) -> Response:
-    if headers is None:
-        headers = {}
     return requests.get(f"{url}{relative_url}", headers=headers)
 
 
 def post(relative_url: str, json: Optional[Any] = None, headers: Optional[Headers] = None, url: str = URL) -> Response:
-    if headers is None:
-        headers = {}
     return requests.post(f"{url}{relative_url}", json=json, headers=headers)
 
 
@@ -47,8 +43,6 @@ def poll(
     headers: Optional[Headers] = None,
     url: str = URL,
 ) -> Response:
-    if headers is None:
-        headers = {}
     interval = INTERVAL
     timeout = MAX_DURATION
     retries = timeout // interval
@@ -161,8 +155,6 @@ def poll_until_ready_and_assert(
     url: str = URL,
     check_x_revision: bool = False,
 ) -> Any:
-    if headers is None:
-        headers = {}
     interval = INTERVAL
     timeout = MAX_DURATION
     retries = timeout // interval


### PR DESCRIPTION
This PR refactors e2e tests so that we do not pass unnecessary None headers (this is their default value).