### PR TITLE
add ExternalServerError in error codes to retry for backfilling

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -202,7 +202,7 @@ backfill:
   log:
     level: "debug"
   action: "backfill"
-  error_codes_to_retry: "CreateCommitError,LockedDatasetTimeoutError,NoIndexableColumnsError"
+  error_codes_to_retry: "CreateCommitError,LockedDatasetTimeoutError,ExternalServerError"
   schedule: "20 21 * * *"
   # every four hours
   nodeSelector:


### PR DESCRIPTION
Currently, we have 856 cached records with error ExternalServerError. This error is thrown when connection to Spawning AI API is not working:

`Error when trying to connect to https://opts-api.spawningaiapi.com/api/v2/query/urls: '{'detail': 'An unknown error has occurred.'}'`

We should retry those jobs because it is not related to an error with our logic but with the connection.
```
Atlas atlas-x5jgb3-shard-0 [primary] datasets_server_cache> db.cachedResponsesBlue.countDocuments({error_code:"ExternalServerError"})
856
Atlas atlas-x5jgb3-shard-0 [primary] datasets_server_cache> db.cachedResponsesBlue.distinct("kind", {error_code:"ExternalServerError"})
[ 'split-opt-in-out-urls-count', 'split-opt-in-out-urls-scan' ]
```
-------------------------
Also removing NoIndexableColumnsError from the list since the exception no longer exist on the code and all the old entries have been refreshed.
```
Atlas atlas-x5jgb3-shard-0 [primary] datasets_server_cache> db.cachedResponsesBlue.countDocuments({error_code:"NoIndexableColumnsError"})
0
```