### PR TITLE
temporary changing difficulty intervals in workers

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -401,7 +401,7 @@ workers:
     uvicornNumWorkers: "1"
     uvicornPort: 8080
     workerDifficultyMax: 100
-    workerDifficultyMin: 0
+    workerDifficultyMin: 80
     workerJobTypesBlocked: ""
     workerJobTypesOnly: ""
     nodeSelector:
@@ -420,8 +420,8 @@ workers:
     uvicornHostname: "0.0.0.0"
     uvicornNumWorkers: "1"
     uvicornPort: 8080
-    workerDifficultyMax: 70
-    workerDifficultyMin: 0
+    workerDifficultyMax: 80
+    workerDifficultyMin: 50
     workerJobTypesBlocked: ""
     workerJobTypesOnly: ""
     nodeSelector:
@@ -440,7 +440,7 @@ workers:
     uvicornHostname: "0.0.0.0"
     uvicornNumWorkers: "1"
     uvicornPort: 8080
-    workerDifficultyMax: 40
+    workerDifficultyMax: 50
     workerDifficultyMin: 0
     workerJobTypesBlocked: ""
     workerJobTypesOnly: ""


### PR DESCRIPTION
Currently we have a queue that isn't able to reduce for at least a couple of days
![image](https://github.com/huggingface/datasets-server/assets/5564745/646f5fa7-270a-498f-b9c4-32a464d2d8da)

The current difficulty distribution is:
```
Atlas atlas-x5jgb3-shard-0 [primary] datasets_server_queue> db.jobsBlue.aggregate([{$match:{status:"waiting"}},{$group:{_id:{difficulty:"$difficulty"},count:{$sum:1}}},{$sort:{count:-1}}])
[
  { _id: { difficulty: 70 }, count: 3290 },
  { _id: { difficulty: 90 }, count: 501 },
  { _id: { difficulty: 50 }, count: 327 },
  { _id: { difficulty: 60 }, count: 19 }
]
```

I will try to see if changing the worker max/min difficulty helps reducing the load.