### PR TITLE
Make admin authentication asynchronous

### DIFF
--- a/services/admin/poetry.lock
+++ b/services/admin/poetry.lock
@@ -3371,4 +3371,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.9.15"
-content-hash = "36bee5baedf76ee0e632b3eb535a6f947aa0a0b4fe33fc14c0e415a29e2ed185"
+content-hash = "8fb5181c3a094f23dc3518ad708c787b2a9ef43ac043087b3346c865f39d4471"

--- a/services/admin/poetry.lock
+++ b/services/admin/poetry.lock
@@ -2527,6 +2527,25 @@ toml = "*"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "pytest-httpx"
+version = "0.26.0"
+description = "Send responses to httpx."
+category = "dev"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pytest_httpx-0.26.0-py3-none-any.whl", hash = "sha256:ca372b94c569c0aca2f06240f6f78cc223dfbc3ab97b5700d4e14c9a73eab17a"},
+    {file = "pytest_httpx-0.26.0.tar.gz", hash = "sha256:b489c5a7bb847551943eaee601bc35053b35dc4f5961c944305120f14a1d770a"},
+]
+
+[package.dependencies]
+httpx = ">=0.25.0,<0.26.0"
+pytest = ">=7.0.0,<8.0.0"
+
+[package.extras]
+testing = ["pytest-asyncio (>=0.21.0,<0.22.0)", "pytest-cov (>=4.0.0,<5.0.0)"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -2639,25 +2658,6 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
-
-[[package]]
-name = "responses"
-version = "0.18.0"
-description = "A utility library for mocking out the `requests` Python library."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "responses-0.18.0-py3-none-any.whl", hash = "sha256:15c63ad16de13ee8e7182d99c9334f64fd81f1ee79f90748d527c28f7ca9dd51"},
-    {file = "responses-0.18.0.tar.gz", hash = "sha256:380cad4c1c1dc942e5e8a8eaae0b4d4edf708f4f010db8b7bcfafad1fcd254ff"},
-]
-
-[package.dependencies]
-requests = ">=2.0,<3.0"
-urllib3 = ">=1.25.10"
-
-[package.extras]
-tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=4.6)", "pytest-cov", "pytest-localserver", "types-mock", "types-requests"]
 
 [[package]]
 name = "rich"
@@ -3371,4 +3371,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.9.15"
-content-hash = "8fb5181c3a094f23dc3518ad708c787b2a9ef43ac043087b3346c865f39d4471"
+content-hash = "f02262b78325d19904d880f4796df771b88fe8c00a9873785366df8cd878498d"

--- a/services/admin/pyproject.toml
+++ b/services/admin/pyproject.toml
@@ -28,7 +28,7 @@ mypy = "^1.0.0"
 pip-audit = "^2.5.4"
 pytest = "^7.2.1"
 pytest-cov = "^2.12.1"
-responses = "^0.18.0"
+pytest-httpx = "^0.26.0"
 types-psutil = "^5.9.5"
 types-requests = "^2.28.11"
 

--- a/services/admin/pyproject.toml
+++ b/services/admin/pyproject.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 [tool.poetry.dependencies]
 python = "3.9.15"
 environs = "^9.5.0"
+httpx = "^0.25.0"
 libapi = {path = "../../libs/libapi", develop = true}
 requests = "^2.28.2"
 starlette = "^0.28.0"

--- a/services/admin/src/admin/authentication.py
+++ b/services/admin/src/admin/authentication.py
@@ -3,27 +3,10 @@
 
 from typing import Literal, Optional
 
-import requests
+import httpx
+from libapi.authentication import RequestAuth
 from libapi.exceptions import ExternalAuthenticatedError, ExternalUnauthenticatedError
-from requests import PreparedRequest
-from requests.auth import AuthBase
 from starlette.requests import Request
-
-
-class RequestAuth(AuthBase):
-    """Attaches input Request authentication headers to the given Request object."""
-
-    def __init__(self, request: Optional[Request]) -> None:
-        if request is not None:
-            self.authorization = request.headers.get("authorization")
-        else:
-            self.authorization = None
-
-    def __call__(self, r: PreparedRequest) -> PreparedRequest:
-        # modify and return the request
-        if self.authorization:
-            r.headers["authorization"] = self.authorization
-        return r
 
 
 def auth_check(
@@ -50,7 +33,7 @@ def auth_check(
     if organization is None or external_auth_url is None:
         return True
     try:
-        response = requests.get(external_auth_url, auth=RequestAuth(request), timeout=hf_timeout_seconds)
+        response = httpx.get(external_auth_url, auth=RequestAuth(request), timeout=hf_timeout_seconds)
     except Exception as err:
         raise RuntimeError("External authentication check failed", err) from err
     if response.status_code == 200:

--- a/services/admin/src/admin/authentication.py
+++ b/services/admin/src/admin/authentication.py
@@ -9,7 +9,7 @@ from libapi.exceptions import ExternalAuthenticatedError, ExternalUnauthenticate
 from starlette.requests import Request
 
 
-def auth_check(
+async def auth_check(
     external_auth_url: Optional[str] = None,
     request: Optional[Request] = None,
     organization: Optional[str] = None,
@@ -33,7 +33,8 @@ def auth_check(
     if organization is None or external_auth_url is None:
         return True
     try:
-        response = httpx.get(external_auth_url, auth=RequestAuth(request), timeout=hf_timeout_seconds)
+        async with httpx.AsyncClient() as client:
+            response = await client.get(external_auth_url, auth=RequestAuth(request), timeout=hf_timeout_seconds)
     except Exception as err:
         raise RuntimeError("External authentication check failed", err) from err
     if response.status_code == 200:

--- a/services/admin/src/admin/routes/cache_reports.py
+++ b/services/admin/src/admin/routes/cache_reports.py
@@ -26,7 +26,7 @@ def create_cache_reports_endpoint(
             cursor = request.query_params.get("cursor") or ""
             logging.info(f"Cache reports for {cache_kind}, cursor={cursor}")
             # if auth_check fails, it will raise an exception that will be caught below
-            auth_check(
+            await auth_check(
                 external_auth_url=external_auth_url,
                 request=request,
                 organization=organization,

--- a/services/admin/src/admin/routes/cache_reports_with_content.py
+++ b/services/admin/src/admin/routes/cache_reports_with_content.py
@@ -30,7 +30,7 @@ def create_cache_reports_with_content_endpoint(
             cursor = request.query_params.get("cursor") or ""
             logging.info(f"Cache reports with content for {cache_kind}, cursor={cursor}")
             # if auth_check fails, it will raise an exception that will be caught below
-            auth_check(
+            await auth_check(
                 external_auth_url=external_auth_url,
                 request=request,
                 organization=organization,

--- a/services/admin/src/admin/routes/dataset_backfill.py
+++ b/services/admin/src/admin/routes/dataset_backfill.py
@@ -34,7 +34,7 @@ def create_dataset_backfill_endpoint(
             logging.info(f"/dataset-backfill, dataset={dataset}")
 
             # if auth_check fails, it will raise an exception that will be caught below
-            auth_check(
+            await auth_check(
                 external_auth_url=external_auth_url,
                 request=request,
                 organization=organization,

--- a/services/admin/src/admin/routes/dataset_backfill_plan.py
+++ b/services/admin/src/admin/routes/dataset_backfill_plan.py
@@ -32,7 +32,7 @@ def create_dataset_backfill_plan_endpoint(
             logging.info(f"/dataset-state, dataset={dataset}")
 
             # if auth_check fails, it will raise an exception that will be caught below
-            auth_check(
+            await auth_check(
                 external_auth_url=external_auth_url,
                 request=request,
                 organization=organization,

--- a/services/admin/src/admin/routes/dataset_status.py
+++ b/services/admin/src/admin/routes/dataset_status.py
@@ -29,7 +29,7 @@ def create_dataset_status_endpoint(
             logging.info(f"/dataset-status, dataset={dataset}")
 
             # if auth_check fails, it will raise an exception that will be caught below
-            auth_check(
+            await auth_check(
                 external_auth_url=external_auth_url,
                 request=request,
                 organization=organization,

--- a/services/admin/src/admin/routes/force_refresh.py
+++ b/services/admin/src/admin/routes/force_refresh.py
@@ -74,7 +74,7 @@ def create_force_refresh_endpoint(
                     total_difficulty += bonus_difficulty_if_dataset_is_big
 
             # if auth_check fails, it will raise an exception that will be caught below
-            auth_check(
+            await auth_check(
                 external_auth_url=external_auth_url,
                 request=request,
                 organization=organization,

--- a/services/admin/src/admin/routes/num_dataset_infos_by_builder_name.py
+++ b/services/admin/src/admin/routes/num_dataset_infos_by_builder_name.py
@@ -24,7 +24,7 @@ def create_num_dataset_infos_by_builder_name_endpoint(
             logging.info("/num-dataset-infos-by-builder-name")
 
             # if auth_check fails, it will raise an exception that will be caught below
-            auth_check(
+            await auth_check(
                 external_auth_url=external_auth_url,
                 request=request,
                 organization=organization,

--- a/services/admin/src/admin/routes/obsolete_cache.py
+++ b/services/admin/src/admin/routes/obsolete_cache.py
@@ -59,7 +59,7 @@ def create_get_obsolete_cache_endpoint(
     async def get_obsolete_cache_endpoint(request: Request) -> Response:
         try:
             logging.info("/obsolete-cache")
-            auth_check(
+            await auth_check(
                 external_auth_url=external_auth_url,
                 request=request,
                 organization=organization,
@@ -116,7 +116,7 @@ def create_delete_obsolete_cache_endpoint(
     async def delete_obsolete_cache_endpoint(request: Request) -> Response:
         try:
             logging.info("/obsolete-cache")
-            auth_check(
+            await auth_check(
                 external_auth_url=external_auth_url,
                 request=request,
                 organization=organization,

--- a/services/admin/src/admin/routes/pending_jobs.py
+++ b/services/admin/src/admin/routes/pending_jobs.py
@@ -25,7 +25,7 @@ def create_pending_jobs_endpoint(
         logging.info("/pending-jobs")
         try:
             # if auth_check fails, it will raise an exception that will be caught below
-            auth_check(
+            await auth_check(
                 external_auth_url=external_auth_url,
                 request=request,
                 organization=organization,

--- a/services/admin/src/admin/routes/recreate_dataset.py
+++ b/services/admin/src/admin/routes/recreate_dataset.py
@@ -45,7 +45,7 @@ def create_recreate_dataset_endpoint(
             logging.info(f"/recreate-dataset, dataset={dataset}, priority={priority}")
 
             # if auth_check fails, it will raise an exception that will be caught below
-            auth_check(
+            await auth_check(
                 external_auth_url=external_auth_url,
                 request=request,
                 organization=organization,

--- a/services/admin/tests/conftest.py
+++ b/services/admin/tests/conftest.py
@@ -59,3 +59,8 @@ def queue_mongo_resource(app_config: AppConfig) -> Iterator[QueueMongoResource]:
     with QueueMongoResource(database=app_config.queue.mongo_database, host=app_config.queue.mongo_url) as resource:
         yield resource
         _clean_queue_database()
+
+
+@fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/services/admin/tests/utils.py
+++ b/services/admin/tests/utils.py
@@ -1,22 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
 
-from collections.abc import Mapping
-from io import BufferedReader
-from typing import Union
-
-from requests import PreparedRequest
-from responses import Response
-
-_Body = Union[str, BaseException, Response, BufferedReader, bytes]
+import httpx
 
 
-def request_callback(request: PreparedRequest) -> Union[Exception, tuple[int, Mapping[str, str], _Body]]:
+def request_callback(request: httpx.Request) -> httpx.Response:
     # return 404 if a token has been provided,
     # and 200 if none has been provided
-    # there is no logic behind this behavior, it's just to test if th
-    # token are correctly passed to the auth_check service
+    # there is no logic behind this behavior, it's just to test if the
+    # tokens are correctly passed to the auth_check service
     body = '{"orgs": [{"name": "org1"}]}'
     if request.headers.get("authorization"):
-        return (404, {"Content-Type": "text/plain"}, body)
-    return (200, {"Content-Type": "text/plain"}, body)
+        return httpx.Response(status_code=404, text=body)
+    return httpx.Response(status_code=200, text=body)


### PR DESCRIPTION
Make admin service authentication asynchronous by using `httpx` instead of `requests`.

Related to:
- #1975