### PR TITLE
feat: 🎸 block big dataset

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -80,7 +80,7 @@ images:
 common:
   # Comma-separated list of blocked datasets (e.g. if not supported by the Hub). No jobs will be processed for those datasets.
   # See https://observablehq.com/@huggingface/blocked-datasets
-  blockedDatasets: "open-llm-leaderboard/*,taesiri/arxiv_qa,enzostvs/stable-diffusion-tpu-generations,lunaluan/*,atom-in-the-universe/*"
+  blockedDatasets: "open-llm-leaderboard/*,taesiri/arxiv_qa,enzostvs/stable-diffusion-tpu-generations,lunaluan/*,atom-in-the-universe/*,Cnam-LMSSC/vibravox"
   # Comma-separated list of the datasets for which we support dataset scripts.
   # Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
   # The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` refers to all the datasets without namespace.


### PR DESCRIPTION
It generates >1K jobs with difficulty 90, which will never be processed (too few "heavy" workers). Also note that the dataset is gated with manual approval, which limits the audience of dataset viewer / parquet conversion.