### PR TITLE
Remove unused httpfs duckdb extension

### DIFF
--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -476,10 +476,6 @@ def compute_descriptive_statistics_response(
     )
 
     con = duckdb.connect(":memory:")  # we don't load data in local db file, we load it in an in-memory table
-    # configure duckdb extensions
-    con.sql(f"SET extension_directory='{local_parquet_directory}';")
-    con.sql("INSTALL httpfs")
-    con.sql("LOAD httpfs")
     con.sql("SET enable_progress_bar=true;")
     logging.info("Loading data into in-memory table. ")
     con.sql(

--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -477,14 +477,21 @@ def compute_descriptive_statistics_response(
 
     con = duckdb.connect(":memory:")  # we don't load data in local db file, we load it in an in-memory table
     con.sql("SET enable_progress_bar=true;")
+    n_threads = con.sql("SELECT current_setting('threads')").fetchall()[0][0]
+    logging.info(f"Original number of threads={n_threads}")
+    con.sql("SET threads TO 8;")
+    n_threads = con.sql("SELECT current_setting('threads')").fetchall()[0][0]
+    logging.info(f"Number of threads={n_threads}")
+
     logging.info("Loading data into in-memory table. ")
-    con.sql(
-        CREATE_TABLE_COMMAND.format(
-            table_name=DATA_TABLE_NAME,
-            column_names=all_feature_names,
-            select_from=f"read_parquet('{local_parquet_glob_path}')",
-        )
+    create_table_command = CREATE_TABLE_COMMAND.format(
+        table_name=DATA_TABLE_NAME,
+        column_names=all_feature_names,
+        select_from=f"read_parquet('{local_parquet_glob_path}')",
     )
+    logging.info(create_table_command)
+    con.sql(create_table_command)
+    logging.info("Loading finished. ")
 
     if string_features:
         logging.info(f"Compute statistics for string columns {string_features}")

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -154,8 +154,6 @@ def compute_index_rows(
     if extensions_directory is not None:
         con.execute(SET_EXTENSIONS_DIRECTORY_COMMAND.format(directory=extensions_directory))
 
-    con.execute(INSTALL_EXTENSION_COMMAND.format(extension="httpfs"))
-    con.execute(LOAD_EXTENSION_COMMAND.format(extension="httpfs"))
     con.execute(INSTALL_EXTENSION_COMMAND.format(extension="fts"))
     con.execute(LOAD_EXTENSION_COMMAND.format(extension="fts"))
 


### PR DESCRIPTION
it's not used for files download anymore, we use `huggingface_hub` directly

**+ I added some logging to check what's going on with the stats computing in this PR to make it fast, to be removed!**