### PR TITLE
Limit max RAM that duckdb can use

### DIFF
--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -481,7 +481,13 @@ def compute_descriptive_statistics_response(
     logging.info(f"Original number of threads={n_threads}")
     con.sql("SET threads TO 8;")
     n_threads = con.sql("SELECT current_setting('threads')").fetchall()[0][0]
-    logging.info(f"Number of threads={n_threads}")
+    logging.info(f"Current number of threads={n_threads}")
+
+    max_memory = con.sql("SELECT current_setting('max_memory');").fetchall()[0][0]
+    logging.info(f"Original {max_memory=}")
+    con.sql("SET max_memory TO '28gb';")
+    max_memory = con.sql("SELECT current_setting('max_memory');").fetchall()[0][0]
+    logging.info(f"Current {max_memory=}")
 
     logging.info("Loading data into in-memory table. ")
     create_table_command = CREATE_TABLE_COMMAND.format(


### PR DESCRIPTION
Current value of `max_memory` in prod is 105.7Gb (despite the pod has only 34Gb but it's set automatically by duckdb as 80% of ram and ram of the node in total is 128Gb)
<img width="382" alt="image" src="https://github.com/huggingface/datasets-server/assets/16348744/b29d7829-43e3-431c-a453-546f80e722a5">
I want to try to lower it manually since we assume there might be some memory issues with duckdb causing the  `split-descriptive-statistics` process to stuck at the step of loading data into in-memory db.
(also want to try to load data to local db file, this is the only difference with `duckdb-index` step)