### PR TITLE
force download when previous file is obsolete

### DIFF
--- a/libs/libapi/src/libapi/duckdb.py
+++ b/libs/libapi/src/libapi/duckdb.py
@@ -83,6 +83,7 @@ def download_index_file(
         local_dir_use_symlinks=False,
         token=hf_token,
         cache_dir=cache_folder,
+        force_download=True,
     )
 
 

--- a/libs/libapi/src/libapi/duckdb.py
+++ b/libs/libapi/src/libapi/duckdb.py
@@ -83,7 +83,6 @@ def download_index_file(
         local_dir_use_symlinks=False,
         token=hf_token,
         cache_dir=cache_folder,
-        force_download=True,
     )
 
 

--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -443,6 +443,7 @@ def compute_descriptive_statistics_response(
             local_dir_use_symlinks=False,
             token=hf_token,
             cache_dir=local_parquet_directory,
+            force_download=True,
         )
 
     local_parquet_glob_path = Path(local_parquet_directory) / config / f"{split}/*.parquet"

--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -444,6 +444,7 @@ def compute_descriptive_statistics_response(
             token=hf_token,
             cache_dir=local_parquet_directory,
             force_download=True,
+            resume_download=False,
         )
 
     local_parquet_glob_path = Path(local_parquet_directory) / config / f"{split}/*.parquet"

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -171,6 +171,7 @@ def compute_index_rows(
             local_dir_use_symlinks=False,
             token=hf_token,
             cache_dir=duckdb_index_file_directory,
+            force_download=True,
         )
 
     all_split_parquets = f"{duckdb_index_file_directory}/{config}/{split_directory}/*.parquet"

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -172,6 +172,7 @@ def compute_index_rows(
             token=hf_token,
             cache_dir=duckdb_index_file_directory,
             force_download=True,
+            resume_download=False,
         )
 
     all_split_parquets = f"{duckdb_index_file_directory}/{config}/{split_directory}/*.parquet"


### PR DESCRIPTION
For https://datasets-server.huggingface.co/search?dataset=xnli&config=all_languages&split=train&offset=0&length=1&query=language

```

OSError: Consistency check failed: file should be of size 301736502 but has size 293192246 (0002.parquet).
We are sorry for the inconvenience. Please retry download and pass `force_download=True, resume_download=False` as argument.
If the issue persists, please let us know by opening an issue on https://github.com/huggingface/huggingface_hub.

```

See that there is an error in hf_hub_download, It looks like the library tried to compare the file with a previous one in the local cache. Maybe the data changed or there was a previously downloaded obsolete/corrupted file. 
I think we should force-download each time to always have a refreshed parquet file.

