### PR TITLE
Factorize getting required request parameters

### DIFF
--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -2832,37 +2832,37 @@
                   "missing-dataset": {
                     "summary": "The dataset parameter is missing.",
                     "value": {
-                      "error": "Parameters 'split', 'config' and 'dataset' are required"
+                      "error": "Parameter 'dataset' is required"
                     }
                   },
                   "missing-config": {
                     "summary": "The config parameter is missing.",
                     "value": {
-                      "error": "Parameters 'split', 'config' and 'dataset' are required"
+                      "error": "Parameter 'config' is required"
                     }
                   },
                   "missing-split": {
                     "summary": "The split parameter is missing.",
                     "value": {
-                      "error": "Parameters 'split', 'config' and 'dataset' are required"
+                      "error": "Parameter 'split' is required"
                     }
                   },
                   "empty-dataset": {
                     "summary": "The dataset parameter is empty.",
                     "value": {
-                      "error": "Parameters 'split', 'config' and 'dataset' are required"
+                      "error": "Parameter 'dataset' is required"
                     }
                   },
                   "empty-config": {
                     "summary": "The config parameter is empty.",
                     "value": {
-                      "error": "Parameters 'split', 'config' and 'dataset' are required"
+                      "error": "Parameter 'config' is required"
                     }
                   },
                   "empty-split": {
                     "summary": "The split parameter is empty.",
                     "value": {
-                      "error": "Parameters 'split', 'config' and 'dataset' are required"
+                      "error": "Parameter 'split' is required"
                     }
                   },
                   "non-integer-offset": {
@@ -3197,49 +3197,49 @@
                   "missing-dataset": {
                     "summary": "The dataset parameter is missing.",
                     "value": {
-                      "error": "Parameter 'dataset', 'config', 'split' and 'query' are required"
+                      "error": "Parameter 'dataset' is required"
                     }
                   },
                   "missing-config": {
                     "summary": "The config parameter is missing.",
                     "value": {
-                      "error": "Parameter 'dataset', 'config', 'split' and 'query' are required"
+                      "error": "Parameter 'config' is required"
                     }
                   },
                   "missing-split": {
                     "summary": "The split parameter is missing.",
                     "value": {
-                      "error": "Parameter 'dataset', 'config', 'split' and 'query' are required"
+                      "error": "Parameter 'split' is required"
                     }
                   },
                   "missing-query": {
                     "summary": "The query parameter is missing.",
                     "value": {
-                      "error": "Parameter 'dataset', 'config', 'split' and 'query' are required"
+                      "error": "Parameter 'query' is required"
                     }
                   },
                   "empty-dataset": {
                     "summary": "The dataset parameter is empty.",
                     "value": {
-                      "error": "Parameter 'dataset', 'config', 'split' and 'query' are required"
+                      "error": "Parameter 'dataset' is required"
                     }
                   },
                   "empty-config": {
                     "summary": "The config parameter is empty.",
                     "value": {
-                      "error": "Parameter 'dataset', 'config', 'split' and 'query' are required"
+                      "error": "Parameter 'config' is required"
                     }
                   },
                   "empty-split": {
                     "summary": "The split parameter is empty.",
                     "value": {
-                      "error": "Parameter 'dataset', 'config', 'split' and 'query' are required"
+                      "error": "Parameter 'split' is required"
                     }
                   },
                   "empty-query": {
                     "summary": "The query parameter is empty.",
                     "value": {
-                      "error": "Parameter 'dataset', 'config', 'split' and 'query' are required"
+                      "error": "Parameter 'query' is required"
                     }
                   },
                   "non-integer-offset": {
@@ -3819,49 +3819,49 @@
                   "missing-dataset": {
                     "summary": "The dataset parameter is missing.",
                     "value": {
-                      "error": "Parameters 'dataset', 'config', 'split' and 'where' are required"
+                      "error": "Parameter 'dataset' is required"
                     }
                   },
                   "missing-config": {
                     "summary": "The config parameter is missing.",
                     "value": {
-                      "error": "Parameters 'dataset', 'config', 'split' and 'where' are required"
+                      "error": "Parameter 'config' is required"
                     }
                   },
                   "missing-split": {
                     "summary": "The split parameter is missing.",
                     "value": {
-                      "error": "Parameters 'dataset', 'config', 'split' and 'where' are required"
+                      "error": "Parameter 'split' is required"
                     }
                   },
                   "missing-query": {
                     "summary": "The where parameter is missing.",
                     "value": {
-                      "error": "Parameters 'dataset', 'config', 'split' and 'where' are required"
+                      "error": "Parameter 'where' is required"
                     }
                   },
                   "empty-dataset": {
                     "summary": "The dataset parameter is empty.",
                     "value": {
-                      "error": "Parameters 'dataset', 'config', 'split' and 'where' are required"
+                      "error": "Parameter 'dataset' is required"
                     }
                   },
                   "empty-config": {
                     "summary": "The config parameter is empty.",
                     "value": {
-                      "error": "Parameters 'dataset', 'config', 'split' and 'where' are required"
+                      "error": "Parameter 'config' is required"
                     }
                   },
                   "empty-split": {
                     "summary": "The split parameter is empty.",
                     "value": {
-                      "error": "Parameters 'dataset', 'config', 'split' and 'where' are required"
+                      "error": "Parameter 'split' is required"
                     }
                   },
                   "empty-query": {
                     "summary": "The where parameter is empty.",
                     "value": {
-                      "error": "Parameters 'dataset', 'config', 'split' and 'where' are required"
+                      "error": "Parameter 'where' is required"
                     }
                   },
                   "non-integer-offset": {

--- a/libs/libapi/src/libapi/request.py
+++ b/libs/libapi/src/libapi/request.py
@@ -29,22 +29,8 @@ def get_request_parameter_offset(request: Request) -> int:
     return offset
 
 
-def get_request_parameter_dataset(request: Request) -> str:
-    dataset = request.query_params.get("dataset")
-    if not dataset or not are_valid_parameters([dataset]):
-        raise MissingRequiredParameterError("Parameter 'dataset' is required")
-    return dataset
-
-
-def get_request_parameter_config(request: Request) -> str:
-    config = request.query_params.get("config")
-    if not config or not are_valid_parameters([config]):
-        raise MissingRequiredParameterError("Parameter 'config' is required")
-    return config
-
-
-def get_request_parameter_split(request: Request) -> str:
-    split = request.query_params.get("split")
-    if not split or not are_valid_parameters([split]):
-        raise MissingRequiredParameterError("Parameter 'split' is required")
-    return split
+def get_required_request_parameter(request: Request, parameter_name: str) -> str:
+    parameter = request.query_params.get(parameter_name)
+    if not parameter or not are_valid_parameters([parameter]):
+        raise MissingRequiredParameterError(f"Parameter '{parameter_name}' is required")
+    return parameter

--- a/libs/libapi/src/libapi/request.py
+++ b/libs/libapi/src/libapi/request.py
@@ -41,3 +41,10 @@ def get_request_parameter_config(request: Request) -> str:
     if not config or not are_valid_parameters([config]):
         raise MissingRequiredParameterError("Parameter 'config' is required")
     return config
+
+
+def get_request_parameter_split(request: Request) -> str:
+    split = request.query_params.get("split")
+    if not split or not are_valid_parameters([split]):
+        raise MissingRequiredParameterError("Parameter 'split' is required")
+    return split

--- a/libs/libapi/src/libapi/request.py
+++ b/libs/libapi/src/libapi/request.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The HuggingFace Authors.
-
 from libcommon.utils import MAX_NUM_ROWS_PER_PAGE
 from starlette.requests import Request
 
-from libapi.exceptions import InvalidParameterError
+from libapi.exceptions import InvalidParameterError, MissingRequiredParameterError
+from libapi.utils import are_valid_parameters
 
 
 def get_request_parameter_length(request: Request) -> int:
@@ -27,3 +27,10 @@ def get_request_parameter_offset(request: Request) -> int:
     if offset < 0:
         raise InvalidParameterError(message="Parameter 'offset' must be positive")
     return offset
+
+
+def get_request_parameter_dataset(request: Request) -> str:
+    dataset = request.query_params.get("dataset")
+    if not dataset or not are_valid_parameters([dataset]):
+        raise MissingRequiredParameterError("Parameter 'dataset' is required")
+    return dataset

--- a/libs/libapi/src/libapi/request.py
+++ b/libs/libapi/src/libapi/request.py
@@ -34,3 +34,10 @@ def get_request_parameter_dataset(request: Request) -> str:
     if not dataset or not are_valid_parameters([dataset]):
         raise MissingRequiredParameterError("Parameter 'dataset' is required")
     return dataset
+
+
+def get_request_parameter_config(request: Request) -> str:
+    config = request.query_params.get("config")
+    if not config or not are_valid_parameters([config]):
+        raise MissingRequiredParameterError("Parameter 'config' is required")
+    return config

--- a/libs/libapi/tests/test_request.py
+++ b/libs/libapi/tests/test_request.py
@@ -2,23 +2,44 @@
 # Copyright 2023 The HuggingFace Authors.
 
 from collections.abc import Callable
+from typing import Optional
 
 import pytest
 from starlette.requests import Request
 
-from libapi.exceptions import InvalidParameterError
-from libapi.request import get_request_parameter_length, get_request_parameter_offset
+from libapi.exceptions import InvalidParameterError, MissingRequiredParameterError
+from libapi.request import (
+    get_request_parameter_length,
+    get_request_parameter_offset,
+    get_required_request_parameter,
+)
 
 
 @pytest.fixture
 def build_request() -> Callable[..., Request]:
     def _build_request(query_string: str = "") -> Request:
-        scope = {"type": "http"}
-        if query_string:
-            scope["query_string"] = query_string  # .encode("utf-8")
+        scope = {"type": "http", "query_string": query_string}
         return Request(scope)
 
     return _build_request
+
+
+@pytest.mark.parametrize("expected_value", ["org-name/dataset-name"])
+def test_get_required_request_parameter(expected_value: str, build_request: Callable[..., Request]) -> None:
+    parameter_name = "dataset"
+    request = build_request(query_string=f"{parameter_name}={expected_value}")
+    assert get_required_request_parameter(request, parameter_name) == expected_value
+
+
+@pytest.mark.parametrize("parameter", [None, "", " "])
+def test_get_required_request_parameter_raises(
+    parameter: Optional[str], build_request: Callable[..., Request]
+) -> None:
+    parameter_name = "dataset"
+    expected_error_message = f"Parameter '{parameter_name}' is required"
+    request = build_request(query_string=f"{parameter_name}={parameter}") if parameter is not None else build_request()
+    with pytest.raises(MissingRequiredParameterError, match=expected_error_message):
+        _ = get_required_request_parameter(request, parameter_name)
 
 
 @pytest.mark.parametrize("length, expected_value", [("50", 50)])

--- a/services/admin/src/admin/routes/dataset_backfill.py
+++ b/services/admin/src/admin/routes/dataset_backfill.py
@@ -4,7 +4,8 @@
 import logging
 from typing import Optional
 
-from libapi.exceptions import MissingRequiredParameterError, UnexpectedApiError
+from libapi.exceptions import UnexpectedApiError
+from libapi.request import get_request_parameter_dataset
 from libcommon.dataset import get_dataset_git_revision
 from libcommon.exceptions import CustomError
 from libcommon.orchestrator import DatasetOrchestrator
@@ -14,12 +15,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from admin.authentication import auth_check
-from admin.utils import (
-    Endpoint,
-    are_valid_parameters,
-    get_json_admin_error_response,
-    get_json_ok_response,
-)
+from admin.utils import Endpoint, get_json_admin_error_response, get_json_ok_response
 
 
 def create_dataset_backfill_endpoint(
@@ -64,10 +60,3 @@ def create_dataset_backfill_endpoint(
             return get_json_admin_error_response(UnexpectedApiError("Unexpected error.", e), max_age=0)
 
     return dataset_backfill_endpoint
-
-
-def get_request_parameter_dataset(request):
-    dataset = request.query_params.get("dataset")
-    if not dataset or not are_valid_parameters([dataset]):
-        raise MissingRequiredParameterError("Parameter 'dataset' is required")
-    return dataset

--- a/services/admin/src/admin/routes/dataset_backfill.py
+++ b/services/admin/src/admin/routes/dataset_backfill.py
@@ -5,7 +5,7 @@ import logging
 from typing import Optional
 
 from libapi.exceptions import UnexpectedApiError
-from libapi.request import get_request_parameter_dataset
+from libapi.request import get_required_request_parameter
 from libcommon.dataset import get_dataset_git_revision
 from libcommon.exceptions import CustomError
 from libcommon.orchestrator import DatasetOrchestrator
@@ -30,7 +30,7 @@ def create_dataset_backfill_endpoint(
 ) -> Endpoint:
     async def dataset_backfill_endpoint(request: Request) -> Response:
         try:
-            dataset = get_request_parameter_dataset(request)
+            dataset = get_required_request_parameter(request, "dataset")
             logging.info(f"/dataset-backfill, dataset={dataset}")
 
             # if auth_check fails, it will raise an exception that will be caught below

--- a/services/admin/src/admin/routes/dataset_backfill.py
+++ b/services/admin/src/admin/routes/dataset_backfill.py
@@ -34,9 +34,7 @@ def create_dataset_backfill_endpoint(
 ) -> Endpoint:
     async def dataset_backfill_endpoint(request: Request) -> Response:
         try:
-            dataset = request.query_params.get("dataset")
-            if not are_valid_parameters([dataset]) or not dataset:
-                raise MissingRequiredParameterError("Parameter 'dataset' is required")
+            dataset = get_request_parameter_dataset(request)
             logging.info(f"/dataset-backfill, dataset={dataset}")
 
             # if auth_check fails, it will raise an exception that will be caught below
@@ -66,3 +64,10 @@ def create_dataset_backfill_endpoint(
             return get_json_admin_error_response(UnexpectedApiError("Unexpected error.", e), max_age=0)
 
     return dataset_backfill_endpoint
+
+
+def get_request_parameter_dataset(request):
+    dataset = request.query_params.get("dataset")
+    if not dataset or not are_valid_parameters([dataset]):
+        raise MissingRequiredParameterError("Parameter 'dataset' is required")
+    return dataset

--- a/services/admin/src/admin/routes/dataset_backfill_plan.py
+++ b/services/admin/src/admin/routes/dataset_backfill_plan.py
@@ -4,11 +4,8 @@
 import logging
 from typing import Optional
 
-from libapi.exceptions import (
-    ApiError,
-    MissingRequiredParameterError,
-    UnexpectedApiError,
-)
+from libapi.exceptions import ApiError, UnexpectedApiError
+from libapi.request import get_request_parameter_dataset
 from libcommon.dataset import get_dataset_git_revision
 from libcommon.orchestrator import DatasetBackfillPlan
 from libcommon.processing_graph import ProcessingGraph
@@ -16,12 +13,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from admin.authentication import auth_check
-from admin.utils import (
-    Endpoint,
-    are_valid_parameters,
-    get_json_admin_error_response,
-    get_json_ok_response,
-)
+from admin.utils import Endpoint, get_json_admin_error_response, get_json_ok_response
 
 
 def create_dataset_backfill_plan_endpoint(
@@ -63,10 +55,3 @@ def create_dataset_backfill_plan_endpoint(
             return get_json_admin_error_response(UnexpectedApiError("Unexpected error.", e), max_age=max_age)
 
     return dataset_state_endpoint
-
-
-def get_request_parameter_dataset(request):
-    dataset = request.query_params.get("dataset")
-    if not dataset or not are_valid_parameters([dataset]):
-        raise MissingRequiredParameterError("Parameter 'dataset' is required")
-    return dataset

--- a/services/admin/src/admin/routes/dataset_backfill_plan.py
+++ b/services/admin/src/admin/routes/dataset_backfill_plan.py
@@ -5,7 +5,7 @@ import logging
 from typing import Optional
 
 from libapi.exceptions import ApiError, UnexpectedApiError
-from libapi.request import get_request_parameter_dataset
+from libapi.request import get_required_request_parameter
 from libcommon.dataset import get_dataset_git_revision
 from libcommon.orchestrator import DatasetBackfillPlan
 from libcommon.processing_graph import ProcessingGraph
@@ -28,7 +28,7 @@ def create_dataset_backfill_plan_endpoint(
 ) -> Endpoint:
     async def dataset_state_endpoint(request: Request) -> Response:
         try:
-            dataset = get_request_parameter_dataset(request)
+            dataset = get_required_request_parameter(request, "dataset")
             logging.info(f"/dataset-state, dataset={dataset}")
 
             # if auth_check fails, it will raise an exception that will be caught below

--- a/services/admin/src/admin/routes/dataset_backfill_plan.py
+++ b/services/admin/src/admin/routes/dataset_backfill_plan.py
@@ -36,9 +36,7 @@ def create_dataset_backfill_plan_endpoint(
 ) -> Endpoint:
     async def dataset_state_endpoint(request: Request) -> Response:
         try:
-            dataset = request.query_params.get("dataset")
-            if not are_valid_parameters([dataset]) or not dataset:
-                raise MissingRequiredParameterError("Parameter 'dataset' is required")
+            dataset = get_request_parameter_dataset(request)
             logging.info(f"/dataset-state, dataset={dataset}")
 
             # if auth_check fails, it will raise an exception that will be caught below
@@ -65,3 +63,10 @@ def create_dataset_backfill_plan_endpoint(
             return get_json_admin_error_response(UnexpectedApiError("Unexpected error.", e), max_age=max_age)
 
     return dataset_state_endpoint
+
+
+def get_request_parameter_dataset(request):
+    dataset = request.query_params.get("dataset")
+    if not dataset or not are_valid_parameters([dataset]):
+        raise MissingRequiredParameterError("Parameter 'dataset' is required")
+    return dataset

--- a/services/admin/src/admin/routes/dataset_status.py
+++ b/services/admin/src/admin/routes/dataset_status.py
@@ -33,9 +33,7 @@ def create_dataset_status_endpoint(
 ) -> Endpoint:
     async def dataset_status_endpoint(request: Request) -> Response:
         try:
-            dataset = request.query_params.get("dataset")
-            if not are_valid_parameters([dataset]) or not dataset:
-                raise MissingRequiredParameterError("Parameter 'dataset' is required")
+            dataset = get_request_parameter_dataset(request)
             logging.info(f"/dataset-status, dataset={dataset}")
 
             # if auth_check fails, it will raise an exception that will be caught below
@@ -66,3 +64,10 @@ def create_dataset_status_endpoint(
             return get_json_admin_error_response(UnexpectedApiError("Unexpected error.", e), max_age=max_age)
 
     return dataset_status_endpoint
+
+
+def get_request_parameter_dataset(request):
+    dataset = request.query_params.get("dataset")
+    if not dataset or not are_valid_parameters([dataset]):
+        raise MissingRequiredParameterError("Parameter 'dataset' is required")
+    return dataset

--- a/services/admin/src/admin/routes/dataset_status.py
+++ b/services/admin/src/admin/routes/dataset_status.py
@@ -4,11 +4,8 @@
 import logging
 from typing import Optional
 
-from libapi.exceptions import (
-    ApiError,
-    MissingRequiredParameterError,
-    UnexpectedApiError,
-)
+from libapi.exceptions import ApiError, UnexpectedApiError
+from libapi.request import get_request_parameter_dataset
 from libcommon.processing_graph import ProcessingGraph
 from libcommon.queue import Queue
 from libcommon.simple_cache import get_dataset_responses_without_content_for_kind
@@ -16,12 +13,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from admin.authentication import auth_check
-from admin.utils import (
-    Endpoint,
-    are_valid_parameters,
-    get_json_admin_error_response,
-    get_json_ok_response,
-)
+from admin.utils import Endpoint, get_json_admin_error_response, get_json_ok_response
 
 
 def create_dataset_status_endpoint(
@@ -64,10 +56,3 @@ def create_dataset_status_endpoint(
             return get_json_admin_error_response(UnexpectedApiError("Unexpected error.", e), max_age=max_age)
 
     return dataset_status_endpoint
-
-
-def get_request_parameter_dataset(request):
-    dataset = request.query_params.get("dataset")
-    if not dataset or not are_valid_parameters([dataset]):
-        raise MissingRequiredParameterError("Parameter 'dataset' is required")
-    return dataset

--- a/services/admin/src/admin/routes/dataset_status.py
+++ b/services/admin/src/admin/routes/dataset_status.py
@@ -5,7 +5,7 @@ import logging
 from typing import Optional
 
 from libapi.exceptions import ApiError, UnexpectedApiError
-from libapi.request import get_request_parameter_dataset
+from libapi.request import get_required_request_parameter
 from libcommon.processing_graph import ProcessingGraph
 from libcommon.queue import Queue
 from libcommon.simple_cache import get_dataset_responses_without_content_for_kind
@@ -25,7 +25,7 @@ def create_dataset_status_endpoint(
 ) -> Endpoint:
     async def dataset_status_endpoint(request: Request) -> Response:
         try:
-            dataset = get_request_parameter_dataset(request)
+            dataset = get_required_request_parameter(request, "dataset")
             logging.info(f"/dataset-status, dataset={dataset}")
 
             # if auth_check fails, it will raise an exception that will be caught below

--- a/services/admin/src/admin/routes/force_refresh.py
+++ b/services/admin/src/admin/routes/force_refresh.py
@@ -9,11 +9,7 @@ from libapi.exceptions import (
     MissingRequiredParameterError,
     UnexpectedApiError,
 )
-from libapi.request import (
-    get_request_parameter_config,
-    get_request_parameter_dataset,
-    get_request_parameter_split,
-)
+from libapi.request import get_required_request_parameter
 from libcommon.constants import MIN_BYTES_FOR_BONUS_DIFFICULTY
 from libcommon.dataset import get_dataset_git_revision
 from libcommon.exceptions import CustomError
@@ -47,16 +43,16 @@ def create_force_refresh_endpoint(
 ) -> Endpoint:
     async def force_refresh_endpoint(request: Request) -> Response:
         try:
-            dataset = get_request_parameter_dataset(request)
+            dataset = get_required_request_parameter(request, "dataset")
             if input_type == "dataset":
                 config = None
                 split = None
             elif input_type == "config":
-                config = get_request_parameter_config(request)
+                config = get_required_request_parameter(request, "config")
                 split = None
             else:
-                config = get_request_parameter_config(request)
-                split = get_request_parameter_split(request)
+                config = get_required_request_parameter(request, "config")
+                split = get_required_request_parameter(request, "split")
                 if not are_valid_parameters([config, split]):
                     raise MissingRequiredParameterError("Parameters 'config' and 'split' are required")
             try:

--- a/services/admin/src/admin/routes/force_refresh.py
+++ b/services/admin/src/admin/routes/force_refresh.py
@@ -9,7 +9,7 @@ from libapi.exceptions import (
     MissingRequiredParameterError,
     UnexpectedApiError,
 )
-from libapi.request import get_request_parameter_dataset
+from libapi.request import get_request_parameter_config, get_request_parameter_dataset
 from libcommon.constants import MIN_BYTES_FOR_BONUS_DIFFICULTY
 from libcommon.dataset import get_dataset_git_revision
 from libcommon.exceptions import CustomError
@@ -48,12 +48,10 @@ def create_force_refresh_endpoint(
                 config = None
                 split = None
             elif input_type == "config":
-                config = request.query_params.get("config")
+                config = get_request_parameter_config(request)
                 split = None
-                if not are_valid_parameters([config]):
-                    raise MissingRequiredParameterError("Parameter 'config' is required")
             else:
-                config = request.query_params.get("config")
+                config = get_request_parameter_config(request)
                 split = request.query_params.get("split")
                 if not are_valid_parameters([config, split]):
                     raise MissingRequiredParameterError("Parameters 'config' and 'split' are required")

--- a/services/admin/src/admin/routes/force_refresh.py
+++ b/services/admin/src/admin/routes/force_refresh.py
@@ -42,9 +42,7 @@ def create_force_refresh_endpoint(
 ) -> Endpoint:
     async def force_refresh_endpoint(request: Request) -> Response:
         try:
-            dataset = request.query_params.get("dataset")
-            if not are_valid_parameters([dataset]) or not dataset:
-                raise MissingRequiredParameterError("Parameter 'dataset' is required")
+            dataset = get_request_parameter_dataset(request)
             if input_type == "dataset":
                 config = None
                 split = None
@@ -104,3 +102,10 @@ def create_force_refresh_endpoint(
             return get_json_admin_error_response(UnexpectedApiError("Unexpected error.", e), max_age=0)
 
     return force_refresh_endpoint
+
+
+def get_request_parameter_dataset(request):
+    dataset = request.query_params.get("dataset")
+    if not dataset or not are_valid_parameters([dataset]):
+        raise MissingRequiredParameterError("Parameter 'dataset' is required")
+    return dataset

--- a/services/admin/src/admin/routes/force_refresh.py
+++ b/services/admin/src/admin/routes/force_refresh.py
@@ -9,7 +9,11 @@ from libapi.exceptions import (
     MissingRequiredParameterError,
     UnexpectedApiError,
 )
-from libapi.request import get_request_parameter_config, get_request_parameter_dataset
+from libapi.request import (
+    get_request_parameter_config,
+    get_request_parameter_dataset,
+    get_request_parameter_split,
+)
 from libcommon.constants import MIN_BYTES_FOR_BONUS_DIFFICULTY
 from libcommon.dataset import get_dataset_git_revision
 from libcommon.exceptions import CustomError
@@ -52,7 +56,7 @@ def create_force_refresh_endpoint(
                 split = None
             else:
                 config = get_request_parameter_config(request)
-                split = request.query_params.get("split")
+                split = get_request_parameter_split(request)
                 if not are_valid_parameters([config, split]):
                     raise MissingRequiredParameterError("Parameters 'config' and 'split' are required")
             try:

--- a/services/admin/src/admin/routes/force_refresh.py
+++ b/services/admin/src/admin/routes/force_refresh.py
@@ -9,6 +9,7 @@ from libapi.exceptions import (
     MissingRequiredParameterError,
     UnexpectedApiError,
 )
+from libapi.request import get_request_parameter_dataset
 from libcommon.constants import MIN_BYTES_FOR_BONUS_DIFFICULTY
 from libcommon.dataset import get_dataset_git_revision
 from libcommon.exceptions import CustomError
@@ -102,10 +103,3 @@ def create_force_refresh_endpoint(
             return get_json_admin_error_response(UnexpectedApiError("Unexpected error.", e), max_age=0)
 
     return force_refresh_endpoint
-
-
-def get_request_parameter_dataset(request):
-    dataset = request.query_params.get("dataset")
-    if not dataset or not are_valid_parameters([dataset]):
-        raise MissingRequiredParameterError("Parameter 'dataset' is required")
-    return dataset

--- a/services/admin/src/admin/routes/recreate_dataset.py
+++ b/services/admin/src/admin/routes/recreate_dataset.py
@@ -43,9 +43,7 @@ def create_recreate_dataset_endpoint(
 ) -> Endpoint:
     async def recreate_dataset_endpoint(request: Request) -> Response:
         try:
-            dataset = request.query_params.get("dataset")
-            if not are_valid_parameters([dataset]) or not dataset:
-                raise MissingRequiredParameterError("Parameter 'dataset' is required")
+            dataset = get_request_parameter_dataset(request)
             try:
                 priority = Priority(request.query_params.get("priority", "low"))
             except ValueError:
@@ -94,3 +92,10 @@ def create_recreate_dataset_endpoint(
             return get_json_admin_error_response(UnexpectedApiError("Unexpected error.", e), max_age=0)
 
     return recreate_dataset_endpoint
+
+
+def get_request_parameter_dataset(request):
+    dataset = request.query_params.get("dataset")
+    if not dataset or not are_valid_parameters([dataset]):
+        raise MissingRequiredParameterError("Parameter 'dataset' is required")
+    return dataset

--- a/services/admin/src/admin/routes/recreate_dataset.py
+++ b/services/admin/src/admin/routes/recreate_dataset.py
@@ -4,11 +4,8 @@
 import logging
 from typing import Optional
 
-from libapi.exceptions import (
-    InvalidParameterError,
-    MissingRequiredParameterError,
-    UnexpectedApiError,
-)
+from libapi.exceptions import InvalidParameterError, UnexpectedApiError
+from libapi.request import get_request_parameter_dataset
 from libcommon.dataset import get_dataset_git_revision
 from libcommon.exceptions import CustomError
 from libcommon.operations import backfill_dataset
@@ -22,12 +19,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from admin.authentication import auth_check
-from admin.utils import (
-    Endpoint,
-    are_valid_parameters,
-    get_json_admin_error_response,
-    get_json_ok_response,
-)
+from admin.utils import Endpoint, get_json_admin_error_response, get_json_ok_response
 
 
 def create_recreate_dataset_endpoint(
@@ -92,10 +84,3 @@ def create_recreate_dataset_endpoint(
             return get_json_admin_error_response(UnexpectedApiError("Unexpected error.", e), max_age=0)
 
     return recreate_dataset_endpoint
-
-
-def get_request_parameter_dataset(request):
-    dataset = request.query_params.get("dataset")
-    if not dataset or not are_valid_parameters([dataset]):
-        raise MissingRequiredParameterError("Parameter 'dataset' is required")
-    return dataset

--- a/services/admin/src/admin/routes/recreate_dataset.py
+++ b/services/admin/src/admin/routes/recreate_dataset.py
@@ -5,7 +5,7 @@ import logging
 from typing import Optional
 
 from libapi.exceptions import InvalidParameterError, UnexpectedApiError
-from libapi.request import get_request_parameter_dataset
+from libapi.request import get_required_request_parameter
 from libcommon.dataset import get_dataset_git_revision
 from libcommon.exceptions import CustomError
 from libcommon.operations import backfill_dataset
@@ -35,7 +35,7 @@ def create_recreate_dataset_endpoint(
 ) -> Endpoint:
     async def recreate_dataset_endpoint(request: Request) -> Response:
         try:
-            dataset = get_request_parameter_dataset(request)
+            dataset = get_required_request_parameter(request, "dataset")
             try:
                 priority = Priority(request.query_params.get("priority", "low"))
             except ValueError:

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -13,6 +13,7 @@ from libapi.exceptions import (
     UnexpectedApiError,
 )
 from libapi.request import (
+    get_request_parameter_config,
     get_request_parameter_dataset,
     get_request_parameter_length,
     get_request_parameter_offset,
@@ -84,7 +85,7 @@ def create_rows_endpoint(
             try:
                 with StepProfiler(method="rows_endpoint", step="validate parameters"):
                     dataset = get_request_parameter_dataset(request)
-                    config = request.query_params.get("config")
+                    config = get_request_parameter_config(request)
                     split = request.query_params.get("split")
                     if not dataset or not config or not split or not are_valid_parameters([dataset, config, split]):
                         raise MissingRequiredParameterError("Parameter 'dataset', 'config' and 'split' are required")

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -12,7 +12,11 @@ from libapi.exceptions import (
     MissingRequiredParameterError,
     UnexpectedApiError,
 )
-from libapi.request import get_request_parameter_length, get_request_parameter_offset
+from libapi.request import (
+    get_request_parameter_dataset,
+    get_request_parameter_length,
+    get_request_parameter_offset,
+)
 from libapi.response import create_response
 from libapi.utils import (
     Endpoint,
@@ -189,10 +193,3 @@ def create_rows_endpoint(
                     return get_json_api_error_response(error=error, max_age=max_age_short, revision=revision)
 
     return rows_endpoint
-
-
-def get_request_parameter_dataset(request):
-    dataset = request.query_params.get("dataset")
-    if not dataset or not are_valid_parameters([dataset]):
-        raise MissingRequiredParameterError("Parameter 'dataset' is required")
-    return dataset

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -17,6 +17,7 @@ from libapi.request import (
     get_request_parameter_dataset,
     get_request_parameter_length,
     get_request_parameter_offset,
+    get_request_parameter_split,
 )
 from libapi.response import create_response
 from libapi.utils import (
@@ -86,7 +87,7 @@ def create_rows_endpoint(
                 with StepProfiler(method="rows_endpoint", step="validate parameters"):
                     dataset = get_request_parameter_dataset(request)
                     config = get_request_parameter_config(request)
-                    split = request.query_params.get("split")
+                    split = get_request_parameter_split(request)
                     if not dataset or not config or not split or not are_valid_parameters([dataset, config, split]):
                         raise MissingRequiredParameterError("Parameter 'dataset', 'config' and 'split' are required")
                     offset = get_request_parameter_offset(request)

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -7,11 +7,7 @@ from typing import Literal, Optional, Union
 
 from fsspec.implementations.http import HTTPFileSystem
 from libapi.authentication import auth_check
-from libapi.exceptions import (
-    ApiError,
-    MissingRequiredParameterError,
-    UnexpectedApiError,
-)
+from libapi.exceptions import ApiError, UnexpectedApiError
 from libapi.request import (
     get_request_parameter_length,
     get_request_parameter_offset,
@@ -20,7 +16,6 @@ from libapi.request import (
 from libapi.response import create_response
 from libapi.utils import (
     Endpoint,
-    are_valid_parameters,
     clean_cached_assets,
     get_json_api_error_response,
     get_json_error_response,
@@ -86,8 +81,6 @@ def create_rows_endpoint(
                     dataset = get_required_request_parameter(request, "dataset")
                     config = get_required_request_parameter(request, "config")
                     split = get_required_request_parameter(request, "split")
-                    if not dataset or not config or not split or not are_valid_parameters([dataset, config, split]):
-                        raise MissingRequiredParameterError("Parameter 'dataset', 'config' and 'split' are required")
                     offset = get_request_parameter_offset(request)
                     length = get_request_parameter_length(request)
                     logging.info(

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -79,7 +79,7 @@ def create_rows_endpoint(
         with StepProfiler(method="rows_endpoint", step="all"):
             try:
                 with StepProfiler(method="rows_endpoint", step="validate parameters"):
-                    dataset = request.query_params.get("dataset")
+                    dataset = get_request_parameter_dataset(request)
                     config = request.query_params.get("config")
                     split = request.query_params.get("split")
                     if not dataset or not config or not split or not are_valid_parameters([dataset, config, split]):
@@ -189,3 +189,10 @@ def create_rows_endpoint(
                     return get_json_api_error_response(error=error, max_age=max_age_short, revision=revision)
 
     return rows_endpoint
+
+
+def get_request_parameter_dataset(request):
+    dataset = request.query_params.get("dataset")
+    if not dataset or not are_valid_parameters([dataset]):
+        raise MissingRequiredParameterError("Parameter 'dataset' is required")
+    return dataset

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -13,11 +13,9 @@ from libapi.exceptions import (
     UnexpectedApiError,
 )
 from libapi.request import (
-    get_request_parameter_config,
-    get_request_parameter_dataset,
     get_request_parameter_length,
     get_request_parameter_offset,
-    get_request_parameter_split,
+    get_required_request_parameter,
 )
 from libapi.response import create_response
 from libapi.utils import (
@@ -85,9 +83,9 @@ def create_rows_endpoint(
         with StepProfiler(method="rows_endpoint", step="all"):
             try:
                 with StepProfiler(method="rows_endpoint", step="validate parameters"):
-                    dataset = get_request_parameter_dataset(request)
-                    config = get_request_parameter_config(request)
-                    split = get_request_parameter_split(request)
+                    dataset = get_required_request_parameter(request, "dataset")
+                    config = get_required_request_parameter(request, "config")
+                    split = get_required_request_parameter(request, "split")
                     if not dataset or not config or not split or not are_valid_parameters([dataset, config, split]):
                         raise MissingRequiredParameterError("Parameter 'dataset', 'config' and 'split' are required")
                     offset = get_request_parameter_offset(request)

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -22,6 +22,7 @@ from libapi.exceptions import (
     UnexpectedApiError,
 )
 from libapi.request import (
+    get_request_parameter_config,
     get_request_parameter_dataset,
     get_request_parameter_length,
     get_request_parameter_offset,
@@ -90,7 +91,7 @@ def create_filter_endpoint(
             try:
                 with StepProfiler(method="filter_endpoint", step="validate parameters"):
                     dataset = get_request_parameter_dataset(request)
-                    config = request.query_params.get("config")
+                    config = get_request_parameter_config(request)
                     split = request.query_params.get("split")
                     where = request.query_params.get("where")
                     if (

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -15,12 +15,7 @@ from libapi.duckdb import (
     get_cache_entry_from_duckdb_index_job,
     get_index_file_location_and_download_if_missing,
 )
-from libapi.exceptions import (
-    ApiError,
-    InvalidParameterError,
-    MissingRequiredParameterError,
-    UnexpectedApiError,
-)
+from libapi.exceptions import ApiError, InvalidParameterError, UnexpectedApiError
 from libapi.request import (
     get_request_parameter_length,
     get_request_parameter_offset,
@@ -29,7 +24,6 @@ from libapi.request import (
 from libapi.response import ROW_IDX_COLUMN, create_response
 from libapi.utils import (
     Endpoint,
-    are_valid_parameters,
     clean_cached_assets_randomly,
     get_json_api_error_response,
     get_json_error_response,
@@ -93,16 +87,6 @@ def create_filter_endpoint(
                     config = get_required_request_parameter(request, "config")
                     split = get_required_request_parameter(request, "split")
                     where = get_required_request_parameter(request, "where")
-                    if (
-                        not dataset
-                        or not config
-                        or not split
-                        or not where
-                        or not are_valid_parameters([dataset, config, split, where])
-                    ):
-                        raise MissingRequiredParameterError(
-                            "Parameters 'dataset', 'config', 'split' and 'where' are required"
-                        )
                     validate_where_parameter(where)
                     offset = get_request_parameter_offset(request)
                     length = get_request_parameter_length(request)

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -22,11 +22,9 @@ from libapi.exceptions import (
     UnexpectedApiError,
 )
 from libapi.request import (
-    get_request_parameter_config,
-    get_request_parameter_dataset,
     get_request_parameter_length,
     get_request_parameter_offset,
-    get_request_parameter_split,
+    get_required_request_parameter,
 )
 from libapi.response import ROW_IDX_COLUMN, create_response
 from libapi.utils import (
@@ -91,9 +89,9 @@ def create_filter_endpoint(
         with StepProfiler(method="filter_endpoint", step="all"):
             try:
                 with StepProfiler(method="filter_endpoint", step="validate parameters"):
-                    dataset = get_request_parameter_dataset(request)
-                    config = get_request_parameter_config(request)
-                    split = get_request_parameter_split(request)
+                    dataset = get_required_request_parameter(request, "dataset")
+                    config = get_required_request_parameter(request, "config")
+                    split = get_required_request_parameter(request, "split")
                     where = request.query_params.get("where")
                     if (
                         not dataset

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -21,7 +21,11 @@ from libapi.exceptions import (
     MissingRequiredParameterError,
     UnexpectedApiError,
 )
-from libapi.request import get_request_parameter_length, get_request_parameter_offset
+from libapi.request import (
+    get_request_parameter_dataset,
+    get_request_parameter_length,
+    get_request_parameter_offset,
+)
 from libapi.response import ROW_IDX_COLUMN, create_response
 from libapi.utils import (
     Endpoint,
@@ -231,10 +235,3 @@ def execute_filter_query(
 def validate_where_parameter(where: str) -> None:
     if SQL_INVALID_SYMBOLS_PATTERN.search(where):
         raise InvalidParameterError(message="Parameter 'where' contains invalid symbols")
-
-
-def get_request_parameter_dataset(request):
-    dataset = request.query_params.get("dataset")
-    if not dataset or not are_valid_parameters([dataset]):
-        raise MissingRequiredParameterError("Parameter 'dataset' is required")
-    return dataset

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -92,7 +92,7 @@ def create_filter_endpoint(
                     dataset = get_required_request_parameter(request, "dataset")
                     config = get_required_request_parameter(request, "config")
                     split = get_required_request_parameter(request, "split")
-                    where = request.query_params.get("where")
+                    where = get_required_request_parameter(request, "where")
                     if (
                         not dataset
                         or not config

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -26,6 +26,7 @@ from libapi.request import (
     get_request_parameter_dataset,
     get_request_parameter_length,
     get_request_parameter_offset,
+    get_request_parameter_split,
 )
 from libapi.response import ROW_IDX_COLUMN, create_response
 from libapi.utils import (
@@ -92,7 +93,7 @@ def create_filter_endpoint(
                 with StepProfiler(method="filter_endpoint", step="validate parameters"):
                     dataset = get_request_parameter_dataset(request)
                     config = get_request_parameter_config(request)
-                    split = request.query_params.get("split")
+                    split = get_request_parameter_split(request)
                     where = request.query_params.get("where")
                     if (
                         not dataset

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -85,7 +85,7 @@ def create_filter_endpoint(
         with StepProfiler(method="filter_endpoint", step="all"):
             try:
                 with StepProfiler(method="filter_endpoint", step="validate parameters"):
-                    dataset = request.query_params.get("dataset")
+                    dataset = get_request_parameter_dataset(request)
                     config = request.query_params.get("config")
                     split = request.query_params.get("split")
                     where = request.query_params.get("where")
@@ -231,3 +231,10 @@ def execute_filter_query(
 def validate_where_parameter(where: str) -> None:
     if SQL_INVALID_SYMBOLS_PATTERN.search(where):
         raise InvalidParameterError(message="Parameter 'where' contains invalid symbols")
+
+
+def get_request_parameter_dataset(request):
+    dataset = request.query_params.get("dataset")
+    if not dataset or not are_valid_parameters([dataset]):
+        raise MissingRequiredParameterError("Parameter 'dataset' is required")
+    return dataset

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -21,11 +21,9 @@ from libapi.exceptions import (
     UnexpectedApiError,
 )
 from libapi.request import (
-    get_request_parameter_config,
-    get_request_parameter_dataset,
     get_request_parameter_length,
     get_request_parameter_offset,
-    get_request_parameter_split,
+    get_required_request_parameter,
 )
 from libapi.response import ROW_IDX_COLUMN
 from libapi.utils import (
@@ -152,9 +150,9 @@ def create_search_endpoint(
         with StepProfiler(method="search_endpoint", step="all"):
             try:
                 with StepProfiler(method="search_endpoint", step="validate parameters"):
-                    dataset = get_request_parameter_dataset(request)
-                    config = get_request_parameter_config(request)
-                    split = get_request_parameter_split(request)
+                    dataset = get_required_request_parameter(request, "dataset")
+                    config = get_required_request_parameter(request, "config")
+                    split = get_required_request_parameter(request, "split")
                     query = request.query_params.get("query")
 
                     if (

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -20,7 +20,11 @@ from libapi.exceptions import (
     SearchFeatureNotAvailableError,
     UnexpectedApiError,
 )
-from libapi.request import get_request_parameter_length, get_request_parameter_offset
+from libapi.request import (
+    get_request_parameter_dataset,
+    get_request_parameter_length,
+    get_request_parameter_offset,
+)
 from libapi.response import ROW_IDX_COLUMN
 from libapi.utils import (
     Endpoint,
@@ -261,10 +265,3 @@ def create_search_endpoint(
                     return get_json_api_error_response(error=error, max_age=max_age_short, revision=revision)
 
     return search_endpoint
-
-
-def get_request_parameter_dataset(request):
-    dataset = request.query_params.get("dataset")
-    if not dataset or not are_valid_parameters([dataset]):
-        raise MissingRequiredParameterError("Parameter 'dataset' is required")
-    return dataset

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -16,7 +16,6 @@ from libapi.duckdb import (
 )
 from libapi.exceptions import (
     ApiError,
-    MissingRequiredParameterError,
     SearchFeatureNotAvailableError,
     UnexpectedApiError,
 )
@@ -28,7 +27,6 @@ from libapi.request import (
 from libapi.response import ROW_IDX_COLUMN
 from libapi.utils import (
     Endpoint,
-    are_valid_parameters,
     clean_cached_assets_randomly,
     get_json_api_error_response,
     get_json_error_response,
@@ -154,20 +152,7 @@ def create_search_endpoint(
                     config = get_required_request_parameter(request, "config")
                     split = get_required_request_parameter(request, "split")
                     query = get_required_request_parameter(request, "query")
-
-                    if (
-                        not dataset
-                        or not config
-                        or not split
-                        or not query
-                        or not are_valid_parameters([dataset, config, split, query])
-                    ):
-                        raise MissingRequiredParameterError(
-                            "Parameter 'dataset', 'config', 'split' and 'query' are required"
-                        )
-
                     offset = get_request_parameter_offset(request)
-
                     length = get_request_parameter_length(request)
 
                 with StepProfiler(method="search_endpoint", step="check authentication"):

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -25,6 +25,7 @@ from libapi.request import (
     get_request_parameter_dataset,
     get_request_parameter_length,
     get_request_parameter_offset,
+    get_request_parameter_split,
 )
 from libapi.response import ROW_IDX_COLUMN
 from libapi.utils import (
@@ -153,7 +154,7 @@ def create_search_endpoint(
                 with StepProfiler(method="search_endpoint", step="validate parameters"):
                     dataset = get_request_parameter_dataset(request)
                     config = get_request_parameter_config(request)
-                    split = request.query_params.get("split")
+                    split = get_request_parameter_split(request)
                     query = request.query_params.get("query")
 
                     if (

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -21,6 +21,7 @@ from libapi.exceptions import (
     UnexpectedApiError,
 )
 from libapi.request import (
+    get_request_parameter_config,
     get_request_parameter_dataset,
     get_request_parameter_length,
     get_request_parameter_offset,
@@ -151,7 +152,7 @@ def create_search_endpoint(
             try:
                 with StepProfiler(method="search_endpoint", step="validate parameters"):
                     dataset = get_request_parameter_dataset(request)
-                    config = request.query_params.get("config")
+                    config = get_request_parameter_config(request)
                     split = request.query_params.get("split")
                     query = request.query_params.get("query")
 

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -146,7 +146,7 @@ def create_search_endpoint(
         with StepProfiler(method="search_endpoint", step="all"):
             try:
                 with StepProfiler(method="search_endpoint", step="validate parameters"):
-                    dataset = request.query_params.get("dataset")
+                    dataset = get_request_parameter_dataset(request)
                     config = request.query_params.get("config")
                     split = request.query_params.get("split")
                     query = request.query_params.get("query")
@@ -261,3 +261,10 @@ def create_search_endpoint(
                     return get_json_api_error_response(error=error, max_age=max_age_short, revision=revision)
 
     return search_endpoint
+
+
+def get_request_parameter_dataset(request):
+    dataset = request.query_params.get("dataset")
+    if not dataset or not are_valid_parameters([dataset]):
+        raise MissingRequiredParameterError("Parameter 'dataset' is required")
+    return dataset

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -153,7 +153,7 @@ def create_search_endpoint(
                     dataset = get_required_request_parameter(request, "dataset")
                     config = get_required_request_parameter(request, "config")
                     split = get_required_request_parameter(request, "split")
-                    query = request.query_params.get("query")
+                    query = get_required_request_parameter(request, "query")
 
                     if (
                         not dataset


### PR DESCRIPTION
Factorize getting the required request parameters `dataset`, `config`, `split`, `query` and `where` (from the service admin and the endpoints /rows, /search and /filter) to `libapi`.
Additionally, align their error messages.