### PR TITLE
try preserve_insertion_order

### DIFF
--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -183,14 +183,8 @@ def compute_index_rows(
     con = duckdb.connect(str(db_path.resolve()))
     con.sql("SET enable_progress_bar=true;")
 
-    # DuckDB uses n_threads = num kubernetes cpu (limits)
-    n_threads = con.sql("SELECT current_setting('threads')").fetchall()[0][0]
-    logging.info(f"Number of threads={n_threads}")
-
-    # However DuckDB uses max_memory = memory of the entite kubernetes node so we lower it
-    max_memory = con.sql("SELECT current_setting('max_memory');").fetchall()[0][0]
-    logging.info(f"Original {max_memory=}")
-    con.sql(f"SET max_memory TO '{28 if n_threads >= 8 else 10}gb';")
+    # try https://duckdb.org/docs/guides/performance/how-to-tune-workloads
+    con.sql(f"SET preserve_insertion_order = false;")
 
     try:
         # configure duckdb extensions

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -184,7 +184,7 @@ def compute_index_rows(
     con.sql("SET enable_progress_bar=true;")
 
     # try https://duckdb.org/docs/guides/performance/how-to-tune-workloads
-    con.sql(f"SET preserve_insertion_order = false;")
+    con.sql("SET preserve_insertion_order = false;")
 
     try:
         # configure duckdb extensions


### PR DESCRIPTION
Memory setting didn't work for big datasets. It took more time to process, rolling back and trying another configuration as recommended in https://duckdb.org/docs/guides/performance/how-to-tune-workloads#the-preserve_insertion_order-option