### PR TITLE
add service for workers

### DIFF
--- a/chart/templates/worker/_service.yaml
+++ b/chart/templates/worker/_service.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 The HuggingFace Authors.
+
+{{- define "serviceWorker" -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ include "name" . }}-worker-{{ .workerValues.deployName }}"
+  annotations: {}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "labels.worker" . | nindent 4 }}
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: {{ .workerValues.uvicornPort }}
+  selector: {{ include "labels.worker" . | nindent 4 }}
+{{- end -}}

--- a/chart/templates/worker/service.yaml
+++ b/chart/templates/worker/service.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 The HuggingFace Authors.
+
+{{- range $index, $workerValues := .Values.workers }}
+{{ include "serviceWorker" (merge (dict "workerValues" $workerValues) $ ) }}
+{{- end }}


### PR DESCRIPTION
We need to access the /metrics endpoint in `servicemonitor`, and it surely requires a _service_ to _monitor_.