### PR TITLE
Fix UnexpectedError for non-integer length/offset

### DIFF
--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -2865,10 +2865,22 @@
                       "error": "Parameters 'split', 'config' and 'dataset' are required"
                     }
                   },
+                  "non-integer-offset": {
+                    "summary": "The offset must be integer.",
+                    "value": {
+                      "error": "Parameter 'offset' must be integer"
+                    }
+                  },
                   "negative-offset": {
                     "summary": "The offset must be positive.",
                     "value": {
                       "error": "Parameter 'offset' must be positive"
+                    }
+                  },
+                  "non-integer-length": {
+                    "summary": "The length must be integer.",
+                    "value": {
+                      "error": "Parameter 'length' must be integer"
                     }
                   },
                   "negative-length": {
@@ -3230,10 +3242,22 @@
                       "error": "Parameter 'dataset', 'config', 'split' and 'query' are required"
                     }
                   },
+                  "non-integer-offset": {
+                    "summary": "The offset must be integer.",
+                    "value": {
+                      "error": "Parameter 'offset' must be integer"
+                    }
+                  },
                   "negative-offset": {
                     "summary": "The offset must be positive.",
                     "value": {
                       "error": "Parameter 'offset' must be positive"
+                    }
+                  },
+                  "non-integer-length": {
+                    "summary": "The length must be integer.",
+                    "value": {
+                      "error": "Parameter 'length' must be integer"
                     }
                   },
                   "negative-length": {
@@ -3840,10 +3864,22 @@
                       "error": "Parameters 'dataset', 'config', 'split' and 'where' are required"
                     }
                   },
+                  "non-integer-offset": {
+                    "summary": "The offset must be integer.",
+                    "value": {
+                      "error": "Parameter 'offset' must be integer"
+                    }
+                  },
                   "negative-offset": {
                     "summary": "The offset must be positive.",
                     "value": {
                       "error": "Parameter 'offset' must be positive"
+                    }
+                  },
+                  "non-integer-length": {
+                    "summary": "The length must be integer.",
+                    "value": {
+                      "error": "Parameter 'length' must be integer"
                     }
                   },
                   "negative-length": {

--- a/libs/libapi/src/libapi/request.py
+++ b/libs/libapi/src/libapi/request.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 The HuggingFace Authors.
+
 from libcommon.utils import MAX_NUM_ROWS_PER_PAGE
 from starlette.requests import Request
 
@@ -5,7 +8,10 @@ from libapi.exceptions import InvalidParameterError
 
 
 def get_request_parameter_length(request: Request) -> int:
-    length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
+    try:
+        length = int(request.query_params.get("length", MAX_NUM_ROWS_PER_PAGE))
+    except ValueError:
+        raise InvalidParameterError("Parameter 'length' must be integer")
     if length < 0:
         raise InvalidParameterError("Parameter 'length' must be positive")
     elif length > MAX_NUM_ROWS_PER_PAGE:
@@ -14,7 +20,10 @@ def get_request_parameter_length(request: Request) -> int:
 
 
 def get_request_parameter_offset(request: Request) -> int:
-    offset = int(request.query_params.get("offset", 0))
+    try:
+        offset = int(request.query_params.get("offset", 0))
+    except ValueError:
+        raise InvalidParameterError("Parameter 'offset' must be integer")
     if offset < 0:
         raise InvalidParameterError(message="Parameter 'offset' must be positive")
     return offset

--- a/libs/libapi/tests/test_request.py
+++ b/libs/libapi/tests/test_request.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 The HuggingFace Authors.
+
+from collections.abc import Callable
+
+import pytest
+from starlette.requests import Request
+
+from libapi.exceptions import InvalidParameterError
+from libapi.request import get_request_parameter_length, get_request_parameter_offset
+
+
+@pytest.fixture
+def build_request() -> Callable[..., Request]:
+    def _build_request(query_string: str = "") -> Request:
+        scope = {"type": "http"}
+        if query_string:
+            scope["query_string"] = query_string  # .encode("utf-8")
+        return Request(scope)
+
+    return _build_request
+
+
+@pytest.mark.parametrize("length, expected_value", [("50", 50)])
+def test_get_request_parameter_length(length: str, expected_value: int, build_request: Callable[..., Request]) -> None:
+    request = build_request(query_string=f"length={length}")
+    assert get_request_parameter_length(request) == expected_value
+
+
+@pytest.mark.parametrize(
+    "length, expected_error_message",
+    [
+        ("abc", "Parameter 'length' must be integer"),
+        ("-1", "Parameter 'length' must be positive"),
+        ("200", "Parameter 'length' must not be greater than 100"),
+    ],
+)
+def test_get_request_parameter_length_raises(
+    length: str, expected_error_message: str, build_request: Callable[..., Request]
+) -> None:
+    request = build_request(query_string=f"length={length}")
+    with pytest.raises(InvalidParameterError, match=expected_error_message):
+        _ = get_request_parameter_length(request)
+
+
+@pytest.mark.parametrize("offset, expected_value", [("50", 50)])
+def test_get_request_parameter_offset(offset: str, expected_value: int, build_request: Callable[..., Request]) -> None:
+    request = build_request(query_string=f"offset={offset}")
+    assert get_request_parameter_offset(request) == expected_value
+
+
+@pytest.mark.parametrize(
+    "offset, expected_error_message",
+    [("abc", "Parameter 'offset' must be integer"), ("-1", "Parameter 'offset' must be positive")],
+)
+def test_get_request_parameter_offset_raises(
+    offset: str, expected_error_message: str, build_request: Callable[..., Request]
+) -> None:
+    request = build_request(query_string=f"offset={offset}")
+    with pytest.raises(InvalidParameterError, match=expected_error_message):
+        _ = get_request_parameter_offset(request)


### PR DESCRIPTION
Fix `UnexpectedError` for non-integer length/offset and raise `InvalidParameterError` instead.