### PR TITLE
fix reverse proxy

### DIFF
--- a/chart/nginx-templates/default.conf.template
+++ b/chart/nginx-templates/default.conf.template
@@ -29,14 +29,6 @@ server {
     return 307 https://raw.githubusercontent.com/huggingface/datasets-server/main/${OPENAPI_FILE};
   }
 
-  location /assets/ {
-    alias ${ASSETS_DIRECTORY}/;
-  }
-
-  location /cached-assets/ {
-    alias ${CACHED_ASSETS_DIRECTORY}/;
-  }
-
   location /admin/ {
     # note the trailing slash, to remove the /admin/ prefix
     proxy_pass ${URL_ADMIN}/;

--- a/chart/templates/reverse-proxy/_container.tpl
+++ b/chart/templates/reverse-proxy/_container.tpl
@@ -6,10 +6,6 @@
   image: {{ include "reverseproxy.image" . }}
   imagePullPolicy: {{ .Values.images.pullPolicy }}
   env:
-  - name: ASSETS_DIRECTORY
-    value: {{ .Values.assets.storageDirectory | quote }}
-  - name: CACHED_ASSETS_DIRECTORY
-    value: {{ .Values.cachedAssets.storageDirectory | quote }}
   - name: OPENAPI_FILE
     value: {{ .Values.reverseProxy.openapiFile | quote }}
   - name: HOST

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -251,8 +251,6 @@ assets:
   storageRoot: "/storage"
   folderName: "assets"
   storageProtocol: "file"
-  # TODO: remove
-  storageDirectory: "/storage/assets"
 
 cachedAssets:
   # base URL for the cached assets files. It should be set accordingly to the datasets-server domain, eg https://datasets-server.huggingface.co/cached-assets
@@ -261,8 +259,6 @@ cachedAssets:
   storageRoot: "/storage"
   folderName: "cached-assets"
   storageProtocol: "file"
-  # TODO: remove
-  storageDirectory: "/storage/cached-assets"
 
 parquetMetadata:
   # Directory on the shared storage (parquet metadata files used for random access in /rows)


### PR DESCRIPTION
After deploying https://github.com/huggingface/datasets-server/pull/2040 in staging, reverse-proxy component failed (I could not see the specific error but suspect it is because of an alias to a no longer existent location /storage).
