### PR TITLE
remove read_parquet from descriptive stats

### DIFF
--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -70,7 +70,7 @@ COMPUTE_HIST_COMMAND = """
         JOIN {bins_table_name} ON ("{column_name}" >= bin_min AND "{column_name}" < bin_max) GROUP BY bin_id;
 """
 CREATE_TABLE_COMMAND = """
-CREATE OR REPLACE TABLE {table_name} AS SELECT {column_names} FROM {select_from};
+CREATE OR REPLACE TABLE {table_name} AS SELECT {column_names} FROM '{select_from}';
 """
 CREATE_TEMPORARY_TABLE_COMMAND = """
 CREATE OR REPLACE TEMPORARY TABLE {table_name} AS SELECT {column_names} FROM {select_from};
@@ -703,7 +703,7 @@ def compute_descriptive_statistics_response(
     create_table_command = CREATE_TABLE_COMMAND.format(
         table_name=DATA_TABLE_NAME,
         column_names=all_feature_names,
-        select_from=f"read_parquet('{local_parquet_glob_path}')",
+        select_from=local_parquet_glob_path,
     )
     logging.info(create_table_command)
     con.sql(create_table_command)


### PR DESCRIPTION
Related to https://github.com/huggingface/datasets-server/issues/2047
I am not sure if this will help, but I saw that many jobs got stuck in the CREATE command, `duckdb-index` worker also performs this operation, but it looks like it doesnt stuck for so long.
I want to try loading directly to parquet files instead of using `read_parquet` function.
![Screenshot from 2023-12-06 12-41-24](https://github.com/huggingface/datasets-server/assets/5564745/06c0d5b7-78a6-453a-a120-185f68038ca4)
