### PR TITLE
Escape names in Croissant.

### DIFF
--- a/services/api/src/api/routes/croissant.py
+++ b/services/api/src/api/routes/croissant.py
@@ -1,8 +1,8 @@
 import logging
+import re
 from collections.abc import Mapping
 from http import HTTPStatus
 from itertools import islice
-import re
 from typing import Any, Optional
 
 from datasets import ClassLabel, Features, Image, Value
@@ -38,6 +38,7 @@ HF_TO_CROISSANT_VALUE_TYPE = {
 }
 
 NAME_PATTERN_REGEX = "[^a-zA-Z0-9\\-_\\.]"
+
 
 def _escape_name(name: str) -> str:
     """Escapes names in Croissant, as `/` are used in the syntax as delimiters."""

--- a/services/api/src/api/routes/croissant.py
+++ b/services/api/src/api/routes/croissant.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Mapping
 from http import HTTPStatus
 from itertools import islice
+import re
 from typing import Any, Optional
 
 from datasets import ClassLabel, Features, Image, Value
@@ -36,9 +37,11 @@ HF_TO_CROISSANT_VALUE_TYPE = {
     "bool": "sc:Boolean",
 }
 
+NAME_PATTERN_REGEX = "[^a-zA-Z0-9\\-_\\.]"
+
 def _escape_name(name: str) -> str:
     """Escapes names in Croissant, as `/` are used in the syntax as delimiters."""
-    return name.replace("/", "_")
+    return re.sub(NAME_PATTERN_REGEX, "_", name)
 
 
 def get_croissant_from_dataset_infos(dataset: str, infos: list[Mapping[str, Any]], partial: bool) -> Mapping[str, Any]:

--- a/services/api/src/api/routes/croissant.py
+++ b/services/api/src/api/routes/croissant.py
@@ -36,6 +36,10 @@ HF_TO_CROISSANT_VALUE_TYPE = {
     "bool": "sc:Boolean",
 }
 
+def _escape_name(name: str) -> str:
+    """Escapes names in Croissant, as `/` are used in the syntax as delimiters."""
+    return name.replace("/", "_")
+
 
 def get_croissant_from_dataset_infos(dataset: str, infos: list[Mapping[str, Any]], partial: bool) -> Mapping[str, Any]:
     distribution = [
@@ -58,7 +62,7 @@ def get_croissant_from_dataset_infos(dataset: str, infos: list[Mapping[str, Any]
         distribution.append(
             {
                 "@type": "sc:FileSet",
-                "name": distribution_name,
+                "name": _escape_name(distribution_name),
                 "containedIn": "repo",
                 "encodingFormat": "application/x-parquet",
                 "includes": f"{config}/*/*.parquet",
@@ -70,7 +74,7 @@ def get_croissant_from_dataset_infos(dataset: str, infos: list[Mapping[str, Any]
                 fields.append(
                     {
                         "@type": "ml:Field",
-                        "name": column,
+                        "name": _escape_name(column),
                         "description": f"Column '{column}' from the Hugging Face parquet file.",
                         "dataType": HF_TO_CROISSANT_VALUE_TYPE[feature.dtype],
                         "source": {"distribution": distribution_name, "extract": {"column": column}},
@@ -80,7 +84,7 @@ def get_croissant_from_dataset_infos(dataset: str, infos: list[Mapping[str, Any]
                 fields.append(
                     {
                         "@type": "ml:Field",
-                        "name": column,
+                        "name": _escape_name(column),
                         "description": f"Image column '{column}' from the Hugging Face parquet file.",
                         "dataType": "sc:ImageObject",
                         "source": {
@@ -94,7 +98,7 @@ def get_croissant_from_dataset_infos(dataset: str, infos: list[Mapping[str, Any]
                 fields.append(
                     {
                         "@type": "ml:Field",
-                        "name": column,
+                        "name": _escape_name(column),
                         "description": f"ClassLabel column '{column}' from the Hugging Face parquet file.\nLabels:\n"
                         + ", ".join(f"{name} ({i})" for i, name in enumerate(feature.names)),
                         "dataType": "sc:Integer",
@@ -117,7 +121,7 @@ def get_croissant_from_dataset_infos(dataset: str, infos: list[Mapping[str, Any]
         record_set.append(
             {
                 "@type": "ml:RecordSet",
-                "name": config,
+                "name": _escape_name(config),
                 "description": description,
                 "field": fields,
             }
@@ -157,7 +161,7 @@ def get_croissant_from_dataset_infos(dataset: str, infos: list[Mapping[str, Any]
             "transform": "ml:transform",
         },
         "@type": "sc:Dataset",
-        "name": dataset,
+        "name": _escape_name(dataset),
         "description": f"{dataset} dataset hosted on Hugging Face and contributed by the HF Datasets community",
         "url": f"https://huggingface.co/datasets/{dataset}",
         "distribution": distribution,

--- a/services/api/tests/routes/test_croissant.py
+++ b/services/api/tests/routes/test_croissant.py
@@ -48,9 +48,11 @@ squad_info = {
 
 
 def test_get_croissant_from_dataset_infos() -> None:
-    croissant = get_croissant_from_dataset_infos("squad", [squad_info], partial=False)
+    croissant = get_croissant_from_dataset_infos("user/squad", [squad_info], partial=False)
     assert "@context" in croissant
     assert "@type" in croissant
+    assert "name" in croissant
+    assert croissant["name"] == "user_squad"
     assert "distribution" in croissant
     assert "recordSet" in croissant
     # column "answers" is not supported (nested)

--- a/services/api/tests/routes/test_croissant.py
+++ b/services/api/tests/routes/test_croissant.py
@@ -20,7 +20,7 @@ squad_info = {
     },
     "task_templates": [{"task": "question-answering-extractive"}],
     "builder_name": "squad",
-    "config_name": "plain_text",
+    "config_name": "config names can contain spaces",
     "version": {"version_str": "1.0.0", "description": "", "major": 1, "minor": 0, "patch": 0},
     "splits": {
         "train": {"name": "train", "num_bytes": 79346108, "num_examples": 87599, "dataset_name": "squad"},
@@ -58,6 +58,7 @@ def test_get_croissant_from_dataset_infos() -> None:
     # column "answers" is not supported (nested)
     assert isinstance(croissant["recordSet"], list)
     assert len(croissant["recordSet"]) == 1
+    assert croissant["recordSet"][0]["name"] == "config_names_can_contain_spaces"
     assert isinstance(croissant["recordSet"][0]["field"], list)
     assert isinstance(squad_info["features"], dict)
     assert len(croissant["recordSet"][0]["field"]) == len(squad_info["features"]) - 1


### PR DESCRIPTION
Reason: `/` are used in the syntax as delimiters.

I ended up testing on the first dataset names and configs, and found more conflicts (like ` ` or `=` in the names), so I ended up applying a regular expression corresponding to [the one used by Croissant](https://github.com/mlcommons/croissant/blob/475998a89716a8a022817f1126cf3dd1a3526418/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py#L20).