### PR TITLE
adding tests for recreate dataset

### DIFF
--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -916,11 +916,12 @@ class Queue:
         """
         jobs = JobDocument.objects(dataset=dataset, status__in=[Status.WAITING, Status.STARTED])
         previous_status = [(job.type, job.status, job.unicity_id) for job in jobs.all()]
+        jobs_to_cancel = len(previous_status)
         jobs.update(finished_at=get_datetime(), status=Status.CANCELLED)
         for job_type, status, unicity_id in previous_status:
             update_metrics_for_type(job_type=job_type, previous_status=status, new_status=Status.CANCELLED)
             release_lock(key=unicity_id)
-        return jobs.count()
+        return jobs_to_cancel
 
     def is_job_in_process(
         self, job_type: str, dataset: str, revision: str, config: Optional[str] = None, split: Optional[str] = None

--- a/libs/libcommon/tests/test_queue.py
+++ b/libs/libcommon/tests/test_queue.py
@@ -676,7 +676,7 @@ def test_cancel_dataset_jobs(queue_mongo_resource: QueueMongoResource) -> None:
     assert started_job_info_2["params"]["dataset"] == other_dataset
     assert started_job_info_2["type"] == job_type_1
 
-    queue.cancel_dataset_jobs(dataset=dataset)
+    assert queue.cancel_dataset_jobs(dataset=dataset) == 4
 
     assert JobDocument.objects().count() == 6
     assert JobDocument.objects(dataset=dataset).count() == 4

--- a/services/admin/src/admin/routes/recreate_dataset.py
+++ b/services/admin/src/admin/routes/recreate_dataset.py
@@ -2,7 +2,7 @@
 # Copyright 2023 The HuggingFace Authors.
 
 import logging
-from typing import Optional
+from typing import Optional, TypedDict
 
 from libapi.exceptions import InvalidParameterError, UnexpectedApiError
 from libapi.request import get_request_parameter
@@ -20,6 +20,49 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from admin.authentication import auth_check
+
+
+class RecreateDatasetReport(TypedDict):
+    status: str
+    dataset: str
+    cancelled_jobs: int
+    deleted_cached_responses: int
+
+
+def recreate_dataset(
+    dataset: str,
+    priority: Priority,
+    processing_graph: ProcessingGraph,
+    assets_directory: StrPath,
+    cached_assets_directory: StrPath,
+    hf_endpoint: str,
+    blocked_datasets: list[str],
+    hf_token: Optional[str] = None,
+) -> RecreateDatasetReport:
+    # try to get the revision of the dataset (before deleting the jobs and the cache, in case it fails)
+    revision = get_dataset_git_revision(dataset=dataset, hf_endpoint=hf_endpoint, hf_token=hf_token)
+    # delete all the jobs and all the cache entries for the dataset (for all the revisions)
+    cancelled_jobs = Queue().cancel_dataset_jobs(dataset=dataset)
+    deleted_cached_responses = delete_dataset_responses(dataset=dataset)
+    if deleted_cached_responses is not None and deleted_cached_responses > 0:
+        # delete assets
+        delete_asset_dir(dataset=dataset, directory=assets_directory)
+        delete_asset_dir(dataset=dataset, directory=cached_assets_directory)
+        # create the jobs to backfill the dataset
+    backfill_dataset(
+        dataset=dataset,
+        revision=revision,
+        processing_graph=processing_graph,
+        priority=priority,
+        cache_max_days=1,
+        blocked_datasets=blocked_datasets,
+    )
+    return RecreateDatasetReport(
+        status="ok",
+        dataset=dataset,
+        cancelled_jobs=cancelled_jobs,
+        deleted_cached_responses=deleted_cached_responses or 0,
+    )
 
 
 def create_recreate_dataset_endpoint(
@@ -51,31 +94,17 @@ def create_recreate_dataset_endpoint(
                 organization=organization,
                 hf_timeout_seconds=hf_timeout_seconds,
             )
-            # try to get the revision of the dataset (before deleting the jobs and the cache, in case it fails)
-            revision = get_dataset_git_revision(dataset=dataset, hf_endpoint=hf_endpoint, hf_token=hf_token)
-            # delete all the jobs and all the cache entries for the dataset (for all the revisions)
-            cancelled_jobs = Queue().cancel_dataset_jobs(dataset=dataset)
-            deleted_cached_responses = delete_dataset_responses(dataset=dataset)
-            if deleted_cached_responses is not None and deleted_cached_responses > 0:
-                # delete assets
-                delete_asset_dir(dataset=dataset, directory=assets_directory)
-                delete_asset_dir(dataset=dataset, directory=cached_assets_directory)
-            # create the jobs to backfill the dataset
-            backfill_dataset(
-                dataset=dataset,
-                revision=revision,
-                processing_graph=processing_graph,
-                priority=priority,
-                cache_max_days=1,
-                blocked_datasets=blocked_datasets,
-            )
             return get_json_ok_response(
-                {
-                    "status": "ok",
-                    "dataset": dataset,
-                    "cancelled_jobs": cancelled_jobs,
-                    "deleted_cached_responses": deleted_cached_responses or 0,
-                },
+                recreate_dataset(
+                    dataset=dataset,
+                    priority=priority,
+                    assets_directory=assets_directory,
+                    blocked_datasets=blocked_datasets,
+                    cached_assets_directory=cached_assets_directory,
+                    hf_endpoint=hf_endpoint,
+                    hf_token=hf_token,
+                    processing_graph=processing_graph,
+                ),
                 max_age=0,
             )
         except CustomError as e:

--- a/services/admin/tests/routes/test_recreate_dataset.py
+++ b/services/admin/tests/routes/test_recreate_dataset.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 The HuggingFace Authors.
+
+import os
+import shutil
+from http import HTTPStatus
+from pathlib import Path
+from unittest.mock import patch
+
+from libcommon.processing_graph import ProcessingGraph
+from libcommon.queue import Queue
+from libcommon.simple_cache import has_some_cache, upsert_response
+from libcommon.utils import Priority, Status
+
+from admin.routes.recreate_dataset import recreate_dataset
+
+REVISION_NAME = "revision"
+
+
+def test_recreate_dataset(tmp_path: Path, processing_graph: ProcessingGraph) -> None:
+    assets_directory = tmp_path / "assets"
+    cached_assets_directory = tmp_path / "cached-assets"
+    dataset = "dataset"
+    os.makedirs(f"{assets_directory}/{dataset}", exist_ok=True)
+    os.makedirs(f"{cached_assets_directory}/{dataset}", exist_ok=True)
+
+    asset_file = Path(f"{assets_directory}/{dataset}/image.jpg")
+    asset_file.touch()
+    assert asset_file.is_file()
+
+    cached_asset_file = Path(f"{cached_assets_directory}/{dataset}/image.jpg")
+    cached_asset_file.touch()
+    assert cached_asset_file.is_file()
+
+    queue = Queue()
+    queue.add_job(
+        job_type="job_type",
+        dataset=dataset,
+        revision=REVISION_NAME,
+        config=None,
+        split=None,
+        difficulty=100,
+    ).update(status=Status.STARTED)
+
+    upsert_response(
+        kind="kind",
+        dataset=dataset,
+        dataset_git_revision=REVISION_NAME,
+        content={"config_names": [{"dataset": dataset, "config": "config"}]},
+        http_status=HTTPStatus.OK,
+    )
+
+    assert has_some_cache(dataset=dataset)
+
+    with patch("admin.routes.recreate_dataset.get_dataset_git_revision", return_value=REVISION_NAME):
+        recreate_dataset_report = recreate_dataset(
+            hf_endpoint="hf_endpoint",
+            hf_token="hf_token",
+            assets_directory=assets_directory,
+            cached_assets_directory=cached_assets_directory,
+            dataset=dataset,
+            priority=Priority.HIGH,
+            processing_graph=processing_graph,
+            blocked_datasets=[],
+        )
+        assert recreate_dataset_report["status"] == "ok"
+        assert recreate_dataset_report["dataset"] == dataset
+        assert recreate_dataset_report["cancelled_jobs"] == 1
+        assert recreate_dataset_report["deleted_cached_responses"] == 1
+    assert not asset_file.is_file()
+    assert not cached_asset_file.is_file()
+    assert not has_some_cache(dataset=dataset)
+
+    shutil.rmtree(assets_directory, ignore_errors=True)
+    shutil.rmtree(cached_assets_directory, ignore_errors=True)


### PR DESCRIPTION
Adding test for recreate dataset in admin service.
Also found a bug for cancel_jobs, it was returning always 0 after the update statement.
