### PR TITLE
remove duckdb setting

### DIFF
--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -181,10 +181,6 @@ def compute_index_rows(
     # index all columns
     db_path = duckdb_index_file_directory.resolve() / index_filename
     con = duckdb.connect(str(db_path.resolve()))
-    con.sql("SET enable_progress_bar=true;")
-
-    # try https://duckdb.org/docs/guides/performance/how-to-tune-workloads
-    con.sql("SET preserve_insertion_order = false;")
 
     try:
         # configure duckdb extensions


### PR DESCRIPTION
Rollback of setting in https://github.com/huggingface/datasets-server/pull/2212. Heavy workers are taking more time when inserting.
