### PR TITLE
Add bonus difficulty to `split-descriptive-statistics` for big datasets

### DIFF
--- a/libs/libcommon/src/libcommon/config.py
+++ b/libs/libcommon/src/libcommon/config.py
@@ -348,6 +348,7 @@ class ProcessingGraphConfig:
                 ],
                 "job_runner_version": PROCESSING_STEP_SPLIT_DESCRIPTIVE_STATISTICS_VERSION,
                 "difficulty": 70,
+                "bonus_difficulty_if_dataset_is_big": 20,
             },
             "split-is-valid": {
                 "input_type": "split",


### PR DESCRIPTION
hopefully will fix ` JobManagerExceededMaximumDurationError` for `split-descriptive-statistics` for big datasets like https://huggingface.co/datasets/Open-Orca/OpenOrca. It appears that loading data to in-memory table takes too much time

We can try like this and meanwhile I'm exploring other options how to query faster on big data