### PR TITLE
Disable dataset scripts

### DIFF
--- a/chart/templates/_env/_envCommon.tpl
+++ b/chart/templates/_env/_envCommon.tpl
@@ -4,6 +4,8 @@
 {{- define "envCommon" -}}
 - name: COMMON_BLOCKED_DATASETS
   value: {{ .Values.common.blockedDatasets | quote}}
+- name: COMMON_DATASET_SCRIPTS_ALLOW_LIST
+  value: {{ .Values.common.datasetScriptsAllowList | quote}}
 - name: COMMON_HF_ENDPOINT
   value: {{ include "datasetsServer.hub.url" . }}
 - name: HF_ENDPOINT # see https://github.com/huggingface/datasets/pull/5196#issuecomment-1322191411

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -83,7 +83,7 @@ common:
   blockedDatasets: "Graphcore/gqa,Graphcore/gqa-lxmert,Graphcore/vqa,Graphcore/vqa-lxmert,echarlaix/gqa-lxmert,echarlaix/vqa,echarlaix/vqa-lxmert,KakologArchives/KakologArchives,open-llm-leaderboard/*"
   # Comma-separated list of the datasets for which we support dataset scripts.
   # Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
-  # The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespace.
+  # The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` refers to all the datasets without namespace.
   datasetScriptsAllowList: "{{ALL_DATASETS_WITH_NO_NAMESPACE}}"
   # URL of the HuggingFace Hub
   hfEndpoint: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -83,7 +83,7 @@ common:
   blockedDatasets: "Graphcore/gqa,Graphcore/gqa-lxmert,Graphcore/vqa,Graphcore/vqa-lxmert,echarlaix/gqa-lxmert,echarlaix/vqa,echarlaix/vqa-lxmert,KakologArchives/KakologArchives,open-llm-leaderboard/*"
   # Comma-separated list of the datasets for which we support dataset scripts.
   # Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
-  # The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespaces.
+  # The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespace.
   datasetScriptsAllowList: "{{ALL_DATASETS_WITH_NO_NAMESPACE}}"
   # URL of the HuggingFace Hub
   hfEndpoint: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -83,8 +83,8 @@ common:
   blockedDatasets: "Graphcore/gqa,Graphcore/gqa-lxmert,Graphcore/vqa,Graphcore/vqa-lxmert,echarlaix/gqa-lxmert,echarlaix/vqa,echarlaix/vqa-lxmert,KakologArchives/KakologArchives,open-llm-leaderboard/*"
   # Comma-separated list of the datasets for which we support dataset scripts.
   # Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
-  # The keyword `canonical` can be used to refer to all the datasets without namespaces.
-  datasetScriptsAllowList: "canonical"
+  # The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespaces.
+  datasetScriptsAllowList: "{{ALL_DATASETS_WITH_NO_NAMESPACE}}"
   # URL of the HuggingFace Hub
   hfEndpoint: ""
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -78,9 +78,13 @@ images:
       tag: sha-fb3399a
 
 common:
-  # comma-separated list of blocked datasets (e.g. if not supported by the Hub). No jobs will be processed for those datasets.
+  # Comma-separated list of blocked datasets (e.g. if not supported by the Hub). No jobs will be processed for those datasets.
   # See https://observablehq.com/@huggingface/blocked-datasets
   blockedDatasets: "Graphcore/gqa,Graphcore/gqa-lxmert,Graphcore/vqa,Graphcore/vqa-lxmert,echarlaix/gqa-lxmert,echarlaix/vqa,echarlaix/vqa-lxmert,KakologArchives/KakologArchives,open-llm-leaderboard/*"
+  # Comma-separated list of the datasets for which we support dataset scripts.
+  # Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
+  # The keyword `canonical` can be used to refer to all the datasets without namespaces.
+  datasetScriptsAllowList: "canonical"
   # URL of the HuggingFace Hub
   hfEndpoint: ""
 

--- a/libs/libcommon/README.md
+++ b/libs/libcommon/README.md
@@ -14,7 +14,7 @@ Set the assets (images and audio files stored locally) environment variables to 
 Set the common environment variables to configure the following aspects:
 
 - `COMMON_BLOCKED_DATASETS`: comma-separated list of the blocked datasets. Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to block all the datasets in the `some_namespace` namespace. If empty, no dataset is blocked. Defaults to empty.
-- `COMMON_DATASET_SCRIPTS_ALLOW_LIST`: comma-separated list of the datasets for which we support dataset scripts. Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace. The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespaces. If empty, no dataset is blocked. Defaults to empty.
+- `COMMON_DATASET_SCRIPTS_ALLOW_LIST`: comma-separated list of the datasets for which we support dataset scripts. Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace. The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespace. If empty, no dataset is blocked. Defaults to empty.
 - `COMMON_HF_ENDPOINT`: URL of the HuggingFace Hub. Defaults to `https://huggingface.co`.
 - `COMMON_HF_TOKEN`: App Access Token (ask moonlanding administrators to get one, only the `read` role is required) to access the gated datasets. Defaults to empty.
 

--- a/libs/libcommon/README.md
+++ b/libs/libcommon/README.md
@@ -14,7 +14,7 @@ Set the assets (images and audio files stored locally) environment variables to 
 Set the common environment variables to configure the following aspects:
 
 - `COMMON_BLOCKED_DATASETS`: comma-separated list of the blocked datasets. Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to block all the datasets in the `some_namespace` namespace. If empty, no dataset is blocked. Defaults to empty.
-- `COMMON_DATASET_SCRIPTS_ALLOW_LIST`: comma-separated list of the datasets for which we support dataset scripts. Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace. The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespace. If empty, no dataset is blocked. Defaults to empty.
+- `COMMON_DATASET_SCRIPTS_ALLOW_LIST`: comma-separated list of the datasets for which we support dataset scripts. Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace. The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` refers to all the datasets without namespace. If empty, no dataset with script is supported. Defaults to empty.
 - `COMMON_HF_ENDPOINT`: URL of the HuggingFace Hub. Defaults to `https://huggingface.co`.
 - `COMMON_HF_TOKEN`: App Access Token (ask moonlanding administrators to get one, only the `read` role is required) to access the gated datasets. Defaults to empty.
 

--- a/libs/libcommon/README.md
+++ b/libs/libcommon/README.md
@@ -14,7 +14,7 @@ Set the assets (images and audio files stored locally) environment variables to 
 Set the common environment variables to configure the following aspects:
 
 - `COMMON_BLOCKED_DATASETS`: comma-separated list of the blocked datasets. Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to block all the datasets in the `some_namespace` namespace. If empty, no dataset is blocked. Defaults to empty.
-- `COMMON_DATASET_SCRIPTS_ALLOW_LIST`: comma-separated list of the datasets for which we support dataset scripts. Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace. The keyword `canonical` can be used to refer to all the datasets without namespaces. If empty, no dataset is blocked. Defaults to empty.
+- `COMMON_DATASET_SCRIPTS_ALLOW_LIST`: comma-separated list of the datasets for which we support dataset scripts. Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace. The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespaces. If empty, no dataset is blocked. Defaults to empty.
 - `COMMON_HF_ENDPOINT`: URL of the HuggingFace Hub. Defaults to `https://huggingface.co`.
 - `COMMON_HF_TOKEN`: App Access Token (ask moonlanding administrators to get one, only the `read` role is required) to access the gated datasets. Defaults to empty.
 

--- a/libs/libcommon/README.md
+++ b/libs/libcommon/README.md
@@ -14,6 +14,7 @@ Set the assets (images and audio files stored locally) environment variables to 
 Set the common environment variables to configure the following aspects:
 
 - `COMMON_BLOCKED_DATASETS`: comma-separated list of the blocked datasets. Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to block all the datasets in the `some_namespace` namespace. If empty, no dataset is blocked. Defaults to empty.
+- `COMMON_DATASET_SCRIPTS_ALLOW_LIST`: comma-separated list of the datasets for which we support dataset scripts. Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace. The keyword `canonical` can be used to refer to all the datasets without namespaces. If empty, no dataset is blocked. Defaults to empty.
 - `COMMON_HF_ENDPOINT`: URL of the HuggingFace Hub. Defaults to `https://huggingface.co`.
 - `COMMON_HF_TOKEN`: App Access Token (ask moonlanding administrators to get one, only the `read` role is required) to access the gated datasets. Defaults to empty.
 

--- a/libs/libcommon/src/libcommon/config.py
+++ b/libs/libcommon/src/libcommon/config.py
@@ -162,6 +162,7 @@ class RowsIndexConfig:
 
 
 COMMON_BLOCKED_DATASETS: list[str] = []
+COMMON_DATASET_SCRIPTS_ALLOW_LIST: list[str] = []
 COMMON_HF_ENDPOINT = "https://huggingface.co"
 COMMON_HF_TOKEN = None
 
@@ -169,6 +170,7 @@ COMMON_HF_TOKEN = None
 @dataclass(frozen=True)
 class CommonConfig:
     blocked_datasets: list[str] = field(default_factory=COMMON_BLOCKED_DATASETS.copy)
+    dataset_scripts_allow_list: list[str] = field(default_factory=COMMON_DATASET_SCRIPTS_ALLOW_LIST.copy)
     hf_endpoint: str = COMMON_HF_ENDPOINT
     hf_token: Optional[str] = COMMON_HF_TOKEN
 
@@ -178,6 +180,9 @@ class CommonConfig:
         with env.prefixed("COMMON_"):
             return cls(
                 blocked_datasets=env.list(name="BLOCKED_DATASETS", default=COMMON_BLOCKED_DATASETS.copy()),
+                dataset_scripts_allow_list=env.list(
+                    name="DATASET_SCRIPTS_ALLOW_LIST", default=COMMON_DATASET_SCRIPTS_ALLOW_LIST.copy()
+                ),
                 hf_endpoint=env.str(name="HF_ENDPOINT", default=COMMON_HF_ENDPOINT),
                 hf_token=env.str(name="HF_TOKEN", default=COMMON_HF_TOKEN),  # nosec
             )

--- a/libs/libcommon/src/libcommon/exceptions.py
+++ b/libs/libcommon/src/libcommon/exceptions.py
@@ -547,3 +547,10 @@ class UnsupportedExternalFilesError(CacheableError):
 
     def __init__(self, message: str, cause: Optional[BaseException] = None):
         super().__init__(message, HTTPStatus.NOT_IMPLEMENTED, "UnsupportedExternalFilesError", cause, True)
+
+
+class DatasetWithScriptNotSupportedError(CacheableError):
+    """We don't support some datasets because they have a dataset script."""
+
+    def __init__(self, message: str, cause: Optional[BaseException] = None):
+        super().__init__(message, HTTPStatus.NOT_IMPLEMENTED, "DatasetWithScriptNotSupportedError", cause, True)

--- a/libs/libcommon/src/libcommon/exceptions.py
+++ b/libs/libcommon/src/libcommon/exceptions.py
@@ -86,6 +86,7 @@ CacheableErrorCode = Literal[
     "DatasetRevisionEmptyError",
     "DatasetRevisionNotFoundError",
     "DatasetScriptError",
+    "DatasetWithScriptNotSupportedError",
     "DatasetWithTooManyConfigsError",
     "DatasetWithTooManyParquetFilesError",
     "DisabledViewerError",

--- a/services/worker/pyproject.toml
+++ b/services/worker/pyproject.toml
@@ -76,7 +76,8 @@ requires = ["poetry-core>=1.0.0"]
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning"]
 markers = [
-    "wip: tests being developed"
+    "wip: tests being developed",
+    "use_hub_prod_endpoint: use the prod endpoint instead of hub-ci"
 ]
 
 [tool.coverage.run]

--- a/services/worker/pyproject.toml
+++ b/services/worker/pyproject.toml
@@ -76,8 +76,7 @@ requires = ["poetry-core>=1.0.0"]
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning"]
 markers = [
-    "wip: tests being developed",
-    "use_hub_prod_endpoint: use the prod endpoint instead of hub-ci"
+    "wip: tests being developed"
 ]
 
 [tool.coverage.run]

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -1129,7 +1129,7 @@ def compute_config_parquet_and_info_response(
         dataset_scripts_allow_list (`list[str]`):
             List of datasets for which we support dataset scripts.
             Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
-            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespaces.
+            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespace.
     Returns:
         `ConfigParquetAndInfoResponse`: An object with the config_parquet_and_info_response
           (dataset info and list of parquet files).

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -1128,8 +1128,9 @@ def compute_config_parquet_and_info_response(
             List of datasets that should be fully converted (no partial conversion).
         dataset_scripts_allow_list (`list[str]`):
             List of datasets for which we support dataset scripts.
-            Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
-            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespace.
+            Unix shell-style wildcards also work in the dataset name for namespaced datasets,
+            for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
+            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` refers to all the datasets without namespace.
     Returns:
         `ConfigParquetAndInfoResponse`: An object with the config_parquet_and_info_response
           (dataset info and list of parquet files).

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -1129,7 +1129,7 @@ def compute_config_parquet_and_info_response(
         dataset_scripts_allow_list (`list[str]`):
             List of datasets for which we support dataset scripts.
             Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
-            The keyword `canonical` can be used to refer to all the datasets without namespaces.
+            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespaces.
     Returns:
         `ConfigParquetAndInfoResponse`: An object with the config_parquet_and_info_response
           (dataset info and list of parquet files).

--- a/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
@@ -116,7 +116,7 @@ def compute_first_rows_response(
         dataset_scripts_allow_list (`list[str]`):
             List of datasets for which we support dataset scripts.
             Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
-            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespaces.
+            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespace.
     Returns:
         [`SplitFirstRowsResponse`]: The list of first rows of the split.
     Raises the following errors:

--- a/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
@@ -140,6 +140,8 @@ def compute_first_rows_response(
           If the split rows could not be obtained using the datasets library in streaming mode.
         - [`libcommon.exceptions.NormalRowsError`]
           If the split rows could not be obtained using the datasets library in normal mode.
+        - [`libcommon.exceptions.DatasetWithScriptNotSupportedError`]
+            If the dataset has a dataset script and is not in the allow list.
     """
     logging.info(f"get first-rows for dataset={dataset} config={config} split={split}")
     # get the features

--- a/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
@@ -115,8 +115,9 @@ def compute_first_rows_response(
             The maximum number of columns supported.
         dataset_scripts_allow_list (`list[str]`):
             List of datasets for which we support dataset scripts.
-            Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
-            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespace.
+            Unix shell-style wildcards also work in the dataset name for namespaced datasets,
+            for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
+            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` refers to all the datasets without namespace.
     Returns:
         [`SplitFirstRowsResponse`]: The list of first rows of the split.
     Raises the following errors:

--- a/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
@@ -116,7 +116,7 @@ def compute_first_rows_response(
         dataset_scripts_allow_list (`list[str]`):
             List of datasets for which we support dataset scripts.
             Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
-            The keyword `canonical` can be used to refer to all the datasets without namespaces.
+            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespaces.
     Returns:
         [`SplitFirstRowsResponse`]: The list of first rows of the split.
     Raises the following errors:

--- a/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
@@ -136,7 +136,7 @@ def compute_opt_in_out_urls_scan_response(
         dataset_scripts_allow_list (`list[str]`):
             List of datasets for which we support dataset scripts.
             Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
-            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespaces.
+            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespace.
 
     Returns:
         [`OptInOutUrlsScanResponse`]

--- a/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
@@ -135,8 +135,9 @@ def compute_opt_in_out_urls_scan_response(
             Spawgning API URL
         dataset_scripts_allow_list (`list[str]`):
             List of datasets for which we support dataset scripts.
-            Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
-            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespace.
+            Unix shell-style wildcards also work in the dataset name for namespaced datasets,
+            for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
+            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` refers to all the datasets without namespace.
 
     Returns:
         [`OptInOutUrlsScanResponse`]

--- a/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
@@ -153,6 +153,8 @@ def compute_opt_in_out_urls_scan_response(
           If the split rows could not be obtained using the datasets library in streaming mode.
         - [`libcommon.exceptions.NormalRowsError`]
           If the split rows could not be obtained using the datasets library in normal mode.
+        - [`libcommon.exceptions.DatasetWithScriptNotSupportedError`]
+            If the dataset has a dataset script and is not in the allow list.
     """
     logging.info(f"get opt-in-out-urls-scan for dataset={dataset} config={config} split={split}")
 

--- a/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
@@ -136,7 +136,7 @@ def compute_opt_in_out_urls_scan_response(
         dataset_scripts_allow_list (`list[str]`):
             List of datasets for which we support dataset scripts.
             Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
-            The keyword `canonical` can be used to refer to all the datasets without namespaces.
+            The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` can be used to refer to all the datasets without namespaces.
 
     Returns:
         [`OptInOutUrlsScanResponse`]

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -9,12 +9,24 @@ import time
 import traceback
 import warnings
 from collections.abc import Callable, Sequence
+from contextlib import AbstractContextManager
+from fnmatch import fnmatch
 from typing import Any, Optional, TypeVar, Union, cast
+from unittest.mock import patch
 from urllib.parse import quote
 
+import datasets
 import PIL
 import requests
-from datasets import Dataset, DatasetInfo, DownloadConfig, IterableDataset, load_dataset
+from datasets import (
+    Dataset,
+    DatasetInfo,
+    DownloadConfig,
+    IterableDataset,
+    disable_caching,
+    load_dataset,
+)
+from datasets.load import HubDatasetModuleFactoryWithScript
 from datasets.utils.file_utils import get_authentication_headers_for_url
 from fsspec.implementations.http import HTTPFileSystem
 from huggingface_hub.hf_api import HfApi
@@ -23,6 +35,7 @@ from libcommon.constants import EXTERNAL_DATASET_SCRIPT_PATTERN
 from libcommon.exceptions import (
     ConfigNotFoundError,
     DatasetNotFoundError,
+    DatasetWithScriptNotSupportedError,
     NormalRowsError,
     PreviousStepFormatError,
     SplitNotFoundError,
@@ -372,3 +385,35 @@ def is_dataset_script_error() -> bool:
     (t, v, tb) = sys.exc_info()
     cause_traceback: list[str] = traceback.format_exception(t, v, tb)
     return any(EXTERNAL_DATASET_SCRIPT_PATTERN in cause for cause in cause_traceback)
+
+
+def disable_dataset_scripts_support(allow_list: list[str]) -> AbstractContextManager[Any]:
+    original_init = HubDatasetModuleFactoryWithScript.__init__
+
+    def raise_unsupported_dataset_with_script_or_init(
+        self: HubDatasetModuleFactoryWithScript,
+        name: str,
+        revision: Optional[Union[str, datasets.Version]] = None,
+        download_config: Optional[DownloadConfig] = None,
+        download_mode: Optional[Union[datasets.DownloadMode, str]] = None,
+        dynamic_modules_path: Optional[str] = None,
+    ) -> None:
+        for allowed_pattern in allow_list:
+            if (allowed_pattern == "canonical" and "/" not in name) or fnmatch(name, allowed_pattern):
+                break
+        else:
+            raise DatasetWithScriptNotSupportedError(
+                "The dataset viewer doesn't support this dataset because it runs "
+                "arbitrary python code. Please open a discussion in the discussion tab "
+                "if you think this is an error and tag @lhoestq and @severo."
+            )
+        original_init(
+            self=self,
+            name=name,
+            revision=revision,
+            download_config=download_config,
+            download_mode=download_mode,
+            dynamic_modules_path=dynamic_modules_path,
+        )
+
+    return patch.object(HubDatasetModuleFactoryWithScript, "__init__", raise_unsupported_dataset_with_script_or_init)

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -18,13 +18,7 @@ from urllib.parse import quote
 import datasets
 import PIL
 import requests
-from datasets import (
-    Dataset,
-    DatasetInfo,
-    DownloadConfig,
-    IterableDataset,
-    load_dataset,
-)
+from datasets import Dataset, DatasetInfo, DownloadConfig, IterableDataset, load_dataset
 from datasets.load import HubDatasetModuleFactoryWithScript
 from datasets.utils.file_utils import get_authentication_headers_for_url
 from fsspec.implementations.http import HTTPFileSystem

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -392,7 +392,9 @@ def disable_dataset_scripts_support(allow_list: list[str]) -> AbstractContextMan
         dynamic_modules_path: Optional[str] = None,
     ) -> None:
         for allowed_pattern in allow_list:
-            if (allowed_pattern == "canonical" and "/" not in name) or fnmatch(name, allowed_pattern):
+            if (allowed_pattern == "{{ALL_DATASETS_WITH_NO_NAMESPACE}}" and "/" not in name) or fnmatch(
+                name, allowed_pattern
+            ):
                 break
         else:
             raise DatasetWithScriptNotSupportedError(

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -23,7 +23,6 @@ from datasets import (
     DatasetInfo,
     DownloadConfig,
     IterableDataset,
-    disable_caching,
     load_dataset,
 )
 from datasets.load import HubDatasetModuleFactoryWithScript

--- a/services/worker/tests/conftest.py
+++ b/services/worker/tests/conftest.py
@@ -16,7 +16,7 @@ from libcommon.storage import (
     init_parquet_metadata_dir,
     init_statistics_cache_dir,
 )
-from pytest import FixtureRequest, MonkeyPatch, fixture
+from pytest import MonkeyPatch, fixture
 
 from worker.config import AppConfig
 from worker.main import WORKER_STATE_FILE_NAME
@@ -51,16 +51,26 @@ def statistics_cache_directory(app_config: AppConfig) -> StrPath:
 
 
 # see https://github.com/pytest-dev/pytest/issues/363#issuecomment-406536200
-@fixture(autouse=True)
-def monkeypatch_session(request: FixtureRequest) -> Iterator[MonkeyPatch]:
+@fixture(scope="session", autouse=True)
+def monkeypatch_session() -> Iterator[MonkeyPatch]:
     mp = MonkeyPatch()
-
-    if "use_hub_prod_endpoint" not in request.keywords:
-        mp.setattr("huggingface_hub.file_download.HUGGINGFACE_CO_URL_TEMPLATE", CI_URL_TEMPLATE)
-        # ^ see https://github.com/huggingface/datasets/pull/5196#issuecomment-1322191056
-        mp.setattr("datasets.config.HF_ENDPOINT", CI_HUB_ENDPOINT)
-
+    mp.setattr("huggingface_hub.file_download.HUGGINGFACE_CO_URL_TEMPLATE", CI_URL_TEMPLATE)
+    # ^ see https://github.com/huggingface/datasets/pull/5196#issuecomment-1322191056
+    mp.setattr("datasets.config.HF_ENDPOINT", CI_HUB_ENDPOINT)
     mp.setattr("datasets.config.HF_UPDATE_DOWNLOAD_COUNTS", False)
+    yield mp
+    mp.undo()
+
+
+@fixture()
+def use_hub_prod_endpoint() -> Iterator[MonkeyPatch]:
+    mp = MonkeyPatch()
+    mp.setattr(
+        "huggingface_hub.file_download.HUGGINGFACE_CO_URL_TEMPLATE",
+        "https://huggingface.co/{repo_id}/resolve/{revision}/{filename}",
+    )
+    # ^ see https://github.com/huggingface/datasets/pull/5196#issuecomment-1322191056
+    mp.setattr("datasets.config.HF_ENDPOINT", "https://huggingface.co")
     yield mp
     mp.undo()
 

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -20,6 +20,7 @@ import pyarrow.parquet as pq
 import pytest
 import requests
 from datasets import Audio, Features, Image, Value, load_dataset_builder
+from datasets.load import dataset_module_factory
 from datasets.packaged_modules.generator.generator import (
     Generator as ParametrizedGeneratorBasedBuilder,
 )
@@ -27,7 +28,11 @@ from datasets.utils.py_utils import asdict
 from huggingface_hub.hf_api import CommitOperationAdd, HfApi
 from libcommon.config import ProcessingGraphConfig
 from libcommon.dataset import get_dataset_info_for_supported_datasets
-from libcommon.exceptions import CustomError, DatasetManualDownloadError
+from libcommon.exceptions import (
+    CustomError,
+    DatasetManualDownloadError,
+    DatasetWithScriptNotSupportedError,
+)
 from libcommon.processing_graph import ProcessingGraph, ProcessingStep
 from libcommon.queue import Queue
 from libcommon.resources import CacheMongoResource, QueueMongoResource
@@ -57,6 +62,7 @@ from worker.job_runners.config.parquet_and_info import (
 )
 from worker.job_runners.dataset.config_names import DatasetConfigNamesJobRunner
 from worker.resources import LibrariesResource
+from worker.utils import disable_dataset_scripts_support
 
 from ...constants import CI_HUB_ENDPOINT, CI_USER_TOKEN
 from ...fixtures.hub import HubDatasetTest
@@ -880,3 +886,23 @@ def test_get_writer_batch_size_from_row_group_size(
         num_rows=num_rows, row_group_byte_size=row_group_byte_size, max_row_group_byte_size=max_row_group_byte_size
     )
     assert writer_batch_size == expected
+
+
+@pytest.mark.use_hub_prod_endpoint
+def test_disable_dataset_scripts_support(tmp_path: Path) -> None:
+    cache_dir = str(tmp_path / "test_disable_dataset_scripts_support_cache_dir")
+    dynamic_modules_path = str(tmp_path / "test_disable_dataset_scripts_support_dynamic_modules_path")
+    with disable_dataset_scripts_support(allow_list=[]):
+        with pytest.raises(DatasetWithScriptNotSupportedError):
+            dataset_module_factory("squad", cache_dir=cache_dir, dynamic_modules_path=dynamic_modules_path)
+    with disable_dataset_scripts_support(allow_list=["canonical"]):
+        dataset_module_factory("squad", cache_dir=cache_dir, dynamic_modules_path=dynamic_modules_path)
+        with pytest.raises(DatasetWithScriptNotSupportedError):
+            dataset_module_factory("lhoestq/squad", cache_dir=cache_dir, dynamic_modules_path=dynamic_modules_path)
+    with disable_dataset_scripts_support(allow_list=["canonical", "lhoestq/s*"]):
+        dataset_module_factory("squad", cache_dir=cache_dir, dynamic_modules_path=dynamic_modules_path)
+        dataset_module_factory("lhoestq/squad", cache_dir=cache_dir, dynamic_modules_path=dynamic_modules_path)
+        with pytest.raises(DatasetWithScriptNotSupportedError):
+            dataset_module_factory(
+                "lhoestq/custom_squad", cache_dir=cache_dir, dynamic_modules_path=dynamic_modules_path
+            )

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -890,9 +890,12 @@ def test_get_writer_batch_size_from_row_group_size(
 
 @pytest.mark.use_hub_prod_endpoint
 def test_disable_dataset_scripts_support(tmp_path: Path) -> None:
+    # with dataset script: squad, lhoestq/squad, lhoestq/custom_squad
+    # no dataset script: lhoest/demo1
     cache_dir = str(tmp_path / "test_disable_dataset_scripts_support_cache_dir")
     dynamic_modules_path = str(tmp_path / "test_disable_dataset_scripts_support_dynamic_modules_path")
     with disable_dataset_scripts_support(allow_list=[]):
+        dataset_module_factory("lhoestq/demo1", cache_dir=cache_dir, dynamic_modules_path=dynamic_modules_path)
         with pytest.raises(DatasetWithScriptNotSupportedError):
             dataset_module_factory("squad", cache_dir=cache_dir, dynamic_modules_path=dynamic_modules_path)
     with disable_dataset_scripts_support(allow_list=["canonical"]):

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -888,8 +888,7 @@ def test_get_writer_batch_size_from_row_group_size(
     assert writer_batch_size == expected
 
 
-@pytest.mark.use_hub_prod_endpoint
-def test_disable_dataset_scripts_support(tmp_path: Path) -> None:
+def test_disable_dataset_scripts_support(use_hub_prod_endpoint: Any, tmp_path: Path) -> None:
     # with dataset script: squad, lhoestq/squad, lhoestq/custom_squad
     # no dataset script: lhoest/demo1
     cache_dir = str(tmp_path / "test_disable_dataset_scripts_support_cache_dir")

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -898,11 +898,11 @@ def test_disable_dataset_scripts_support(tmp_path: Path) -> None:
         dataset_module_factory("lhoestq/demo1", cache_dir=cache_dir, dynamic_modules_path=dynamic_modules_path)
         with pytest.raises(DatasetWithScriptNotSupportedError):
             dataset_module_factory("squad", cache_dir=cache_dir, dynamic_modules_path=dynamic_modules_path)
-    with disable_dataset_scripts_support(allow_list=["canonical"]):
+    with disable_dataset_scripts_support(allow_list=["{{ALL_DATASETS_WITH_NO_NAMESPACE}}"]):
         dataset_module_factory("squad", cache_dir=cache_dir, dynamic_modules_path=dynamic_modules_path)
         with pytest.raises(DatasetWithScriptNotSupportedError):
             dataset_module_factory("lhoestq/squad", cache_dir=cache_dir, dynamic_modules_path=dynamic_modules_path)
-    with disable_dataset_scripts_support(allow_list=["canonical", "lhoestq/s*"]):
+    with disable_dataset_scripts_support(allow_list=["{{ALL_DATASETS_WITH_NO_NAMESPACE}}", "lhoestq/s*"]):
         dataset_module_factory("squad", cache_dir=cache_dir, dynamic_modules_path=dynamic_modules_path)
         dataset_module_factory("lhoestq/squad", cache_dir=cache_dir, dynamic_modules_path=dynamic_modules_path)
         with pytest.raises(DatasetWithScriptNotSupportedError):

--- a/tools/docker-compose-base.yml
+++ b/tools/docker-compose-base.yml
@@ -3,6 +3,7 @@ services:
     environment:
       # common
       COMMON_BLOCKED_DATASETS: ${COMMON_BLOCKED_DATASETS-}
+      COMMON_DATASET_SCRIPTS_ALLOW_LIST: ${COMMON_DATASET_SCRIPTS_ALLOW_LIST-}
       COMMON_HF_ENDPOINT: ${COMMON_HF_ENDPOINT-https://huggingface.co}
       COMMON_HF_TOKEN: ${COMMON_HF_TOKEN-}
       # log

--- a/tools/docker-compose-dev-base.yml
+++ b/tools/docker-compose-dev-base.yml
@@ -3,6 +3,7 @@ services:
     environment:
       # common
       COMMON_BLOCKED_DATASETS: ${COMMON_BLOCKED_DATASETS-}
+      COMMON_DATASET_SCRIPTS_ALLOW_LIST: ${COMMON_DATASET_SCRIPTS_ALLOW_LIST-}
       COMMON_HF_ENDPOINT: ${COMMON_HF_ENDPOINT-https://hub-ci.huggingface.co}
       COMMON_HF_TOKEN: ${COMMON_HF_TOKEN-hf_app_datasets-server_token}
       # log


### PR DESCRIPTION
The `config-parquet-and-info` step will now raise a `DatasetWithScriptNotSupportedError` for datasets with a script, except those in the allow list. This will prevent users from running arbitrary code using dataset scripts.

The error message is shown to the user on the website and it says
```python
            raise DatasetWithScriptNotSupportedError(
                "The dataset viewer doesn't support this dataset because it runs "
                "arbitrary python code. Please open a discussion in the discussion tab "
                "if you think this is an error and tag @lhoestq and @severo."
            )
```

The allow list is hardcoded for now: `DATASET_SCRIPTS_ALLOW_LIST = ["canonical"]`
The keyword "canonical" means all the datasets without namespaces.

We can add other datasets to the allow list, and it supports `fnmatch`, for example to support all the datasets from `huggingface` we can add `huggingface/*` to the allow list.

cc @severo @XciD 