### PR TITLE
feat: 🎸 upgrade nginx image to 1.25.3

### DIFF
--- a/chart/env/staging.yaml
+++ b/chart/env/staging.yaml
@@ -17,7 +17,7 @@ images:
     useGlobalRegistry: false
     registry: docker.io
     repository: nginx
-    tag: "1.20"
+    tag: "1.25.3"
   jobs:
     mongodbMigration:
       registry: huggingface

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -28,7 +28,7 @@ images:
     useGlobalRegistry: false
     registry: docker.io
     repository: nginx
-    tag: "1.20"
+    tag: "1.25.3"
   jobs:
     mongodbMigration:
       registry: huggingface
@@ -391,7 +391,6 @@ cleanDuckdbIndexCache:
   expiredTimeIntervalSeconds: 600
   subfolderPattern: "cache/*"
 
-
 cleanDuckdbIndexDownloads:
   enabled: true
   log:
@@ -430,7 +429,6 @@ cleanDuckdbIndexJobRunner:
   expiredTimeIntervalSeconds: 600
   subfolderPattern: "job_runner/*"
 
-
 cleanStatsCache:
   enabled: true
   log:
@@ -448,7 +446,6 @@ cleanStatsCache:
   tolerations: []
   expiredTimeIntervalSeconds: 600
   subfolderPattern: "*"
-
 
 postMessages:
   enabled: true

--- a/tools/docker-compose-datasets-server.yml
+++ b/tools/docker-compose-datasets-server.yml
@@ -1,6 +1,6 @@
 services:
   reverse-proxy:
-    image: docker.io/nginx:1.20
+    image: docker.io/nginx:1.25.3
     # image: ${IMAGE_REVERSE_PROXY?IMAGE_REVERSE_PROXY env var must be provided}
     volumes:
       - ../chart/nginx-templates/:/etc/nginx/templates:ro

--- a/tools/docker-compose-dev-datasets-server.yml
+++ b/tools/docker-compose-dev-datasets-server.yml
@@ -1,6 +1,6 @@
 services:
   reverse-proxy:
-    image: docker.io/nginx:1.20
+    image: docker.io/nginx:1.25.3
     # image: ${IMAGE_REVERSE_PROXY?IMAGE_REVERSE_PROXY env var must be provided}
     volumes:
       - ../chart/nginx-templates/:/etc/nginx/templates:ro


### PR DESCRIPTION
fixes #1961.

RELEASE NOTES are here: https://nginx.org/en/CHANGES.

The change we're interested in is:
> *) Change: improved detection of misbehaving clients when using
HTTP/2.