### PR TITLE
Stats resources

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -436,7 +436,7 @@ workers:
     replicas: 30
     resources:
       requests:
-        cpu: 1
+        cpu: 2
         memory: "14Gi"
       limits:
         cpu: 2

--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -479,7 +479,7 @@ def compute_descriptive_statistics_response(
 
     con = duckdb.connect(str(local_parquet_directory / DATABASE_FILENAME))  # load data in local db file
     con.sql("SET enable_progress_bar=true;")
-    
+
     # DuckDB uses n_threads = num kubernetes cpu (limits)
     n_threads = con.sql("SELECT current_setting('threads')").fetchall()[0][0]
     logging.info(f"Number of threads={n_threads}")


### PR DESCRIPTION
@polinaeterna I fixed the n_threads and max_memory settings of DuckDB (they should be different based on the pod type)

I also set requests == limits for cpu to see if it fixes the DuckDB hanging issue (and more generally any hanging issue that we can also observe when killing pods or in parquet conversion jobs)