### PR TITLE
chore: 🤖 use the same packages in all the docker imges

### DIFF
--- a/jobs/cache_maintenance/Dockerfile
+++ b/jobs/cache_maintenance/Dockerfile
@@ -16,7 +16,9 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # System deps:
 RUN apt-get update \
-    && apt-get install -y build-essential python3-dev make \
+    && apt-get install -y build-essential unzip wget make \
+    libicu-dev ffmpeg libavcodec-extra libsndfile1 llvm pkg-config \
+    poppler-utils procps htop \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install -U pip
 RUN pip install "poetry==$POETRY_VERSION"

--- a/jobs/mongodb_migration/Dockerfile
+++ b/jobs/mongodb_migration/Dockerfile
@@ -16,7 +16,9 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # System deps:
 RUN apt-get update \
-    && apt-get install -y build-essential make \
+    && apt-get install -y build-essential unzip wget make \
+    libicu-dev ffmpeg libavcodec-extra libsndfile1 llvm pkg-config \
+    poppler-utils procps htop \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install -U pip
 RUN pip install "poetry==$POETRY_VERSION"

--- a/services/admin/Dockerfile
+++ b/services/admin/Dockerfile
@@ -16,8 +16,9 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # System deps:
 RUN apt-get update \
-    && apt-get install -y build-essential make \
-    procps htop \
+    && apt-get install -y build-essential unzip wget make \
+    libicu-dev ffmpeg libavcodec-extra libsndfile1 llvm pkg-config \
+    poppler-utils procps htop \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install -U pip
 RUN pip install "poetry==$POETRY_VERSION"

--- a/services/admin/dev.Dockerfile
+++ b/services/admin/dev.Dockerfile
@@ -16,9 +16,9 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # System deps:
 RUN apt-get update \
-    && apt-get install -y build-essential unzip wget \
+    && apt-get install -y build-essential unzip wget make \
     libicu-dev ffmpeg libavcodec-extra libsndfile1 llvm pkg-config \
-    procps htop \
+    poppler-utils procps htop \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install -U pip
 RUN pip install "poetry==$POETRY_VERSION"

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -16,9 +16,9 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # System deps:
 RUN apt-get update \
-    && apt-get install -y build-essential unzip wget \
+    && apt-get install -y build-essential unzip wget make \
     libicu-dev ffmpeg libavcodec-extra libsndfile1 llvm pkg-config \
-    procps htop \
+    poppler-utils procps htop \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install -U pip
 RUN pip install "poetry==$POETRY_VERSION"

--- a/services/api/dev.Dockerfile
+++ b/services/api/dev.Dockerfile
@@ -16,9 +16,9 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # System deps:
 RUN apt-get update \
-    && apt-get install -y build-essential unzip wget \
+    && apt-get install -y build-essential unzip wget make \
     libicu-dev ffmpeg libavcodec-extra libsndfile1 llvm pkg-config \
-    procps htop \
+    poppler-utils procps htop \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install -U pip
 RUN pip install "poetry==$POETRY_VERSION"

--- a/services/rows/Dockerfile
+++ b/services/rows/Dockerfile
@@ -16,9 +16,9 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # System deps:
 RUN apt-get update \
-    && apt-get install -y build-essential unzip wget \
+    && apt-get install -y build-essential unzip wget make \
     libicu-dev ffmpeg libavcodec-extra libsndfile1 llvm pkg-config \
-    procps htop \
+    poppler-utils procps htop \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install -U pip
 RUN pip install "poetry==$POETRY_VERSION"

--- a/services/rows/dev.Dockerfile
+++ b/services/rows/dev.Dockerfile
@@ -16,9 +16,9 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # System deps:
 RUN apt-get update \
-    && apt-get install -y build-essential unzip wget \
+    && apt-get install -y build-essential unzip wget make \
     libicu-dev ffmpeg libavcodec-extra libsndfile1 llvm pkg-config \
-    procps htop \
+    poppler-utils procps htop \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install -U pip
 RUN pip install "poetry==$POETRY_VERSION"

--- a/services/search/Dockerfile
+++ b/services/search/Dockerfile
@@ -16,9 +16,9 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # System deps:
 RUN apt-get update \
-    && apt-get install -y build-essential unzip wget \
+    && apt-get install -y build-essential unzip wget make \
     libicu-dev ffmpeg libavcodec-extra libsndfile1 llvm pkg-config \
-    procps htop \
+    poppler-utils procps htop \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install -U pip
 RUN pip install "poetry==$POETRY_VERSION"

--- a/services/search/dev.Dockerfile
+++ b/services/search/dev.Dockerfile
@@ -16,9 +16,9 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # System deps:
 RUN apt-get update \
-    && apt-get install -y build-essential unzip wget \
+    && apt-get install -y build-essential unzip wget make \
     libicu-dev ffmpeg libavcodec-extra libsndfile1 llvm pkg-config \
-    procps htop \
+    poppler-utils procps htop \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install -U pip
 RUN pip install "poetry==$POETRY_VERSION"

--- a/services/sse-api/Dockerfile
+++ b/services/sse-api/Dockerfile
@@ -16,8 +16,9 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # System deps:
 RUN apt-get update \
-    && apt-get install -y build-essential unzip wget \
+    && apt-get install -y build-essential unzip wget make \
     libicu-dev ffmpeg libavcodec-extra libsndfile1 llvm pkg-config \
+    poppler-utils procps htop \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install -U pip
 RUN pip install "poetry==$POETRY_VERSION"

--- a/services/sse-api/dev.Dockerfile
+++ b/services/sse-api/dev.Dockerfile
@@ -16,8 +16,9 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # System deps:
 RUN apt-get update \
-    && apt-get install -y build-essential unzip wget \
+    && apt-get install -y build-essential unzip wget make \
     libicu-dev ffmpeg libavcodec-extra libsndfile1 llvm pkg-config \
+    poppler-utils procps htop \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install -U pip
 RUN pip install "poetry==$POETRY_VERSION"

--- a/services/worker/dev.Dockerfile
+++ b/services/worker/dev.Dockerfile
@@ -18,7 +18,7 @@ ENV PYTHONFAULTHANDLER=1 \
 RUN apt-get update \
     && apt-get install -y build-essential unzip wget make \
     libicu-dev ffmpeg libavcodec-extra libsndfile1 llvm pkg-config \
-    poppler-utils procps htop\
+    poppler-utils procps htop \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install -U pip


### PR DESCRIPTION
we could surely build a base image, if somebody wants to do it...

it should fix the following error message we see in the admin service logs:

```
/src/services/admin/.venv/lib/python3.9/site-packages/pydub/utils.py:170: RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work 
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
```