### PR TITLE
fix cron job metadata name lenght

### DIFF
--- a/chart/templates/_common/_helpers.tpl
+++ b/chart/templates/_common/_helpers.tpl
@@ -111,12 +111,12 @@ app.kubernetes.io/component: "{{ include "name" . }}-backfill"
 
 {{- define "labels.cleanDuckdbIndexDownloads" -}}
 {{ include "hf.labels.commons" . }}
-app.kubernetes.io/component: "{{ include "name" . }}-clean-duckdb-index-downloads"
+app.kubernetes.io/component: "{{ include "name" . }}-clean-duckdb-downloads"
 {{- end -}}
 
 {{- define "labels.cleanDuckdbIndexJobRunner" -}}
 {{ include "hf.labels.commons" . }}
-app.kubernetes.io/component: "{{ include "name" . }}-clean-duckdb-index-job-runner"
+app.kubernetes.io/component: "{{ include "name" . }}-clean-duckdb-job-runner"
 {{- end -}}
 
 {{- define "labels.cleanHfDatasetsCache" -}}

--- a/chart/templates/cron-jobs/clean-duckdb-index-downloads/_container.tpl
+++ b/chart/templates/cron-jobs/clean-duckdb-index-downloads/_container.tpl
@@ -2,7 +2,7 @@
 # Copyright 2023 The HuggingFace Authors.
 
 {{- define "containerCleanDuckdbIndexDownloads" -}}
-- name: "{{ include "name" . }}-clean-duckdb-index-downloads"
+- name: "{{ include "name" . }}-clean-duckdb-downloads"
   image: {{ include "jobs.cacheMaintenance.image" . }}
   imagePullPolicy: {{ .Values.images.pullPolicy }}
   volumeMounts:

--- a/chart/templates/cron-jobs/clean-duckdb-index-downloads/job.yaml
+++ b/chart/templates/cron-jobs/clean-duckdb-index-downloads/job.yaml
@@ -6,7 +6,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels: {{ include "labels.cleanDuckdbIndexDownloads" . | nindent 4 }}
-  name: "{{ include "name" . }}-job-clean-duckdb-index-downloads"
+  name: "{{ include "name" . }}-job-clean-duckdb-downloads"
   namespace: {{ .Release.Namespace }}
 spec:
   schedule: {{ .Values.cleanDuckdbIndexDownloads.schedule | quote }}

--- a/chart/templates/cron-jobs/clean-duckdb-index-job-runner/_container.tpl
+++ b/chart/templates/cron-jobs/clean-duckdb-index-job-runner/_container.tpl
@@ -2,7 +2,7 @@
 # Copyright 2023 The HuggingFace Authors.
 
 {{- define "containerCleanDuckdbIndexJobRunner" -}}
-- name: "{{ include "name" . }}-clean-duckdb-index-job-runner"
+- name: "{{ include "name" . }}-clean-duckdb-job-runner"
   image: {{ include "jobs.cacheMaintenance.image" . }}
   imagePullPolicy: {{ .Values.images.pullPolicy }}
   volumeMounts:

--- a/chart/templates/cron-jobs/clean-duckdb-index-job-runner/job.yaml
+++ b/chart/templates/cron-jobs/clean-duckdb-index-job-runner/job.yaml
@@ -6,7 +6,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels: {{ include "labels.cleanDuckdbIndexJobRunner" . | nindent 4 }}
-  name: "{{ include "name" . }}-job-clean-duckdb-index-job-runner"
+  name: "{{ include "name" . }}-job-clean-duckdb-job-runner"
   namespace: {{ .Release.Namespace }}
 spec:
   schedule: {{ .Values.cleanDuckdbIndexJobRunner.schedule | quote }}


### PR DESCRIPTION
When deploying to staging, this error appeared:
`one or more objects failed to apply, reason: CronJob.batch "staging-datasets-server-job-clean-duckdb-index-downloads" is invalid: metadata.name: Invalid value: "staging-datasets-server-job-clean-duckdb-index-downloads": must be no more than 52 characters,CronJob.batch "staging-datasets-server-job-clean-duckdb-index-job-runner" is invalid: metadata.name: Invalid value: "staging-datasets-server-job-clean-duckdb-index-job-runner": must be no more than 52 characters`

Reducing the job name to see if it fix the error