### PR TITLE
invalidate the datasets cache after 3 years instead of 3 months

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -167,7 +167,7 @@ mongodb:
 
 cache:
   # Maximum number of days to keep the cached API responses
-  maxDays: 90
+  maxDays: 1000
   # Name of the mongo db database used to cache the API responses
   mongoDatabase: "datasets_server_cache"
 


### PR DESCRIPTION
Quick fix to avoid deleting old cache entries (in particular, to be sure to keep the old dataset cache entries for datasets with a dataset script, now that we don't support scripts anymore)