### PR TITLE
Increase the number of CPUs from 2 to 8 for heavy workers

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -406,10 +406,10 @@ workers:
     replicas: 4
     resources:
       requests:
-        cpu: 2
+        cpu: 8
         memory: "34Gi"
       limits:
-        cpu: 2
+        cpu: 8
         memory: "34Gi"
     tolerations: []
   - deployName: "medium"


### PR DESCRIPTION
Currently loading data into table takes too much time but should be decreased proportionally to the number of cpus. 
For example, on my local machine using 2 cpus loads 4Gb parquet files of [Open-Orca/OpenOrca](https://huggingface.co/datasets/Open-Orca/OpenOrca) for 20 sec and with 8 cpus for 5 sec.

Can we try this? 