### PR TITLE
add cacheable ParquetResponseEmptyError in first-rows-from-parquet

### DIFF
--- a/libs/libcommon/src/libcommon/parquet_utils.py
+++ b/libs/libcommon/src/libcommon/parquet_utils.py
@@ -26,7 +26,7 @@ from libcommon.viewer_utils.features import get_supported_unsupported_columns
 PARTIAL_PREFIX = "partial-"
 
 
-class ParquetResponseEmptyError(Exception):
+class EmptyParquetMetadataError(Exception):
     pass
 
 
@@ -228,7 +228,7 @@ class ParquetIndexWithMetadata:
         unsupported_features: list[FeatureType] = [],
     ) -> "ParquetIndexWithMetadata":
         if not parquet_file_metadata_items:
-            raise ParquetResponseEmptyError("No parquet files found.")
+            raise EmptyParquetMetadataError("No parquet files found.")
 
         partial = parquet_export_is_partial(parquet_file_metadata_items[0]["url"])
 

--- a/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
@@ -15,8 +15,7 @@ from libcommon.exceptions import (
     TooBigContentError,
     TooManyColumnsError,
 )
-from libcommon.parquet_utils import Indexer, TooBigRows
-from libcommon.parquet_utils import ParquetResponseEmptyError as EmptyError
+from libcommon.parquet_utils import EmptyParquetMetadataError, Indexer, TooBigRows
 from libcommon.processing_graph import ProcessingGraph, ProcessingStep
 from libcommon.public_assets_storage import PublicAssetsStorage
 from libcommon.storage import StrPath
@@ -79,7 +78,7 @@ def compute_first_rows_response(
             config=config,
             split=split,
         )
-    except EmptyError:
+    except EmptyParquetMetadataError:
         raise ParquetResponseEmptyError("No parquet files found.")
 
     # validate the features

--- a/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_parquet.py
@@ -10,11 +10,13 @@ from libcommon.constants import (
     PROCESSING_STEP_SPLIT_FIRST_ROWS_FROM_STREAMING_VERSION,
 )
 from libcommon.exceptions import (
+    ParquetResponseEmptyError,
     RowsPostProcessingError,
     TooBigContentError,
     TooManyColumnsError,
 )
 from libcommon.parquet_utils import Indexer, TooBigRows
+from libcommon.parquet_utils import ParquetResponseEmptyError as EmptyError
 from libcommon.processing_graph import ProcessingGraph, ProcessingStep
 from libcommon.public_assets_storage import PublicAssetsStorage
 from libcommon.storage import StrPath
@@ -71,11 +73,14 @@ def compute_first_rows_response(
 ) -> SplitFirstRowsResponse:
     logging.info(f"get first-rows for dataset={dataset} config={config} split={split}")
 
-    rows_index = indexer.get_rows_index(
-        dataset=dataset,
-        config=config,
-        split=split,
-    )
+    try:
+        rows_index = indexer.get_rows_index(
+            dataset=dataset,
+            config=config,
+            split=split,
+        )
+    except EmptyError:
+        raise ParquetResponseEmptyError("No parquet files found.")
 
     # validate the features
     features = rows_index.parquet_index.features

--- a/services/worker/tests/job_runners/split/test_first_rows_from_parquet.py
+++ b/services/worker/tests/job_runners/split/test_first_rows_from_parquet.py
@@ -121,11 +121,12 @@ def ds_fs(ds: Dataset, tmpfs: AbstractFileSystem) -> Generator[AbstractFileSyste
 
 
 @pytest.mark.parametrize(
-    "rows_max_bytes,columns_max_number,error_code",
+    "rows_max_bytes,columns_max_number,has_parquet_files,error_code",
     [
-        (0, 10, "TooBigContentError"),  # too small limit, even with truncation
-        (1_000, 1, "TooManyColumnsError"),  # too small columns limit
-        (1_000, 10, None),
+        (0, 10, True, "TooBigContentError"),  # too small limit, even with truncation
+        (1_000, 1, True, "TooManyColumnsError"),  # too small columns limit
+        (1_000, 10, True, None),
+        (1_000, 10, False, "ParquetResponseEmptyError"),
     ],
 )
 def test_compute(
@@ -136,6 +137,7 @@ def test_compute(
     app_config: AppConfig,
     rows_max_bytes: int,
     columns_max_number: int,
+    has_parquet_files: bool,
     error_code: str,
 ) -> None:
     dataset, config, split = "dataset", "config", "split"
@@ -157,7 +159,7 @@ def test_compute(
                 "num_rows": len(ds),
                 "parquet_metadata_subpath": fake_metadata_subpath,
             }
-        ]
+        ] if has_parquet_files else []
     }
 
     upsert_response(

--- a/services/worker/tests/job_runners/split/test_first_rows_from_parquet.py
+++ b/services/worker/tests/job_runners/split/test_first_rows_from_parquet.py
@@ -159,7 +159,9 @@ def test_compute(
                 "num_rows": len(ds),
                 "parquet_metadata_subpath": fake_metadata_subpath,
             }
-        ] if has_parquet_files else []
+        ]
+        if has_parquet_files
+        else []
     }
 
     upsert_response(


### PR DESCRIPTION
Part of https://github.com/huggingface/datasets-server/issues/1443
Currently, we have `{ _id: { cause: 'ParquetResponseEmptyError' }, count: 303 }`, records in cache collection with UnexpectedError because of `ParquetResponseEmptyError`.
Actually, we have two definitions of `ParquetResponseEmptyError`: one in parquet_utils.py https://github.com/huggingface/datasets-server/blob/main/libs/libcommon/src/libcommon/parquet_utils.py#L29 and another in https://github.com/huggingface/datasets-server/blob/main/libs/libcommon/src/libcommon/exceptions.py#L424.
`SplitFirstRowsFromParquetJobRunner` should throw the cacheable version of `ParquetResponseEmptyError` but currently it is not handling the noncacheable exception leading to an `UnexpectedError`.
After this PR, I will refresh the cache of the 303 records.
