### PR TITLE
feat: 🎸 disable two datasets to avoid load on the Hub

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -80,7 +80,7 @@ images:
 common:
   # Comma-separated list of blocked datasets (e.g. if not supported by the Hub). No jobs will be processed for those datasets.
   # See https://observablehq.com/@huggingface/blocked-datasets
-  blockedDatasets: "open-llm-leaderboard/*"
+  blockedDatasets: "open-llm-leaderboard/*,taesiri/arxiv_qa,enzostvs/stable-diffusion-tpu-generations"
   # Comma-separated list of the datasets for which we support dataset scripts.
   # Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
   # The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` refers to all the datasets without namespace.


### PR DESCRIPTION
> a lot of calls to the Hub are pending because of "expand" in the tree
API by the datasets library