### PR TITLE
docs: ✏️ add two details to the Parquet docs

### DIFF
--- a/docs/source/parquet.mdx
+++ b/docs/source/parquet.mdx
@@ -1,10 +1,10 @@
 # List Parquet files
 
-Datasets can be published in any format (CSV, JSONL, directories of images, etc.) to the Hub, and they are easily accessed with the 🤗 [Datasets](https://huggingface.co/docs/datasets/) library. For a more performant experience (especially when it comes to large datasets), Datasets Server automatically converts every public dataset to the [Parquet](https://parquet.apache.org/) format. The Parquet files are published to the Hub on a specific `refs/convert/parquet` branch (like this `amazon_polarity` [branch](https://huggingface.co/datasets/amazon_polarity/tree/refs%2Fconvert%2Fparquet) for example).
+Datasets can be published in any format (CSV, JSONL, directories of images, etc.) to the Hub, and they are easily accessed with the 🤗 [Datasets](https://huggingface.co/docs/datasets/) library. For a more performant experience (especially when it comes to large datasets), Datasets Server automatically converts every public dataset to the [Parquet](https://parquet.apache.org/) format. The Parquet files are published to the Hub on a specific `refs/convert/parquet` branch (like this `amazon_polarity` [branch](https://huggingface.co/datasets/amazon_polarity/tree/refs%2Fconvert%2Fparquet) for example) that lives in parallel to the `main` branch.
 
 <Tip>
 
-In order for Datasets Server to generate a Parquet version of a dataset, the dataset must be *public*.
+In order for Datasets Server to generate a Parquet version of a dataset, the dataset must be _public_.
 
 </Tip>
 
@@ -52,7 +52,7 @@ curl https://datasets-server.huggingface.co/parquet?dataset=duorc \
 </curl>
 </inferencesnippet>
 
-The endpoint response is a JSON containing a list of the dataset's files in the Parquet format. For example, the [`duorc`](https://huggingface.co/datasets/duorc) dataset has six Parquet files, which corresponds to the `test`, `train` and `validation` splits of its two configurations, `ParaphraseRC` and `SelfRC` (see the [List splits and configurations](./splits) guide for more details about splits and configurations). 
+The endpoint response is a JSON containing a list of the dataset's files in the Parquet format. For example, the [`duorc`](https://huggingface.co/datasets/duorc) dataset has six Parquet files, which corresponds to the `test`, `train` and `validation` splits of its two configurations, `ParaphraseRC` and `SelfRC` (see the [List splits and configurations](./splits) guide for more details about splits and configurations).
 
 The endpoint also gives the filename and size of each file:
 
@@ -125,8 +125,8 @@ Big datasets are partitioned into Parquet files (shards) of about 500MB each. Th
       "url": "https://huggingface.co/datasets/amazon_polarity/resolve/refs%2Fconvert%2Fparquet/amazon_polarity/test/0000.parquet",
       "filename": "0000.parquet",
       "size": 117422359
-   },
-   {
+    },
+    {
       "dataset": "amazon_polarity",
       "config": "amazon_polarity",
       "split": "train",
@@ -159,8 +159,9 @@ Big datasets are partitioned into Parquet files (shards) of about 500MB each. Th
       "size": 66515954
     }
   ],
- "pending": [],
- "failed": []}
+  "pending": [],
+  "failed": []
+}
 ```
 
 To read and query the Parquet files, take a look at the [Query datasets from Datasets Server](parquet_process) guide.
@@ -170,6 +171,10 @@ To read and query the Parquet files, take a look at the [Query datasets from Dat
 The Parquet version can be partial if the dataset is not already in Parquet format or if it is bigger than 5GB.
 
 In that case the Parquet files are generated up to 5GB and placed in a split directory prefixed with "partial", e.g. "partial-train" instead of "train".
+
+## Parquet-native datasets
+
+When the dataset is already in Parquet format, the data are not converted and the files in `refs/convert/parquet` are links to the original files. This rule suffers an exception to ensure the Datasets Server API to stay fast: if the [row group](https://parquet.apache.org/docs/concepts/) size of the original Parquet files is too big, new Parquet files are generated.
 
 ## Using the Hugging Face Hub API
 


### PR DESCRIPTION
1. refs/convert/parquet lives in parallel to `main` and is not meant to be merged, 2. the parquet native datasets are not converted