### PR TITLE
Remove requests as dependency of libapi

### DIFF
--- a/libs/libapi/poetry.lock
+++ b/libs/libapi/poetry.lock
@@ -3142,33 +3142,6 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
-name = "types-requests"
-version = "2.31.0.6"
-description = "Typing stubs for requests"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "types-requests-2.31.0.6.tar.gz", hash = "sha256:cd74ce3b53c461f1228a9b783929ac73a666658f223e28ed29753771477b3bd0"},
-    {file = "types_requests-2.31.0.6-py3-none-any.whl", hash = "sha256:a2db9cb228a81da8348b49ad6db3f5519452dd20a9c1e1a868c83c5fe88fd1a9"},
-]
-
-[package.dependencies]
-types-urllib3 = "*"
-
-[[package]]
-name = "types-urllib3"
-version = "1.26.25.14"
-description = "Typing stubs for urllib3"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f"},
-    {file = "types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e"},
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.8.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -3425,4 +3398,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.9.15"
-content-hash = "fea3705ef291d72c5dfdf4ae49b66746189dc69a0b843b26b1b49a5a61e7a020"
+content-hash = "76e7d7e984eb1974ef3cf63c2344388c0fd908ca903989713a1c6fdaadb46e15"

--- a/libs/libapi/poetry.lock
+++ b/libs/libapi/poetry.lock
@@ -3425,4 +3425,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.9.15"
-content-hash = "26cd610f7e932d237f986607e532f9c79e7545556d02b2104f72db28096ed944"
+content-hash = "fea3705ef291d72c5dfdf4ae49b66746189dc69a0b843b26b1b49a5a61e7a020"

--- a/libs/libapi/pyproject.toml
+++ b/libs/libapi/pyproject.toml
@@ -14,7 +14,6 @@ httpx = "^0.25.0"
 libcommon = {path = "../../libs/libcommon", develop = true}
 orjson = "^3.8.6"
 pyjwt = { extras = ["crypto"], version = "^2.6.0" }
-requests = "^2.28.2"
 starlette = "^0.28.0"
 starlette-prometheus = "^0.9.0"
 

--- a/libs/libapi/pyproject.toml
+++ b/libs/libapi/pyproject.toml
@@ -30,7 +30,6 @@ pip-audit = "^2.5.4"
 pytest = "^7.2.1"
 pytest-cov = "^2.12.1"
 pytest-httpserver = "^1.0.6"
-types-requests = "^2.28.11"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"

--- a/libs/libapi/src/libapi/jwt_token.py
+++ b/libs/libapi/src/libapi/jwt_token.py
@@ -4,8 +4,8 @@
 import logging
 from typing import Any, Optional, Union
 
+import httpx
 import jwt
-import requests
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ec import (
     EllipticCurvePrivateKey,
@@ -174,7 +174,7 @@ def fetch_jwt_public_key_json(
         RuntimeError: if the request fails
     """
     try:
-        response = requests.get(url, timeout=hf_timeout_seconds)
+        response = httpx.get(url, timeout=hf_timeout_seconds)
         response.raise_for_status()
         return response.json()
     except Exception as err:

--- a/services/admin/poetry.lock
+++ b/services/admin/poetry.lock
@@ -1278,7 +1278,6 @@ httpx = "^0.25.0"
 libcommon = {path = "../../libs/libcommon", develop = true}
 orjson = "^3.8.6"
 pyjwt = {version = "^2.6.0", extras = ["crypto"]}
-requests = "^2.28.2"
 starlette = "^0.28.0"
 starlette-prometheus = "^0.9.0"
 

--- a/services/api/poetry.lock
+++ b/services/api/poetry.lock
@@ -1298,7 +1298,6 @@ httpx = "^0.25.0"
 libcommon = {path = "../../libs/libcommon", develop = true}
 orjson = "^3.8.6"
 pyjwt = {version = "^2.6.0", extras = ["crypto"]}
-requests = "^2.28.2"
 starlette = "^0.28.0"
 starlette-prometheus = "^0.9.0"
 

--- a/services/api/poetry.lock
+++ b/services/api/poetry.lock
@@ -3106,33 +3106,6 @@ files = [
 ]
 
 [[package]]
-name = "types-requests"
-version = "2.31.0.1"
-description = "Typing stubs for requests"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "types-requests-2.31.0.1.tar.gz", hash = "sha256:3de667cffa123ce698591de0ad7db034a5317457a596eb0b4944e5a9d9e8d1ac"},
-    {file = "types_requests-2.31.0.1-py3-none-any.whl", hash = "sha256:afb06ef8f25ba83d59a1d424bd7a5a939082f94b94e90ab5e6116bd2559deaa3"},
-]
-
-[package.dependencies]
-types-urllib3 = "*"
-
-[[package]]
-name = "types-urllib3"
-version = "1.26.25.13"
-description = "Typing stubs for urllib3"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "types-urllib3-1.26.25.13.tar.gz", hash = "sha256:3300538c9dc11dad32eae4827ac313f5d986b8b21494801f1bf97a1ac6c03ae5"},
-    {file = "types_urllib3-1.26.25.13-py3-none-any.whl", hash = "sha256:5dbd1d2bef14efee43f5318b5d36d805a489f6600252bb53626d4bfafd95e27c"},
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.6.3"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -3447,4 +3420,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.9.15"
-content-hash = "39c9eb30e27eef6667b47ee330c76f0168f07f735009ee68efb391c1de149a14"
+content-hash = "8200833dd33f052389e0a812b37377f755e1a130a56ea3ca0a673a77ad28226c"

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -6,11 +6,11 @@ version = "0.1.3"
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
+python = "3.9.15"
 environs = "^9.5.0"
 jsonschema = "^4.17.0"
 libapi = {path = "../../libs/libapi", develop = true}
 pyarrow = "^11.0.0"
-python = "3.9.15"
 soundfile = ">=0.12.1"
 uvicorn = "^0.20.0"
 watchdog = { extras = ["watchmedo"], version = "^2.2.1" }
@@ -20,16 +20,15 @@ bandit = "^1.7.4"
 black = "^22.12.0"
 flake8 = "^3.9.2"
 flake8-pep585 = "^0.1.7"
+flake8-unused-arguments = "^0.0.13"
 isort = "^5.12.0"
 mypy = "^1.0.0"
 pandas-stubs = "^1.5.3"
 pip-audit = "^2.5.4"
 pytest = "^7.2.1"
 pytest-cov = "^2.12.1"
-types-psutil = "^5.9.5"
 types-jsonschema = "^4.17.0.4"
-types-requests = "^2.28.11"
-flake8-unused-arguments = "^0.0.13"
+types-psutil = "^5.9.5"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"

--- a/services/rows/poetry.lock
+++ b/services/rows/poetry.lock
@@ -1327,7 +1327,6 @@ httpx = "^0.25.0"
 libcommon = {path = "../../libs/libcommon", develop = true}
 orjson = "^3.8.6"
 pyjwt = {version = "^2.6.0", extras = ["crypto"]}
-requests = "^2.28.2"
 starlette = "^0.28.0"
 starlette-prometheus = "^0.9.0"
 

--- a/services/rows/poetry.lock
+++ b/services/rows/poetry.lock
@@ -3291,33 +3291,6 @@ files = [
 ]
 
 [[package]]
-name = "types-requests"
-version = "2.31.0.1"
-description = "Typing stubs for requests"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "types-requests-2.31.0.1.tar.gz", hash = "sha256:3de667cffa123ce698591de0ad7db034a5317457a596eb0b4944e5a9d9e8d1ac"},
-    {file = "types_requests-2.31.0.1-py3-none-any.whl", hash = "sha256:afb06ef8f25ba83d59a1d424bd7a5a939082f94b94e90ab5e6116bd2559deaa3"},
-]
-
-[package.dependencies]
-types-urllib3 = "*"
-
-[[package]]
-name = "types-urllib3"
-version = "1.26.25.13"
-description = "Typing stubs for urllib3"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "types-urllib3-1.26.25.13.tar.gz", hash = "sha256:3300538c9dc11dad32eae4827ac313f5d986b8b21494801f1bf97a1ac6c03ae5"},
-    {file = "types_urllib3-1.26.25.13-py3-none-any.whl", hash = "sha256:5dbd1d2bef14efee43f5318b5d36d805a489f6600252bb53626d4bfafd95e27c"},
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -3662,4 +3635,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.9.15"
-content-hash = "e2ed15b71e85da1c739432208f806566b820cf6f2cf16e9fd7b7a5431d8008e5"
+content-hash = "9fe69cd1d37b5c59604510b5288ffce9899d7657aaf20edd7a9702993cae3691"

--- a/services/rows/pyproject.toml
+++ b/services/rows/pyproject.toml
@@ -31,7 +31,6 @@ pytest = "^7.2.1"
 pytest-cov = "^2.12.1"
 types-jsonschema = "^4.17.0.4"
 types-psutil = "^5.9.5"
-types-requests = "^2.28.11"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"

--- a/services/search/poetry.lock
+++ b/services/search/poetry.lock
@@ -3239,33 +3239,6 @@ files = [
 ]
 
 [[package]]
-name = "types-requests"
-version = "2.31.0.2"
-description = "Typing stubs for requests"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "types-requests-2.31.0.2.tar.gz", hash = "sha256:6aa3f7faf0ea52d728bb18c0a0d1522d9bfd8c72d26ff6f61bfc3d06a411cf40"},
-    {file = "types_requests-2.31.0.2-py3-none-any.whl", hash = "sha256:56d181c85b5925cbc59f4489a57e72a8b2166f18273fd8ba7b6fe0c0b986f12a"},
-]
-
-[package.dependencies]
-types-urllib3 = "*"
-
-[[package]]
-name = "types-urllib3"
-version = "1.26.25.14"
-description = "Typing stubs for urllib3"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f"},
-    {file = "types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e"},
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -3580,4 +3553,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.9.15"
-content-hash = "40e841e8e5a46efd7bd8f52f44a1fdc9a4c611dde7c02159988e240763272997"
+content-hash = "0c2354ac621a036b72ebfe40e2b319dab3a08dc8e1b1eef75a9bdec6964f93c4"

--- a/services/search/poetry.lock
+++ b/services/search/poetry.lock
@@ -1313,7 +1313,6 @@ httpx = "^0.25.0"
 libcommon = {path = "../../libs/libcommon", develop = true}
 orjson = "^3.8.6"
 pyjwt = {version = "^2.6.0", extras = ["crypto"]}
-requests = "^2.28.2"
 starlette = "^0.28.0"
 starlette-prometheus = "^0.9.0"
 

--- a/services/search/pyproject.toml
+++ b/services/search/pyproject.toml
@@ -30,7 +30,6 @@ pytest = "^7.2.1"
 pytest-cov = "^2.12.1"
 types-jsonschema = "^4.17.0.4"
 types-psutil = "^5.9.5"
-types-requests = "^2.28.11"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"

--- a/services/sse-api/poetry.lock
+++ b/services/sse-api/poetry.lock
@@ -1348,7 +1348,6 @@ httpx = "^0.25.0"
 libcommon = {path = "../../libs/libcommon", develop = true}
 orjson = "^3.8.6"
 pyjwt = {version = "^2.6.0", extras = ["crypto"]}
-requests = "^2.28.2"
 starlette = "^0.28.0"
 starlette-prometheus = "^0.9.0"
 


### PR DESCRIPTION
Remove `requests` as `libapi` dependency by using `httpx` instead.