### PR TITLE
remove finished_at from code

### DIFF
--- a/jobs/mongodb_migration/tests/test_deletion_migrations.py
+++ b/jobs/mongodb_migration/tests/test_deletion_migrations.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The HuggingFace Authors.
 
+import pytest
 from libcommon.constants import (
     CACHE_COLLECTION_RESPONSES,
     CACHE_METRICS_COLLECTION,
@@ -112,6 +113,7 @@ def test_metrics_deletion_migration(mongo_host: str) -> None:
         db[CACHE_METRICS_COLLECTION].drop()
 
 
+@pytest.mark.skip(reason="obsolete, queue collection does not have 'finished_at' field")
 def test_queue_delete_ttl_index(mongo_host: str) -> None:
     with MongoResource(database="test_queue_delete_ttl_index", host=mongo_host, mongoengine_alias="queue"):
         JobDocument(

--- a/libs/libcommon/tests/test_queue.py
+++ b/libs/libcommon/tests/test_queue.py
@@ -529,18 +529,6 @@ def test_queue_get_zombies() -> None:
     assert queue.get_zombies(max_seconds_without_heartbeat=9999999) == []
 
 
-def test_has_ttl_index_on_finished_at_field() -> None:
-    ttl_index_names = [
-        name
-        for name, value in JobDocument._get_collection().index_information().items()
-        if "expireAfterSeconds" in value and "key" in value and value["key"] == [("finished_at", 1)]
-    ]
-    assert len(ttl_index_names) == 1
-    ttl_index_name = ttl_index_names[0]
-    assert ttl_index_name == "finished_at_1"
-    assert JobDocument._get_collection().index_information()[ttl_index_name]["expireAfterSeconds"] == QUEUE_TTL_SECONDS
-
-
 def random_sleep() -> None:
     MAX_SLEEP_MS = 40
     time.sleep(MAX_SLEEP_MS / 1000 * random.random())


### PR DESCRIPTION
As suggested by @severo  in https://github.com/huggingface/datasets-server/pull/2175#discussion_r1412342252 for "remove finished jobs," PR, finished_at, and TTL index field is being removed from code. Once merged, It will be necessary to deploy before changes in https://github.com/huggingface/datasets-server/pull/2175