### PR TITLE
catch exception on delete assets

### DIFF
--- a/libs/libcommon/src/libcommon/storage_client.py
+++ b/libs/libcommon/src/libcommon/storage_client.py
@@ -50,5 +50,5 @@ class StorageClient:
         try:
             self._fs.rm(dataset_key, recursive=True)
             logging.info(f"Directory deleted: {dataset_key}")
-        except Exception as e:
+        except Exception:
             logging.warning(f"Could not delete directory {dataset_key}")

--- a/libs/libcommon/src/libcommon/storage_client.py
+++ b/libs/libcommon/src/libcommon/storage_client.py
@@ -47,5 +47,8 @@ class StorageClient:
 
     def delete_dataset_directory(self, dataset: str) -> None:
         dataset_key = f"{self.get_base_directory()}/{dataset}"
-        self._fs.rm(dataset_key, recursive=True)
-        logging.info(f"Directory removed: {dataset_key}")
+        try:
+            self._fs.rm(dataset_key, recursive=True)
+            logging.info(f"Directory deleted: {dataset_key}")
+        except Exception as e:
+            logging.warning(f"Could not delete directory {dataset_key}")


### PR DESCRIPTION
Fix for obsolete cache, FileNotFound error is shown when a datasets does not have either assets or cached assets:
```
ERROR: 2023-11-07 15:42:28,461 - root - Unexpected error.
Traceback (most recent call last):
File "/src/services/admin/src/admin/routes/obsolete_cache.py", line 126, in delete_obsolete_cache_endpoint
delete_obsolete_cache(
File "/src/services/admin/src/admin/routes/obsolete_cache.py", line 95, in delete_obsolete_cache
cached_assets_storage_client.delete_dataset_directory(dataset)
File "/src/libs/libcommon/src/libcommon/storage_client.py", line 50, in delete_dataset_directory
self._fs.rm(dataset_key, recursive=True)
File "/src/services/admin/.venv/lib/python3.9/site-packages/fsspec/asyn.py", line 118, in wrapper
return sync(self.loop, func, *args, **kwargs)
File "/src/services/admin/.venv/lib/python3.9/site-packages/fsspec/asyn.py", line 103, in sync
raise return_result
File "/src/services/admin/.venv/lib/python3.9/site-packages/fsspec/asyn.py", line 56, in _runner
result[0] = await coro
File "/src/services/admin/.venv/lib/python3.9/site-packages/s3fs/core.py", line 1920, in _rm
paths = await self._expand_path(path, recursive=recursive)
File "/src/services/admin/.venv/lib/python3.9/site-packages/fsspec/asyn.py", line 864, in _expand_path
out = await self._expand_path([path], recursive, maxdepth)
File "/src/services/admin/.venv/lib/python3.9/site-packages/fsspec/asyn.py", line 893, in _expand_path
raise FileNotFoundError(path)
FileNotFoundError: ['hf-datasets-server-statics/cached-assets/typeof/acapla']

```
Will also fix https://github.com/huggingface/datasets-server/issues/2057