### PR TITLE
increase limits memory for heavy workers

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -412,7 +412,7 @@ workers:
         memory: "34Gi"
       limits:
         cpu: 8
-        memory: "34Gi"
+        memory: "44Gi"
     tolerations: []
   - deployName: "medium"
     prometheusMultiprocDirectory: "/tmp"


### PR DESCRIPTION
With 34Gi it fails because of OOMs when processing `split-duckdb-index` for some Wikipedia configs like 20231101.es and 20231101.en when creating index step.

