### PR TITLE
adding clean stats cache cron job

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.19.0
+version: 1.20.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -227,6 +227,11 @@ cleanDuckdbIndexJobRunner:
     role-datasets-server: "true"
   expiredTimeIntervalSeconds: 10_800 # 3 hours
 
+cleanStatsCache:
+  nodeSelector:
+    role-datasets-server: "true"
+  expiredTimeIntervalSeconds: 10_800 # 3 hours
+
 postMessages:
   nodeSelector:
     role-datasets-server: "true"

--- a/chart/templates/_common/_helpers.tpl
+++ b/chart/templates/_common/_helpers.tpl
@@ -124,6 +124,11 @@ app.kubernetes.io/component: "{{ include "name" . }}-clean-duckdb-job-runner"
 app.kubernetes.io/component: "{{ include "name" . }}-clean-hf-datasets-cache"
 {{- end -}}
 
+{{- define "labels.cleanStatsCache" -}}
+{{ include "hf.labels.commons" . }}
+app.kubernetes.io/component: "{{ include "name" . }}-clean-stats-cache"
+{{- end -}}
+
 {{- define "labels.postMessages" -}}
 {{ include "hf.labels.commons" . }}
 app.kubernetes.io/component: "{{ include "name" . }}-post-messages"

--- a/chart/templates/cron-jobs/clean-stats-cache/_container.tpl
+++ b/chart/templates/cron-jobs/clean-stats-cache/_container.tpl
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 The HuggingFace Authors.
+
+{{- define "containerCleanStatsCache" -}}
+- name: "{{ include "name" . }}-clean-stats-cache"
+  image: {{ include "jobs.cacheMaintenance.image" . }}
+  imagePullPolicy: {{ .Values.images.pullPolicy }}
+  volumeMounts:
+  {{ include "volumeMountDescriptiveStatisticsRW" . | nindent 2 }}
+  securityContext:
+    allowPrivilegeEscalation: false
+  resources: {{ toYaml .Values.cleanStatsCache.resources | nindent 4 }}
+  env:
+    {{ include "envCommon" . | nindent 2 }}
+  - name: CACHE_MAINTENANCE_ACTION
+    value: {{ .Values.cleanStatsCache.action | quote }}
+  - name: LOG_LEVEL
+    value: {{ .Values.cleanStatsCache.log.level | quote }}
+  - name: DIRECTORY_CLEANING_CACHE_DIRECTORY
+    value: {{ .Values.descriptiveStatistics.cacheDirectory | quote }}
+  - name: DIRECTORY_CLEANING_SUBFOLDER_PATTERN
+    value: {{ .Values.cleanStatsCache.subfolderPattern | quote }}
+  - name: DIRECTORY_CLEANING_EXPIRED_TIME_INTERVAL_SECONDS
+    value: {{ .Values.cleanStatsCache.expiredTimeIntervalSeconds | quote }}
+{{- end -}}

--- a/chart/templates/cron-jobs/clean-stats-cache/job.yaml
+++ b/chart/templates/cron-jobs/clean-stats-cache/job.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 The HuggingFace Authors.
+
+{{- if and .Values.images.jobs.cacheMaintenance .Values.cleanStatsCache.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels: {{ include "labels.cleanStatsCache" . | nindent 4 }}
+  name: "{{ include "name" . }}-job-clean-stats-cache"
+  namespace: {{ .Release.Namespace }}
+spec:
+  schedule: {{ .Values.cleanStatsCache.schedule | quote }}
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 3600
+      template:
+        spec:
+          restartPolicy: OnFailure
+          {{- include "dnsConfig" . | nindent 10 }}
+          {{- include "image.imagePullSecrets" . | nindent 6 }}
+          nodeSelector: {{ toYaml .Values.cleanStatsCache.nodeSelector | nindent 12 }}
+          tolerations: {{ toYaml .Values.cleanStatsCache.tolerations | nindent 12 }}
+          containers: {{ include "containerCleanHfDatasetsCache" . | nindent 12 }}
+          securityContext: {{ include "securityContext" . | nindent 12 }}
+          initContainers: {{ include "initContainerDescriptiveStatistics" . | nindent 12 }}
+          volumes: {{ include "volumeDescriptiveStatistics" . | nindent 12 }}
+{{- end}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -413,6 +413,25 @@ cleanDuckdbIndexJobRunner:
   subfolderPattern: "job_runner/*"
 
 
+cleanStatsCache:
+  enabled: true
+  log:
+    level: "info"
+  action: "clean-directory"
+  error_codes_to_retry: ""
+  schedule: "0 */3 * * *"
+  # every 3 hours
+  nodeSelector: {}
+  resources:
+    requests:
+      cpu: 0
+    limits:
+      cpu: 0
+  tolerations: []
+  expiredTimeIntervalSeconds: 600
+  subfolderPattern: "*"
+
+
 postMessages:
   enabled: true
   log:


### PR DESCRIPTION
Same as we do now for `duckdb-index` and `hf-datasets-cache` (cleaning periodically obsolete/old files), we can sometimes keep files in stats because of job runner crash or zombie killer.
Adding a cron job to delete files/folders in /storage/stats-cache that are older than 3 hours ago.
 