### PR TITLE
Make CI quality verify consistency of poetry.lock

### DIFF
--- a/.github/workflows/_quality-python.yml
+++ b/.github/workflows/_quality-python.yml
@@ -33,6 +33,8 @@ jobs:
             ${{ inputs.working-directory }}/poetry.lock
       - name: Install packages
         run: sudo apt update; sudo apt install -y libicu-dev ffmpeg libavcodec-extra libsndfile1 llvm pkg-config poppler-utils
+      - name: Verify consistency of poetry.lock with pyproject.toml
+        run: poetry lock --no-update --check
       - name: Install dependencies
         # "poetry env use" is required: https://github.com/actions/setup-python/issues/374#issuecomment-1088938718
         run: |

--- a/e2e/poetry.lock
+++ b/e2e/poetry.lock
@@ -1461,4 +1461,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "3.9.15"
-content-hash = "c4f6ac138a4933e562ec57a67e00db426dcda5f4ea0fc15b9e44d538c8c6cc91"
+content-hash = "eedc4a3a6771cb94f9a8eb133ad96cfd4fd12f9190993492d5eeab485ef616cf"


### PR DESCRIPTION
Add check to CI quality, so that we verify that the `poetry.lock` file is consistent with the `pyproject.toml`.

@severo this verification also checks if the dependencies of a service are consistent, for example if the dependencies of `libcommon` or `libapi` have been previously updated. See related discussion in: https://github.com/huggingface/datasets-server/pull/1943#issuecomment-1750964793

Note that this approach does not avoid skipping updating the dependencies of the `libs` without updating the dependencies in the dependent services, but at least will guarantee that the dependencies of the services are updated as soon as possible afterwards.

The CI should be green once other PRs (that update the dependencies of the services after the updates of the libs) are merged:
- [x] #1942 
- [x] #1943

See "services/rows / quality / code-quality": https://github.com/huggingface/datasets-server/actions/runs/6453845913/job/17518191315
```
> Run poetry lock --no-update --check
Error: poetry.lock is not consistent with pyproject.toml. Run `poetry lock [--no-update]` to fix it.
Error: Process completed with exit code 1.
```