### PR TITLE
Add date type support in cache responses

### DIFF
--- a/libs/libcommon/src/libcommon/resources.py
+++ b/libs/libcommon/src/libcommon/resources.py
@@ -80,7 +80,7 @@ class MongoResource(Resource):
     mongoengine_alias: str
     server_selection_timeout_ms: int = 30_000
 
-    _client: MongoClient = field(init=False)
+    _client: MongoClient = field(init=False, repr=False)
 
     def allocate(self) -> None:
         try:

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -35,6 +35,8 @@ from libcommon.utils import JobParams, get_datetime
 
 
 class DateCodec(TypeCodec):  # type: ignore[misc]
+    """To be able to save datetime.date objects like datetime.datetime objects in mongo"""
+
     python_type = date  # the Python type acted upon by this type codec
     bson_type = DatetimeMS  # the BSON type acted upon by this type codec
 

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -68,7 +68,7 @@ QuerySet.__class_getitem__ = types.MethodType(no_op, QuerySet)
 class QuerySetManager(Generic[U]):
     def __get__(self, instance: object, cls: type[U]) -> QuerySet[U]:
         cls._collection = cls._get_db().get_collection(  # type: ignore[attr-defined]
-            cls._get_collection_name(), codec_options=CodecOptions(type_registry=TypeRegistry([DateCodec()]))   # type: ignore[call-arg]
+            cls._get_collection_name(), codec_options=CodecOptions(type_registry=TypeRegistry([DateCodec()]))  # type: ignore[call-arg]
         )
         return QuerySet(cls, cls._get_collection())
 

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -70,11 +70,11 @@ type_registry = TypeRegistry([DateCodec(), TimeCodec(), TimedeltaCodec(), Decima
 U = TypeVar("U", bound=Document)
 
 
-def np_op(self, _):  # type: ignore
+def no_op(self, _):  # type: ignore
     return self
 
 
-QuerySet.__class_getitem__ = types.MethodType(np_op, QuerySet)
+QuerySet.__class_getitem__ = types.MethodType(no_op, QuerySet)
 
 
 class QuerySetManager(Generic[U]):

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -67,8 +67,9 @@ QuerySet.__class_getitem__ = types.MethodType(no_op, QuerySet)
 
 class QuerySetManager(Generic[U]):
     def __get__(self, instance: object, cls: type[U]) -> QuerySet[U]:
+        codec_options = CodecOptions(type_registry=TypeRegistry([DateCodec()]))  # type: ignore[call-arg]
         cls._collection = cls._get_db().get_collection(  # type: ignore[attr-defined]
-            cls._get_collection_name(), codec_options=CodecOptions(type_registry=TypeRegistry([DateCodec()]))  # type: ignore[call-arg]
+            cls._get_collection_name(), codec_options=codec_options
         )
         return QuerySet(cls, cls._get_collection())
 

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -12,7 +12,6 @@ from typing import Any, Generic, NamedTuple, Optional, TypedDict, TypeVar, overl
 import pandas as pd
 from bson import CodecOptions, ObjectId
 from bson.codec_options import TypeEncoder, TypeRegistry  # type: ignore[attr-defined]
-from bson.datetime_ms import DatetimeMS
 from bson.errors import InvalidId
 from mongoengine import Document
 from mongoengine.errors import DoesNotExist

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -11,7 +11,7 @@ from typing import Any, Generic, NamedTuple, Optional, TypedDict, TypeVar, overl
 
 import pandas as pd
 from bson import CodecOptions, ObjectId
-from bson.codec_options import TypeCodec, TypeRegistry  # type: ignore[attr-defined]
+from bson.codec_options import TypeEncoder, TypeRegistry  # type: ignore[attr-defined]
 from bson.datetime_ms import DatetimeMS
 from bson.errors import InvalidId
 from mongoengine import Document
@@ -35,44 +35,32 @@ from libcommon.constants import (
 from libcommon.utils import JobParams, get_datetime
 
 
-def no_op_on_value(self, value):  # type: ignore
-    return value
-
-
-class DateCodec(TypeCodec):  # type: ignore[misc]
+class DateCodec(TypeEncoder):  # type: ignore[misc]
     """To be able to save datetime.date objects like datetime.datetime objects in mongo"""
 
     python_type = date  # the Python type acted upon by this type codec
-    bson_type = str  # the BSON type acted upon by this type codec
     transform_python = str  # convert date objects to strings in mongo
-    transform_bson = no_op_on_value  # reload from mongo as strings
 
 
-class TimeCodec(TypeCodec):  # type: ignore[misc]
+class TimeCodec(TypeEncoder):  # type: ignore[misc]
     """To be able to save datetime.time objects as strings in mongo"""
 
     python_type = time  # the Python type acted upon by this type codec
-    bson_type = str  # the BSON type acted upon by this type codec
     transform_python = str  # convert time objects to strings in mongo
-    transform_bson = no_op_on_value  # reload from mongo as strings
 
 
-class TimedeltaCodec(TypeCodec):  # type: ignore[misc]
-    """To be able to save datetime.time objects as strings in mongo"""
+class TimedeltaCodec(TypeEncoder):  # type: ignore[misc]
+    """To be able to save datetime.timedelta objects as strings in mongo"""
 
     python_type = timedelta  # the Python type acted upon by this type codec
-    bson_type = str  # the BSON type acted upon by this type codec
     transform_python = str  # convert timedelta objects to strings in mongo
-    transform_bson = no_op_on_value  # reload from mongo as strings
 
 
-class DecimalCodec(TypeCodec):  # type: ignore[misc]
-    """To be able to save datetime.time objects as strings in mongo"""
+class DecimalCodec(TypeEncoder):  # type: ignore[misc]
+    """To be able to save decimal.Decimal objects as strings in mongo"""
 
     python_type = Decimal  # the Python type acted upon by this type codec
-    bson_type = str  # the BSON type acted upon by this type codec
     transform_python = str  # convert decimal objects to strings in mongo
-    transform_bson = no_op_on_value  # reload from mongo as strings
 
 
 type_registry = TypeRegistry([DateCodec(), TimeCodec(), TimedeltaCodec(), DecimalCodec()])
@@ -83,11 +71,11 @@ type_registry = TypeRegistry([DateCodec(), TimeCodec(), TimedeltaCodec(), Decima
 U = TypeVar("U", bound=Document)
 
 
-def no_op_on_self(self, _):  # type: ignore
+def np_op(self, _):  # type: ignore
     return self
 
 
-QuerySet.__class_getitem__ = types.MethodType(no_op_on_self, QuerySet)
+QuerySet.__class_getitem__ = types.MethodType(np_op, QuerySet)
 
 
 class QuerySetManager(Generic[U]):

--- a/libs/libcommon/tests/test_simple_cache.py
+++ b/libs/libcommon/tests/test_simple_cache.py
@@ -2,7 +2,8 @@
 # Copyright 2022 The HuggingFace Authors.
 
 from collections.abc import Mapping
-from datetime import date, datetime
+from datetime import datetime
+from decimal import Decimal
 from http import HTTPStatus
 from time import process_time
 from typing import Any, Optional, TypedDict
@@ -196,17 +197,21 @@ def test_upsert_response_types() -> None:
     dataset = "test_dataset"
 
     now = datetime.now()
-    today = date.today()
+    decimal = Decimal(now.time().microsecond * 1e-6)
     content = {
-        "datetime": now,  # microsecond is rounded to millisecond
-        "date": today,  # date is turned into a datetime
+        "datetime": now,  # microsecond is truncated to millisecond
+        "time": now.time(),  # time it turned into a string
+        "date": now.date(),  # date is turned into a string
+        "decimal": decimal,  # decimal is turned into a string
     }
     upsert_response(kind=kind, dataset=dataset, content=content, http_status=HTTPStatus.OK)
     cached_response = get_response(kind=kind, dataset=dataset)
     assert cached_response["content"]["datetime"] == datetime(
         now.year, now.month, now.day, now.hour, now.minute, now.second, now.microsecond // 1000 * 1000
     )
-    assert cached_response["content"]["date"] == datetime(today.year, today.month, today.day)
+    assert cached_response["content"]["time"] == str(now.time())
+    assert cached_response["content"]["date"] == str(now.date())
+    assert cached_response["content"]["decimal"] == str(decimal)
 
 
 def test_delete_response() -> None:

--- a/libs/libcommon/tests/test_simple_cache.py
+++ b/libs/libcommon/tests/test_simple_cache.py
@@ -2,7 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 from collections.abc import Mapping
-from datetime import datetime
+from datetime import date, datetime
 from http import HTTPStatus
 from time import process_time
 from typing import Any, Optional, TypedDict
@@ -189,6 +189,24 @@ def test_upsert_response(config: Optional[str], split: Optional[str]) -> None:
         "dataset_git_revision": dataset_git_revision,
         "progress": None,
     }
+
+
+def test_upsert_response_types() -> None:
+    kind = "test_kind"
+    dataset = "test_dataset"
+
+    now = datetime.now()
+    today = date.today()
+    content = {
+        "datetime": now,  # microsecond is rounded to millisecond
+        "date": today,  # date is turned into a datetime
+    }
+    upsert_response(kind=kind, dataset=dataset, content=content, http_status=HTTPStatus.OK)
+    cached_response = get_response(kind=kind, dataset=dataset)
+    assert cached_response["content"]["datetime"] == datetime(
+        now.year, now.month, now.day, now.hour, now.minute, now.second, now.microsecond // 1000 * 1000
+    )
+    assert cached_response["content"]["date"] == datetime(today.year, today.month, today.day)
 
 
 def test_delete_response() -> None:


### PR DESCRIPTION
Mongo only supports dates with time (not date alone) because of bson. 
So the `date` python type from `date32` pyarrow type couldn't be saved in mongo.

I fixed it by saving the `date` the same way as `string` objects.

Fix https://github.com/huggingface/datasets-server/issues/86

e.g. in first-rows for [aborruso](https://huggingface.co/aborruso)[/pnrr](https://huggingface.co/datasets/aborruso/pnrr)
```json
{
  "dataset": "__DUMMY_DATASETS_SERVER_USER__/pnrr",
  "config": "default",
  "split": "train",
  "features": [
    {
      "feature_idx": 0,
      "name": "Programma",
      "type": {
        "dtype": "string",
        "_type": "Value"
      }
    },
    ...
    {
      "feature_idx": 50,
      "name": "Data di Estrazione",
      "type": {
        "dtype": "date32",
        "_type": "Value"
      }
    }
  ],
  "rows": [
    {
      "row_idx": 0,
      "row": {
        "Programma": "PNRR",
        ...
        "Data di Estrazione": "2023-06-13"
      },
      "truncated_cells": []
    },
    ...
    ]
}
```

EDIT: also added support for time, timedelta and decimal

I also checked binary but it is already supported, though its format is not ideal (we get a list of integers from mongo)