### PR TITLE
blocking temporary lunaluan datasets

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -80,7 +80,7 @@ images:
 common:
   # Comma-separated list of blocked datasets (e.g. if not supported by the Hub). No jobs will be processed for those datasets.
   # See https://observablehq.com/@huggingface/blocked-datasets
-  blockedDatasets: "open-llm-leaderboard/*,taesiri/arxiv_qa,enzostvs/stable-diffusion-tpu-generations"
+  blockedDatasets: "open-llm-leaderboard/*,taesiri/arxiv_qa,enzostvs/stable-diffusion-tpu-generations,lunaluan/*"
   # Comma-separated list of the datasets for which we support dataset scripts.
   # Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
   # The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` refers to all the datasets without namespace.


### PR DESCRIPTION
Temporary blocking namespace lunaluan/* because of a high activity in datasets (many frequent commits): 

- lunaluan/chatbox6_history 23778 commits
- lunaluan/chatbox8_history 22964 commits
- lunaluan/chatbox4_history 79255 commits
- lunaluan/chat_history5 46412 commits
- lunaluan/chatbox3_history 76140 commits