### PR TITLE
logs and stop executor on failure

### DIFF
--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -1006,11 +1006,7 @@ class Queue:
         This is used to keep track of running jobs.
         If a job doesn't have recent heartbeats, it means it crashed at one point and is considered a zombie.
         """
-        try:
-            job = self.get_job_with_id(job_id)
-        except DoesNotExist:
-            logging.warning(f"Heartbeat skipped because job {job_id} doesn't exist in the queue.")
-            return
+        job = self.get_job_with_id(job_id)
         # no need to update metrics since it is just the last_heartbeat
         job.update(last_heartbeat=get_datetime())
 

--- a/services/worker/src/worker/executor.py
+++ b/services/worker/src/worker/executor.py
@@ -156,7 +156,12 @@ class WorkerExecutor:
     def heartbeat(self) -> None:
         worker_state = self.get_state()
         if worker_state and worker_state["current_job_info"]:
-            Queue().heartbeat(job_id=worker_state["current_job_info"]["job_id"])
+            job_id = worker_state["current_job_info"]["job_id"]
+            try:
+                Queue().heartbeat(job_id=job_id)
+            except Exception as error:
+                logging.warning(f"Heartbeat failed for job {job_id}.", error)
+                self.stop()
 
     def kill_zombies(self) -> None:
         queue = Queue()

--- a/services/worker/src/worker/job_manager.py
+++ b/services/worker/src/worker/job_manager.py
@@ -249,7 +249,7 @@ class JobManager:
             }
 
     def set_crashed(self, message: str, cause: Optional[BaseException] = None) -> None:
-        self.debug(
+        self.info(
             "response for"
             f" dataset={self.job_params['dataset']} revision={self.job_params['revision']} job_info={self.job_info}"
             " had an error (crashed)"
@@ -271,7 +271,7 @@ class JobManager:
         )
 
     def set_exceeded_maximum_duration(self, message: str, cause: Optional[BaseException] = None) -> None:
-        self.debug(
+        self.info(
             "response for"
             f" dataset={self.job_params['dataset']} revision={self.job_params['revision']} job_info={self.job_info}"
             " had an error (exceeded maximum duration)"


### PR DESCRIPTION
Sometimes, a long job gets finished by another worker (still investigating the cause), and heartbeat logs the issue forever.
Once the heartbeat fails for some reason, the executor should stop to avoid blocking the worker:
![image](https://github.com/huggingface/datasets-server/assets/5564745/13f39968-1043-4792-95bf-71c992cb1e22)

This scenario keeps being logged forever until the worker restarts, which is why, in each deployment, we have almost the same number of started jobs compared to the number of workers, but when getting into this case, the number of active workers reduces.
I also changed the log level to INFO when finishing a job to investigate the root cause of the message: `"WARNING: 2023-12-07 17:44:14,644 - root - Heartbeat skipped because job 657202cb9c5adfceb6840d88 doesn't exist in the queue." `

Note.- I have already seen this behavior before: https://github.com/huggingface/datasets-server/pull/2175, but I didn't realize that this was the cause of blocked workers.