### PR TITLE
Sync queue index

### DIFF
--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -152,8 +152,8 @@ class JobDocument(Document):
             ("priority", "status", "created_at", "difficulty", "namespace"),
             ("priority", "status", "type", "namespace", "unicity_id", "created_at", "-difficulty"),
             ("status", "type"),
-            # ("unicity_id", "-created_at", "status"), # 4440
-            ("unicity_id", "status", "-created_at"), # 12700
+            # ("unicity_id", "-created_at", "status"),
+            ("unicity_id", "status", "-created_at"),
             {
                 "fields": ["finished_at"],
                 "expireAfterSeconds": QUEUE_TTL_SECONDS,

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -20,33 +20,17 @@ import pytz
 from bson import ObjectId
 from mongoengine import Document
 from mongoengine.errors import DoesNotExist, NotUniqueError
-from mongoengine.fields import (
-    DateTimeField,
-    EnumField,
-    IntField,
-    ObjectIdField,
-    StringField,
-)
+from mongoengine.fields import (DateTimeField, EnumField, IntField,
+                                ObjectIdField, StringField)
 from mongoengine.queryset.queryset import QuerySet
 
-from libcommon.constants import (
-    DEFAULT_DIFFICULTY_MAX,
-    DEFAULT_DIFFICULTY_MIN,
-    LOCK_TTL_SECONDS,
-    QUEUE_COLLECTION_JOBS,
-    QUEUE_COLLECTION_LOCKS,
-    QUEUE_METRICS_COLLECTION,
-    QUEUE_MONGOENGINE_ALIAS,
-    QUEUE_TTL_SECONDS,
-)
-from libcommon.utils import (
-    FlatJobInfo,
-    JobInfo,
-    Priority,
-    Status,
-    get_datetime,
-    inputs_to_string,
-)
+from libcommon.constants import (DEFAULT_DIFFICULTY_MAX,
+                                 DEFAULT_DIFFICULTY_MIN, LOCK_TTL_SECONDS,
+                                 QUEUE_COLLECTION_JOBS, QUEUE_COLLECTION_LOCKS,
+                                 QUEUE_METRICS_COLLECTION,
+                                 QUEUE_MONGOENGINE_ALIAS, QUEUE_TTL_SECONDS)
+from libcommon.utils import (FlatJobInfo, JobInfo, Priority, Status,
+                             get_datetime, inputs_to_string)
 
 # START monkey patching ### hack ###
 # see https://github.com/sbdchd/mongo-types#install
@@ -160,12 +144,16 @@ class JobDocument(Document):
         "collection": QUEUE_COLLECTION_JOBS,
         "db_alias": QUEUE_MONGOENGINE_ALIAS,
         "indexes": [
+            ("dataset", "status"),
             ("type", "dataset", "status"),
-            ("type", "dataset", "revision", "config", "split", "status", "priority"),
-            ("priority", "status", "created_at", "namespace"),
+            # ("type", "dataset", "revision", "config", "split", "status", "priority"),
+            # ("priority", "status", "created_at", "namespace"),
+            ("priority", "status", "created_at", "namespace", "difficulty", "unicity_id"),
+            ("priority", "status", "created_at", "difficulty", "namespace"),
             ("priority", "status", "type", "namespace", "unicity_id", "created_at", "-difficulty"),
             ("status", "type"),
-            ("unicity_id", "-created_at", "status"),
+            # ("unicity_id", "-created_at", "status"), # 4440
+            ("unicity_id", "status", "-created_at"), # 12700
             {
                 "fields": ["finished_at"],
                 "expireAfterSeconds": QUEUE_TTL_SECONDS,

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -20,17 +20,20 @@ import pytz
 from bson import ObjectId
 from mongoengine import Document
 from mongoengine.errors import DoesNotExist, NotUniqueError
-from mongoengine.fields import (DateTimeField, EnumField, IntField,
-                                ObjectIdField, StringField)
+from mongoengine.fields import DateTimeField, EnumField, IntField, ObjectIdField, StringField
 from mongoengine.queryset.queryset import QuerySet
 
-from libcommon.constants import (DEFAULT_DIFFICULTY_MAX,
-                                 DEFAULT_DIFFICULTY_MIN, LOCK_TTL_SECONDS,
-                                 QUEUE_COLLECTION_JOBS, QUEUE_COLLECTION_LOCKS,
-                                 QUEUE_METRICS_COLLECTION,
-                                 QUEUE_MONGOENGINE_ALIAS, QUEUE_TTL_SECONDS)
-from libcommon.utils import (FlatJobInfo, JobInfo, Priority, Status,
-                             get_datetime, inputs_to_string)
+from libcommon.constants import (
+    DEFAULT_DIFFICULTY_MAX,
+    DEFAULT_DIFFICULTY_MIN,
+    LOCK_TTL_SECONDS,
+    QUEUE_COLLECTION_JOBS,
+    QUEUE_COLLECTION_LOCKS,
+    QUEUE_METRICS_COLLECTION,
+    QUEUE_MONGOENGINE_ALIAS,
+    QUEUE_TTL_SECONDS,
+)
+from libcommon.utils import FlatJobInfo, JobInfo, Priority, Status, get_datetime, inputs_to_string
 
 # START monkey patching ### hack ###
 # see https://github.com/sbdchd/mongo-types#install

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -149,13 +149,10 @@ class JobDocument(Document):
         "indexes": [
             ("dataset", "status"),
             ("type", "dataset", "status"),
-            # ("type", "dataset", "revision", "config", "split", "status", "priority"),
-            # ("priority", "status", "created_at", "namespace"),
             ("priority", "status", "created_at", "namespace", "difficulty", "unicity_id"),
             ("priority", "status", "created_at", "difficulty", "namespace"),
             ("priority", "status", "type", "namespace", "unicity_id", "created_at", "-difficulty"),
             ("status", "type"),
-            # ("unicity_id", "-created_at", "status"),
             ("unicity_id", "status", "-created_at"),
             {
                 "fields": ["finished_at"],


### PR DESCRIPTION
**According to index usage, these indexes are not used very frecuently or can ve covered by another index:**
- ("type", "dataset", "revision", "config", "split", "status", "priority"),
- ("priority", "status", "created_at", "namespace"),
- ("unicity_id", "-created_at", "status"), # 4440

I hid them to evaluate if the system will be affected once we delete them. 
 
**Adding these indexes in the code as they already exist in the server and are used by the queries:**
- ("dataset", "status"),
- ("priority", "status", "created_at", "namespace", "difficulty", "unicity_id"),
- ("priority", "status", "created_at", "difficulty", "namespace"),
- ("unicity_id", "status", "-created_at"),
See index usage report:
```
[
  {
    name: 'type_1_dataset_1_revision_1_config_1_split_1_status_1_priority_1',
    key: {
      type: 1,
      dataset: 1,
      revision: 1,
      config: 1,
      split: 1,
      status: 1,
      priority: 1
    },
    host: 'atlas-x5jgb3-shard-00-01.ujrd0.mongodb.net:27017',
    accesses: { ops: Long("8"), since: ISODate("2023-11-22T19:20:27.967Z") },
    spec: {
      v: 2,
      key: {
        type: 1,
        dataset: 1,
        revision: 1,
        config: 1,
        split: 1,
        status: 1,
        priority: 1
      },
      name: 'type_1_dataset_1_revision_1_config_1_split_1_status_1_priority_1',
      background: false
    }
  },
  {
    name: 'priority_1_status_1_created_at_1_difficulty_1_namespace_1',
    key: {
      priority: 1,
      status: 1,
      created_at: 1,
      difficulty: 1,
      namespace: 1
    },
    host: 'atlas-x5jgb3-shard-00-01.ujrd0.mongodb.net:27017',
    accesses: { ops: Long("11302"), since: ISODate("2023-11-22T19:20:27.967Z") },
    spec: {
      v: 2,
      key: {
        priority: 1,
        status: 1,
        created_at: 1,
        difficulty: 1,
        namespace: 1
      },
      name: 'priority_1_status_1_created_at_1_difficulty_1_namespace_1'
    }
  },
  {
    name: 'priority_1_status_1_created_at_1_namespace_1_difficulty_1_unicity_id_1',
    key: {
      priority: 1,
      status: 1,
      created_at: 1,
      namespace: 1,
      difficulty: 1,
      unicity_id: 1
    },
    host: 'atlas-x5jgb3-shard-00-01.ujrd0.mongodb.net:27017',
    accesses: { ops: Long("275"), since: ISODate("2023-11-22T19:20:27.967Z") },
    spec: {
      v: 2,
      key: {
        priority: 1,
        status: 1,
        created_at: 1,
        namespace: 1,
        difficulty: 1,
        unicity_id: 1
      },
      name: 'priority_1_status_1_created_at_1_namespace_1_difficulty_1_unicity_id_1'
    }
  },
  {
    name: 'priority_1_status_1_type_1_namespace_1_unicity_id_1_created_at_1_difficulty_-1',
    key: {
      priority: 1,
      status: 1,
      type: 1,
      namespace: 1,
      unicity_id: 1,
      created_at: 1,
      difficulty: -1
    },
    host: 'atlas-x5jgb3-shard-00-01.ujrd0.mongodb.net:27017',
    accesses: { ops: Long("6030"), since: ISODate("2023-11-22T19:20:27.967Z") },
    spec: {
      v: 2,
      key: {
        priority: 1,
        status: 1,
        type: 1,
        namespace: 1,
        unicity_id: 1,
        created_at: 1,
        difficulty: -1
      },
      name: 'priority_1_status_1_type_1_namespace_1_unicity_id_1_created_at_1_difficulty_-1'
    }
  },
  {
    name: '_id_',
    key: { _id: 1 },
    host: 'atlas-x5jgb3-shard-00-01.ujrd0.mongodb.net:27017',
    accesses: { ops: Long("24007"), since: ISODate("2023-11-22T19:20:27.967Z") },
    spec: { v: 2, key: { _id: 1 }, name: '_id_' }
  },
  {
    name: 'finished_at_1',
    key: { finished_at: 1 },
    host: 'atlas-x5jgb3-shard-00-01.ujrd0.mongodb.net:27017',
    accesses: { ops: Long("0"), since: ISODate("2023-11-22T19:20:27.967Z") },
    spec: {
      v: 2,
      key: { finished_at: 1 },
      name: 'finished_at_1',
      background: false,
      expireAfterSeconds: 600,
      partialFilterExpression: { status: { '$in': [ 'success', 'error', 'cancelled' ] } }
    }
  },
  {
    name: 'status_1_type_1',
    key: { status: 1, type: 1 },
    host: 'atlas-x5jgb3-shard-00-01.ujrd0.mongodb.net:27017',
    accesses: { ops: Long("59169"), since: ISODate("2023-11-22T19:20:27.967Z") },
    spec: {
      v: 2,
      key: { status: 1, type: 1 },
      name: 'status_1_type_1',
      background: false
    }
  },
  {
    name: 'type_1_dataset_1_status_1',
    key: { type: 1, dataset: 1, status: 1 },
    host: 'atlas-x5jgb3-shard-00-01.ujrd0.mongodb.net:27017',
    accesses: { ops: Long("3252"), since: ISODate("2023-11-22T19:20:27.967Z") },
    spec: {
      v: 2,
      key: { type: 1, dataset: 1, status: 1 },
      name: 'type_1_dataset_1_status_1',
      background: false
    }
  },
  {
    name: 'priority_1_status_1_created_at_1_namespace_1',
    key: { priority: 1, status: 1, created_at: 1, namespace: 1 },
    host: 'atlas-x5jgb3-shard-00-01.ujrd0.mongodb.net:27017',
    accesses: { ops: Long("10901"), since: ISODate("2023-11-22T19:20:27.967Z") },
    spec: {
      v: 2,
      key: { priority: 1, status: 1, created_at: 1, namespace: 1 },
      name: 'priority_1_status_1_created_at_1_namespace_1'
    }
  },
  {
    name: 'unicity_id_1_created_at_-1_status_1',
    key: { unicity_id: 1, created_at: -1, status: 1 },
    host: 'atlas-x5jgb3-shard-00-01.ujrd0.mongodb.net:27017',
    accesses: { ops: Long("4440"), since: ISODate("2023-11-22T19:20:27.967Z") },
    spec: {
      v: 2,
      key: { unicity_id: 1, created_at: -1, status: 1 },
      name: 'unicity_id_1_created_at_-1_status_1'
    }
  },
  {
    name: 'dataset_1_status_1',
    key: { dataset: 1, status: 1 },
    host: 'atlas-x5jgb3-shard-00-01.ujrd0.mongodb.net:27017',
    accesses: { ops: Long("406"), since: ISODate("2023-11-22T19:20:27.967Z") },
    spec: {
      v: 2,
      key: { dataset: 1, status: 1 },
      name: 'dataset_1_status_1'
    }
  },
  {
    name: 'unicity_id_1_status_1_created_at_-1',
    key: { unicity_id: 1, status: 1, created_at: -1 },
    host: 'atlas-x5jgb3-shard-00-01.ujrd0.mongodb.net:27017',
    accesses: { ops: Long("12700"), since: ISODate("2023-11-22T19:20:27.967Z") },
    spec: {
      v: 2,
      key: { unicity_id: 1, status: 1, created_at: -1 },
      name: 'unicity_id_1_status_1_created_at_-1'
    }
  }

```