### PR TITLE
More rows workers

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -346,7 +346,7 @@ rows:
   uvicornNumWorkers: "2"
   nodeSelector:
     role-datasets-server-rows: "true"
-  replicas: 12
+  replicas: 16
   service:
     type: NodePort
   resources:


### PR DESCRIPTION
`/rows` workers get killed since this morning when someone started using it to scrape coyo-700m

<img width="608" alt="image" src="https://github.com/huggingface/datasets-server/assets/42851186/53d960bc-3aed-48f5-85cf-a8725916ed1e">

<img width="685" alt="image" src="https://github.com/huggingface/datasets-server/assets/42851186/99f314e9-3825-4810-8e8b-dc27ec597b94">
