### PR TITLE
Factorize getting request parameters

### DIFF
--- a/libs/libapi/src/libapi/request.py
+++ b/libs/libapi/src/libapi/request.py
@@ -29,8 +29,9 @@ def get_request_parameter_offset(request: Request) -> int:
     return offset
 
 
-def get_required_request_parameter(request: Request, parameter_name: str) -> str:
-    parameter = request.query_params.get(parameter_name)
-    if not parameter or not is_non_empty_string(parameter):
-        raise MissingRequiredParameterError(f"Parameter '{parameter_name}' is required")
+def get_request_parameter(request: Request, parameter_name: str, required: bool = False, default: str = "") -> str:
+    parameter = request.query_params.get(parameter_name, default)
+    if required:
+        if not parameter or not is_non_empty_string(parameter):
+            raise MissingRequiredParameterError(f"Parameter '{parameter_name}' is required")
     return parameter

--- a/libs/libapi/src/libapi/request.py
+++ b/libs/libapi/src/libapi/request.py
@@ -4,7 +4,7 @@ from libcommon.utils import MAX_NUM_ROWS_PER_PAGE
 from starlette.requests import Request
 
 from libapi.exceptions import InvalidParameterError, MissingRequiredParameterError
-from libapi.utils import are_valid_parameters
+from libapi.utils import is_non_empty_string
 
 
 def get_request_parameter_length(request: Request) -> int:
@@ -31,6 +31,6 @@ def get_request_parameter_offset(request: Request) -> int:
 
 def get_required_request_parameter(request: Request, parameter_name: str) -> str:
     parameter = request.query_params.get(parameter_name)
-    if not parameter or not are_valid_parameters([parameter]):
+    if not parameter or not is_non_empty_string(parameter):
         raise MissingRequiredParameterError(f"Parameter '{parameter_name}' is required")
     return parameter

--- a/libs/libapi/src/libapi/utils.py
+++ b/libs/libapi/src/libapi/utils.py
@@ -94,7 +94,7 @@ def get_json_api_error_response(error: CustomError, max_age: int = 0, revision: 
 
 
 def is_non_empty_string(string: Any) -> bool:
-    return isinstance(string, str) and bool(string and string.strip())
+    return isinstance(string, str) and bool(string.strip())
 
 
 def are_valid_parameters(parameters: list[Any]) -> bool:

--- a/libs/libapi/tests/test_request.py
+++ b/libs/libapi/tests/test_request.py
@@ -2,6 +2,7 @@
 # Copyright 2023 The HuggingFace Authors.
 
 from collections.abc import Callable
+from contextlib import nullcontext as does_not_raise
 from typing import Optional
 
 import pytest
@@ -25,21 +26,23 @@ def build_request() -> Callable[..., Request]:
 
 
 @pytest.mark.parametrize("expected_value", ["org-name/dataset-name"])
-def test_get_required_request_parameter(expected_value: str, build_request: Callable[..., Request]) -> None:
+@pytest.mark.parametrize("required", [False, True])
+def test_get_request_parameter(expected_value: str, required: bool, build_request: Callable[..., Request]) -> None:
     parameter_name = "dataset"
     request = build_request(query_string=f"{parameter_name}={expected_value}")
-    assert get_request_parameter(request, parameter_name, required=True) == expected_value
+    assert get_request_parameter(request, parameter_name, required=required) == expected_value
 
 
 @pytest.mark.parametrize("parameter", [None, "", " "])
-def test_get_required_request_parameter_raises(
-    parameter: Optional[str], build_request: Callable[..., Request]
+@pytest.mark.parametrize("required", [False, True])
+def test_get_request_parameter_raises(
+    parameter: Optional[str], required: bool, build_request: Callable[..., Request]
 ) -> None:
     parameter_name = "dataset"
     expected_error_message = f"Parameter '{parameter_name}' is required"
     request = build_request(query_string=f"{parameter_name}={parameter}") if parameter is not None else build_request()
-    with pytest.raises(MissingRequiredParameterError, match=expected_error_message):
-        _ = get_request_parameter(request, parameter_name, required=True)
+    with pytest.raises(MissingRequiredParameterError, match=expected_error_message) if required else does_not_raise():
+        _ = get_request_parameter(request, parameter_name, required=required)
 
 
 @pytest.mark.parametrize("length, expected_value", [("50", 50)])

--- a/libs/libapi/tests/test_request.py
+++ b/libs/libapi/tests/test_request.py
@@ -9,9 +9,9 @@ from starlette.requests import Request
 
 from libapi.exceptions import InvalidParameterError, MissingRequiredParameterError
 from libapi.request import (
+    get_request_parameter,
     get_request_parameter_length,
     get_request_parameter_offset,
-    get_required_request_parameter,
 )
 
 
@@ -28,7 +28,7 @@ def build_request() -> Callable[..., Request]:
 def test_get_required_request_parameter(expected_value: str, build_request: Callable[..., Request]) -> None:
     parameter_name = "dataset"
     request = build_request(query_string=f"{parameter_name}={expected_value}")
-    assert get_required_request_parameter(request, parameter_name) == expected_value
+    assert get_request_parameter(request, parameter_name, required=True) == expected_value
 
 
 @pytest.mark.parametrize("parameter", [None, "", " "])
@@ -39,7 +39,7 @@ def test_get_required_request_parameter_raises(
     expected_error_message = f"Parameter '{parameter_name}' is required"
     request = build_request(query_string=f"{parameter_name}={parameter}") if parameter is not None else build_request()
     with pytest.raises(MissingRequiredParameterError, match=expected_error_message):
-        _ = get_required_request_parameter(request, parameter_name)
+        _ = get_request_parameter(request, parameter_name, required=True)
 
 
 @pytest.mark.parametrize("length, expected_value", [("50", 50)])

--- a/services/admin/src/admin/routes/cache_reports.py
+++ b/services/admin/src/admin/routes/cache_reports.py
@@ -5,6 +5,7 @@ import logging
 from typing import Optional
 
 from libapi.exceptions import ApiError, InvalidParameterError, UnexpectedApiError
+from libapi.request import get_request_parameter
 from libapi.utils import Endpoint, get_json_api_error_response, get_json_ok_response
 from libcommon.simple_cache import InvalidCursor, InvalidLimit, get_cache_reports
 from starlette.requests import Request
@@ -23,7 +24,7 @@ def create_cache_reports_endpoint(
 ) -> Endpoint:
     async def cache_reports_endpoint(request: Request) -> Response:
         try:
-            cursor = request.query_params.get("cursor") or ""
+            cursor = get_request_parameter(request, "cursor")
             logging.info(f"Cache reports for {cache_kind}, cursor={cursor}")
             # if auth_check fails, it will raise an exception that will be caught below
             await auth_check(

--- a/services/admin/src/admin/routes/cache_reports_with_content.py
+++ b/services/admin/src/admin/routes/cache_reports_with_content.py
@@ -5,6 +5,7 @@ import logging
 from typing import Optional
 
 from libapi.exceptions import ApiError, InvalidParameterError, UnexpectedApiError
+from libapi.request import get_request_parameter
 from libapi.utils import Endpoint, get_json_api_error_response, get_json_ok_response
 from libcommon.simple_cache import (
     InvalidCursor,
@@ -27,7 +28,7 @@ def create_cache_reports_with_content_endpoint(
 ) -> Endpoint:
     async def cache_reports_with_content_endpoint(request: Request) -> Response:
         try:
-            cursor = request.query_params.get("cursor") or ""
+            cursor = get_request_parameter(request, "cursor")
             logging.info(f"Cache reports with content for {cache_kind}, cursor={cursor}")
             # if auth_check fails, it will raise an exception that will be caught below
             await auth_check(

--- a/services/admin/src/admin/routes/dataset_backfill.py
+++ b/services/admin/src/admin/routes/dataset_backfill.py
@@ -5,7 +5,7 @@ import logging
 from typing import Optional
 
 from libapi.exceptions import UnexpectedApiError
-from libapi.request import get_required_request_parameter
+from libapi.request import get_request_parameter
 from libapi.utils import Endpoint, get_json_api_error_response, get_json_ok_response
 from libcommon.dataset import get_dataset_git_revision
 from libcommon.exceptions import CustomError
@@ -30,7 +30,7 @@ def create_dataset_backfill_endpoint(
 ) -> Endpoint:
     async def dataset_backfill_endpoint(request: Request) -> Response:
         try:
-            dataset = get_required_request_parameter(request, "dataset")
+            dataset = get_request_parameter(request, "dataset", required=True)
             logging.info(f"/dataset-backfill, dataset={dataset}")
 
             # if auth_check fails, it will raise an exception that will be caught below

--- a/services/admin/src/admin/routes/dataset_backfill_plan.py
+++ b/services/admin/src/admin/routes/dataset_backfill_plan.py
@@ -5,7 +5,7 @@ import logging
 from typing import Optional
 
 from libapi.exceptions import ApiError, UnexpectedApiError
-from libapi.request import get_required_request_parameter
+from libapi.request import get_request_parameter
 from libapi.utils import Endpoint, get_json_api_error_response, get_json_ok_response
 from libcommon.dataset import get_dataset_git_revision
 from libcommon.orchestrator import DatasetBackfillPlan
@@ -28,7 +28,7 @@ def create_dataset_backfill_plan_endpoint(
 ) -> Endpoint:
     async def dataset_state_endpoint(request: Request) -> Response:
         try:
-            dataset = get_required_request_parameter(request, "dataset")
+            dataset = get_request_parameter(request, "dataset", required=True)
             logging.info(f"/dataset-state, dataset={dataset}")
 
             # if auth_check fails, it will raise an exception that will be caught below

--- a/services/admin/src/admin/routes/dataset_status.py
+++ b/services/admin/src/admin/routes/dataset_status.py
@@ -5,7 +5,7 @@ import logging
 from typing import Optional
 
 from libapi.exceptions import ApiError, UnexpectedApiError
-from libapi.request import get_required_request_parameter
+from libapi.request import get_request_parameter
 from libapi.utils import Endpoint, get_json_api_error_response, get_json_ok_response
 from libcommon.processing_graph import ProcessingGraph
 from libcommon.queue import Queue
@@ -25,7 +25,7 @@ def create_dataset_status_endpoint(
 ) -> Endpoint:
     async def dataset_status_endpoint(request: Request) -> Response:
         try:
-            dataset = get_required_request_parameter(request, "dataset")
+            dataset = get_request_parameter(request, "dataset", required=True)
             logging.info(f"/dataset-status, dataset={dataset}")
 
             # if auth_check fails, it will raise an exception that will be caught below

--- a/services/admin/src/admin/routes/force_refresh.py
+++ b/services/admin/src/admin/routes/force_refresh.py
@@ -9,7 +9,7 @@ from libapi.exceptions import (
     MissingRequiredParameterError,
     UnexpectedApiError,
 )
-from libapi.request import get_required_request_parameter
+from libapi.request import get_request_parameter
 from libapi.utils import (
     Endpoint,
     are_valid_parameters,
@@ -43,16 +43,16 @@ def create_force_refresh_endpoint(
 ) -> Endpoint:
     async def force_refresh_endpoint(request: Request) -> Response:
         try:
-            dataset = get_required_request_parameter(request, "dataset")
+            dataset = get_request_parameter(request, "dataset", required=True)
             if input_type == "dataset":
                 config = None
                 split = None
             elif input_type == "config":
-                config = get_required_request_parameter(request, "config")
+                config = get_request_parameter(request, "config", required=True)
                 split = None
             else:
-                config = get_required_request_parameter(request, "config")
-                split = get_required_request_parameter(request, "split")
+                config = get_request_parameter(request, "config", required=True)
+                split = get_request_parameter(request, "split", required=True)
                 if not are_valid_parameters([config, split]):
                     raise MissingRequiredParameterError("Parameters 'config' and 'split' are required")
             try:

--- a/services/admin/src/admin/routes/force_refresh.py
+++ b/services/admin/src/admin/routes/force_refresh.py
@@ -56,7 +56,7 @@ def create_force_refresh_endpoint(
                 if not are_valid_parameters([config, split]):
                     raise MissingRequiredParameterError("Parameters 'config' and 'split' are required")
             try:
-                priority = Priority(request.query_params.get("priority", "low"))
+                priority = Priority(get_request_parameter(request, "priority", default="low"))
             except ValueError:
                 raise InvalidParameterError(
                     f"Parameter 'priority' should be one of {', '.join(prio.value for prio in Priority)}."

--- a/services/admin/src/admin/routes/recreate_dataset.py
+++ b/services/admin/src/admin/routes/recreate_dataset.py
@@ -37,7 +37,7 @@ def create_recreate_dataset_endpoint(
         try:
             dataset = get_request_parameter(request, "dataset", required=True)
             try:
-                priority = Priority(request.query_params.get("priority", "low"))
+                priority = Priority(get_request_parameter(request, "priority", default="low"))
             except ValueError:
                 raise InvalidParameterError(
                     f"Parameter 'priority' should be one of {', '.join(prio.value for prio in Priority)}."

--- a/services/admin/src/admin/routes/recreate_dataset.py
+++ b/services/admin/src/admin/routes/recreate_dataset.py
@@ -5,7 +5,7 @@ import logging
 from typing import Optional
 
 from libapi.exceptions import InvalidParameterError, UnexpectedApiError
-from libapi.request import get_required_request_parameter
+from libapi.request import get_request_parameter
 from libapi.utils import Endpoint, get_json_api_error_response, get_json_ok_response
 from libcommon.dataset import get_dataset_git_revision
 from libcommon.exceptions import CustomError
@@ -35,7 +35,7 @@ def create_recreate_dataset_endpoint(
 ) -> Endpoint:
     async def recreate_dataset_endpoint(request: Request) -> Response:
         try:
-            dataset = get_required_request_parameter(request, "dataset")
+            dataset = get_request_parameter(request, "dataset", required=True)
             try:
                 priority = Priority(request.query_params.get("priority", "low"))
             except ValueError:

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -8,9 +8,9 @@ from fsspec.implementations.http import HTTPFileSystem
 from libapi.authentication import auth_check
 from libapi.exceptions import ApiError, UnexpectedApiError
 from libapi.request import (
+    get_request_parameter,
     get_request_parameter_length,
     get_request_parameter_offset,
-    get_required_request_parameter,
 )
 from libapi.response import create_response
 from libapi.utils import (
@@ -71,9 +71,9 @@ def create_rows_endpoint(
         with StepProfiler(method="rows_endpoint", step="all"):
             try:
                 with StepProfiler(method="rows_endpoint", step="validate parameters"):
-                    dataset = get_required_request_parameter(request, "dataset")
-                    config = get_required_request_parameter(request, "config")
-                    split = get_required_request_parameter(request, "split")
+                    dataset = get_request_parameter(request, "dataset", required=True)
+                    config = get_request_parameter(request, "config", required=True)
+                    split = get_request_parameter(request, "split", required=True)
                     offset = get_request_parameter_offset(request)
                     length = get_request_parameter_length(request)
                     logging.info(

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -18,9 +18,9 @@ from libapi.duckdb import (
 )
 from libapi.exceptions import ApiError, InvalidParameterError, UnexpectedApiError
 from libapi.request import (
+    get_request_parameter,
     get_request_parameter_length,
     get_request_parameter_offset,
-    get_required_request_parameter,
 )
 from libapi.response import ROW_IDX_COLUMN, create_response
 from libapi.utils import (
@@ -79,10 +79,10 @@ def create_filter_endpoint(
         with StepProfiler(method="filter_endpoint", step="all"):
             try:
                 with StepProfiler(method="filter_endpoint", step="validate parameters"):
-                    dataset = get_required_request_parameter(request, "dataset")
-                    config = get_required_request_parameter(request, "config")
-                    split = get_required_request_parameter(request, "split")
-                    where = get_required_request_parameter(request, "where")
+                    dataset = get_request_parameter(request, "dataset", required=True)
+                    config = get_request_parameter(request, "config", required=True)
+                    split = get_request_parameter(request, "split", required=True)
+                    where = get_request_parameter(request, "where", required=True)
                     validate_where_parameter(where)
                     offset = get_request_parameter_offset(request)
                     length = get_request_parameter_length(request)

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -20,9 +20,9 @@ from libapi.exceptions import (
     UnexpectedApiError,
 )
 from libapi.request import (
+    get_request_parameter,
     get_request_parameter_length,
     get_request_parameter_offset,
-    get_required_request_parameter,
 )
 from libapi.response import ROW_IDX_COLUMN
 from libapi.utils import (
@@ -145,10 +145,10 @@ def create_search_endpoint(
         with StepProfiler(method="search_endpoint", step="all"):
             try:
                 with StepProfiler(method="search_endpoint", step="validate parameters"):
-                    dataset = get_required_request_parameter(request, "dataset")
-                    config = get_required_request_parameter(request, "config")
-                    split = get_required_request_parameter(request, "split")
-                    query = get_required_request_parameter(request, "query")
+                    dataset = get_request_parameter(request, "dataset", required=True)
+                    config = get_request_parameter(request, "config", required=True)
+                    split = get_request_parameter(request, "split", required=True)
+                    query = get_request_parameter(request, "query", required=True)
                     offset = get_request_parameter_offset(request)
                     length = get_request_parameter_length(request)
 

--- a/services/sse-api/src/sse_api/routes/hub_cache.py
+++ b/services/sse-api/src/sse_api/routes/hub_cache.py
@@ -7,6 +7,7 @@ import logging
 from asyncio import CancelledError
 from collections.abc import AsyncGenerator, AsyncIterable
 
+from libapi.request import get_request_parameter
 from libapi.utils import Endpoint
 from sse_starlette import EventSourceResponse, ServerSentEvent
 from starlette.requests import Request
@@ -26,7 +27,7 @@ def create_hub_cache_endpoint(hub_cache_watcher: HubCacheWatcher) -> Endpoint:
     async def hub_cache_endpoint(request: Request) -> Response:
         logging.info("/hub-cache")
 
-        all = request.query_params.get("all", "false").lower() == "true"
+        all = get_request_parameter(request, "all", default="false").lower() == "true"
         # ^ the values that trigger the initialization are "true", "True" and any other case-insensitive variant
 
         uuid, event = hub_cache_watcher.subscribe()


### PR DESCRIPTION
Factorize getting request parameters for both required and non-required ones, by using the function `get_request_parameter` and merging `get_required_request_parameter` into it, with the addition of the parameters "required" and "default".

Use `get_request_parameter` to get the "cursor", "priority" and "all" parameters.