### PR TITLE
Move modification time update of duckdb index file to libapi

### DIFF
--- a/libs/libapi/src/libapi/duckdb.py
+++ b/libs/libapi/src/libapi/duckdb.py
@@ -50,6 +50,8 @@ def get_index_file_location_and_download_if_missing(
                     repo_file_location=repo_file_location,
                     hf_token=hf_token,
                 )
+        # Update its modification time
+        index_path.touch()
         return index_file_location
 
 

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -210,7 +210,6 @@ def create_search_endpoint(
                 with StepProfiler(method="search_endpoint", step="perform FTS command"):
                     logging.debug(f"connect to index file {index_file_location}")
                     (num_rows_total, pa_table) = full_text_search(index_file_location, query, offset, length)
-                    Path(index_file_location).touch()
 
                 with StepProfiler(method="search_endpoint", step="clean cache randomly"):
                     clean_cached_assets_randomly(

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -3,6 +3,7 @@
 
 import logging
 from http import HTTPStatus
+from pathlib import Path
 from typing import Optional
 
 import pyarrow as pa
@@ -209,6 +210,7 @@ def create_search_endpoint(
                 with StepProfiler(method="search_endpoint", step="perform FTS command"):
                     logging.debug(f"connect to index file {index_file_location}")
                     (num_rows_total, pa_table) = full_text_search(index_file_location, query, offset, length)
+                    Path(index_file_location).touch()
 
                 with StepProfiler(method="search_endpoint", step="clean cache randomly"):
                     clean_cached_assets_randomly(

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -3,7 +3,6 @@
 
 import logging
 from http import HTTPStatus
-from pathlib import Path
 from typing import Optional
 
 import pyarrow as pa
@@ -210,7 +209,6 @@ def create_search_endpoint(
                 with StepProfiler(method="search_endpoint", step="perform FTS command"):
                     logging.debug(f"connect to index file {index_file_location}")
                     (num_rows_total, pa_table) = full_text_search(index_file_location, query, offset, length)
-                    Path(index_file_location).touch()
 
                 with StepProfiler(method="search_endpoint", step="clean cache randomly"):
                     clean_cached_assets_randomly(


### PR DESCRIPTION
EDIT:
After the explanation by @AndreaFrancis, this PR moves the updating of the modification time of the duckdb index file from the /search endpoint to the `libapi` function `get_index_file_location_and_download_if_missing`.
This way, the modification time is also updated by the /filter endpoint.

~~Remove unnecessary `Path.touch` in /search.~~

~~I think this is not needed.~~
CC: @AndreaFrancis 