### PR TITLE
enable viewer for MERA benchmark

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -84,7 +84,7 @@ common:
   # Comma-separated list of the datasets for which we support dataset scripts.
   # Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
   # The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` refers to all the datasets without namespace.
-  datasetScriptsAllowList: "{{ALL_DATASETS_WITH_NO_NAMESPACE}},togethercomputer/RedPajama-Data-V2,andreped/*,gaia-benchmark/GAIA,poloclub/diffusiondb,pufanyi/MIMICIT"
+  datasetScriptsAllowList: "{{ALL_DATASETS_WITH_NO_NAMESPACE}},togethercomputer/RedPajama-Data-V2,andreped/*,gaia-benchmark/GAIA,poloclub/diffusiondb,pufanyi/MIMICIT,ai-forever/MERA"
   # URL of the HuggingFace Hub
   hfEndpoint: ""
 


### PR DESCRIPTION
The viewer for the [MERA benchmark](https://huggingface.co/datasets/ai-forever/MERA) is not working because it is a script-based dataset but this is a cool benchmark for LLMs evaluation in Russian and I believe it's okay to add it to the allow list for now (along with encouraging the authors to push it as parquet in the future as well).

https://huggingface.co/datasets/ai-forever/MERA/discussions/1



