### PR TITLE
return a specific error message when dataset is not supported

### DIFF
--- a/e2e/tests/test_11_api.py
+++ b/e2e/tests/test_11_api.py
@@ -231,7 +231,7 @@ def test_normal_user_blocked(csv_path: str) -> None:
         # ^ should be caught by COMMON_BLOCKED_DATASETS := "__DUMMY_DATASETS_SERVER_USER__/blocked-*"
     ) as dataset:
         poll_parquet_until_ready_and_assert(
-            dataset=dataset, expected_status_code=404, expected_error_code="ResponseNotFound"
+            dataset=dataset, expected_status_code=501, expected_error_code="DatasetInBlockListError"
         )
 
 

--- a/e2e/tests/test_11_api.py
+++ b/e2e/tests/test_11_api.py
@@ -222,7 +222,21 @@ def test_pro_user_private_gated(csv_path: str) -> None:
         )
 
 
-def test_normal_user_blocked(csv_path: str) -> None:
+def test_normal_user_blocked_private(csv_path: str) -> None:
+    with tmp_dataset(
+        namespace=NORMAL_USER,
+        token=NORMAL_USER_TOKEN,
+        files={"data.csv": csv_path},
+        dataset_prefix="blocked-",
+        # ^ should be caught by COMMON_BLOCKED_DATASETS := "__DUMMY_DATASETS_SERVER_USER__/blocked-*"
+        private=True,
+    ) as dataset:
+        poll_parquet_until_ready_and_assert(
+            dataset=dataset, expected_status_code=404, expected_error_code="ResponseNotFound"
+        )
+
+
+def test_normal_user_blocked_public(csv_path: str) -> None:
     with tmp_dataset(
         namespace=NORMAL_USER,
         token=NORMAL_USER_TOKEN,

--- a/e2e/tests/test_11_api.py
+++ b/e2e/tests/test_11_api.py
@@ -120,8 +120,8 @@ def normal_user_private_dataset(csv_path: str) -> Iterator[str]:
     "auth_type,expected_status_code,expected_error_code",
     [
         (None, 401, "ExternalUnauthenticatedError"),
-        ("token", 404, "ResponseNotFound"),
-        ("cookie", 404, "ResponseNotFound"),
+        ("token", 501, "NotSupportedPrivateRepositoryError"),
+        ("cookie", 501, "NotSupportedPrivateRepositoryError"),
     ],
 )
 def test_auth_private(
@@ -145,8 +145,8 @@ def test_normal_org_private(csv_path: str) -> None:
         poll_parquet_until_ready_and_assert(
             dataset=dataset,
             headers=get_auth_headers("token"),
-            expected_status_code=404,
-            expected_error_code="ResponseNotFound",
+            expected_status_code=501,
+            expected_error_code="NotSupportedPrivateRepositoryError",
         )
 
 
@@ -157,8 +157,8 @@ def test_pro_user_private(csv_path: str) -> None:
         poll_parquet_until_ready_and_assert(
             dataset=dataset,
             headers={"Authorization": f"Bearer {PRO_USER_TOKEN}"},
-            expected_status_code=404,
-            expected_error_code="ResponseNotFound",
+            expected_status_code=501,
+            expected_error_code="NotSupportedPrivateRepositoryError",
         )
 
 
@@ -172,8 +172,8 @@ def test_enterprise_user_private(csv_path: str) -> None:
         poll_parquet_until_ready_and_assert(
             dataset=dataset,
             headers={"Authorization": f"Bearer {ENTERPRISE_USER_TOKEN}"},
-            expected_status_code=404,
-            expected_error_code="ResponseNotFound",
+            expected_status_code=501,
+            expected_error_code="NotSupportedPrivateRepositoryError",
         )
 
 
@@ -187,8 +187,8 @@ def test_enterprise_org_private(csv_path: str) -> None:
         poll_parquet_until_ready_and_assert(
             dataset=dataset,
             headers={"Authorization": f"Bearer {ENTERPRISE_USER_TOKEN}"},
-            expected_status_code=404,
-            expected_error_code="ResponseNotFound",
+            expected_status_code=501,
+            expected_error_code="NotSupportedPrivateRepositoryError",
         )
 
 
@@ -202,8 +202,8 @@ def test_normal_user_private_gated(csv_path: str) -> None:
         poll_parquet_until_ready_and_assert(
             dataset=dataset,
             headers={"Authorization": f"Bearer {NORMAL_USER_TOKEN}"},
-            expected_status_code=404,
-            expected_error_code="ResponseNotFound",
+            expected_status_code=501,
+            expected_error_code="NotSupportedPrivateRepositoryError",
         )
 
 
@@ -217,8 +217,8 @@ def test_pro_user_private_gated(csv_path: str) -> None:
         poll_parquet_until_ready_and_assert(
             dataset=dataset,
             headers={"Authorization": f"Bearer {PRO_USER_TOKEN}"},
-            expected_status_code=404,
-            expected_error_code="ResponseNotFound",
+            expected_status_code=501,
+            expected_error_code="NotSupportedPrivateRepositoryError",
         )
 
 
@@ -234,8 +234,8 @@ def test_normal_user_blocked_private(csv_path: str) -> None:
         poll_parquet_until_ready_and_assert(
             dataset=dataset,
             headers=get_auth_headers("token"),
-            expected_status_code=404,
-            expected_error_code="ResponseNotFound",
+            expected_status_code=501,
+            expected_error_code="NotSupportedPrivateRepositoryError",
         )
 
 
@@ -275,7 +275,7 @@ def test_normal_user_disabled_viewer(csv_path: str, disabled_viewer_readme_path:
         files={"data.csv": csv_path, "README.md": disabled_viewer_readme_path},
     ) as dataset:
         poll_parquet_until_ready_and_assert(
-            dataset=dataset, expected_status_code=404, expected_error_code="ResponseNotFound"
+            dataset=dataset, expected_status_code=501, expected_error_code="NotSupportedDisabledViewerError"
         )
 
 

--- a/e2e/tests/test_11_api.py
+++ b/e2e/tests/test_11_api.py
@@ -229,10 +229,13 @@ def test_normal_user_blocked_private(csv_path: str) -> None:
         files={"data.csv": csv_path},
         dataset_prefix="blocked-",
         # ^ should be caught by COMMON_BLOCKED_DATASETS := "__DUMMY_DATASETS_SERVER_USER__/blocked-*"
-        private=True,
+        repo_settings={"private": True},
     ) as dataset:
         poll_parquet_until_ready_and_assert(
-            dataset=dataset, expected_status_code=404, expected_error_code="ResponseNotFound"
+            dataset=dataset,
+            headers=get_auth_headers("token"),
+            expected_status_code=404,
+            expected_error_code="ResponseNotFound",
         )
 
 

--- a/jobs/cache_maintenance/src/cache_maintenance/backfill.py
+++ b/jobs/cache_maintenance/src/cache_maintenance/backfill.py
@@ -4,7 +4,7 @@
 import logging
 from typing import Optional
 
-from libcommon.exceptions import DatasetNotFoundError
+from libcommon.exceptions import NotSupportedError
 from libcommon.operations import update_dataset
 from libcommon.simple_cache import get_all_datasets
 from libcommon.storage_client import StorageClient
@@ -50,7 +50,7 @@ def backfill_cache(
                 storage_clients=storage_clients,
             )
             supported_datasets += 1
-        except DatasetNotFoundError:
+        except NotSupportedError:
             deleted_datasets += 1
         except Exception as e:
             logging.warning(f"failed to update_dataset {dataset}: {e}")

--- a/libs/libapi/src/libapi/utils.py
+++ b/libs/libapi/src/libapi/utils.py
@@ -132,7 +132,7 @@ def try_backfill_dataset_then_raise(
         priority=Priority.NORMAL,
         storage_clients=storage_clients,
     )
-    # ^ raises with NotSupportedError if the dataset is not supported
+    # ^ raises with NotSupportedError if the dataset is not supported - in which case it's deleted from the cache
     logging.debug("The dataset is supported and it's being backfilled")
     raise ResponseNotReadyError(
         "The server is busier than usual and the response is not ready yet. Please retry later."

--- a/libs/libapi/src/libapi/utils.py
+++ b/libs/libapi/src/libapi/utils.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 
 import pyarrow as pa
 from datasets import Features
-from libcommon.exceptions import CustomError
+from libcommon.exceptions import CustomError, DatasetNotFoundError
 from libcommon.operations import update_dataset
 from libcommon.orchestrator import has_pending_ancestor_jobs
 from libcommon.public_assets_storage import PublicAssetsStorage
@@ -122,22 +122,25 @@ def try_backfill_dataset_then_raise(
         )
         raise ResponseNotFoundError("Not found.")
     logging.debug("No cache entry found")
-    if update_dataset(
-        dataset=dataset,
-        cache_max_days=cache_max_days,
-        blocked_datasets=blocked_datasets,
-        hf_endpoint=hf_endpoint,
-        hf_token=hf_token,
-        hf_timeout_seconds=hf_timeout_seconds,
-        priority=Priority.NORMAL,
-        storage_clients=storage_clients,
-    ):
+    try:
+        update_dataset(
+            dataset=dataset,
+            cache_max_days=cache_max_days,
+            blocked_datasets=blocked_datasets,
+            hf_endpoint=hf_endpoint,
+            hf_token=hf_token,
+            hf_timeout_seconds=hf_timeout_seconds,
+            priority=Priority.NORMAL,
+            storage_clients=storage_clients,
+            let_raise_if_blocked=True,
+        )
         logging.debug("The dataset is supported and it's being backfilled")
         raise ResponseNotReadyError(
             "The server is busier than usual and the response is not ready yet. Please retry later."
         )
-    logging.debug("The dataset is not supported")
-    raise ResponseNotFoundError("Not found.")
+    except DatasetNotFoundError:
+        logging.debug("The dataset is not supported")
+        raise ResponseNotFoundError("Not found.")
 
 
 def get_cache_entry_from_steps(

--- a/libs/libcommon/src/libcommon/exceptions.py
+++ b/libs/libcommon/src/libcommon/exceptions.py
@@ -102,6 +102,9 @@ CacheableErrorCode = Literal[
     "LockedDatasetTimeoutError",
     "MissingSpawningTokenError",
     "NoSupportedFeaturesError",
+    "NotSupportedDisabledRepositoryError",
+    "NotSupportedDisabledViewerError",
+    "NotSupportedPrivateRepositoryError",
     "NormalRowsError",
     "ParameterMissingError",
     "ParquetResponseEmptyError",
@@ -171,13 +174,6 @@ class CreateCommitError(CacheableError):
 
     def __init__(self, message: str, cause: Optional[BaseException] = None):
         super().__init__(message, HTTPStatus.INTERNAL_SERVER_ERROR, "CreateCommitError", cause, False)
-
-
-class DatasetInBlockListError(CacheableError):
-    """The dataset is in the list of blocked datasets."""
-
-    def __init__(self, message: str, cause: Optional[BaseException] = None):
-        super().__init__(message, HTTPStatus.NOT_IMPLEMENTED, "DatasetInBlockListError", cause, False)
 
 
 class DatasetManualDownloadError(CacheableError):
@@ -533,3 +529,35 @@ class DatasetWithScriptNotSupportedError(CacheableError):
 
     def __init__(self, message: str, cause: Optional[BaseException] = None):
         super().__init__(message, HTTPStatus.NOT_IMPLEMENTED, "DatasetWithScriptNotSupportedError", cause, True)
+
+
+class NotSupportedError(CacheableError):
+    pass
+
+
+class NotSupportedDisabledRepositoryError(NotSupportedError):
+    """The repository is disabled."""
+
+    def __init__(self, message: str, cause: Optional[BaseException] = None):
+        super().__init__(message, HTTPStatus.NOT_IMPLEMENTED, "NotSupportedDisabledRepositoryError", cause, False)
+
+
+class NotSupportedDisabledViewerError(NotSupportedError):
+    """The dataset viewer is disabled in the dataset configuration."""
+
+    def __init__(self, message: str, cause: Optional[BaseException] = None):
+        super().__init__(message, HTTPStatus.NOT_IMPLEMENTED, "NotSupportedDisabledViewerError", cause, False)
+
+
+class NotSupportedPrivateRepositoryError(NotSupportedError):
+    """The repository is private."""
+
+    def __init__(self, message: str, cause: Optional[BaseException] = None):
+        super().__init__(message, HTTPStatus.NOT_IMPLEMENTED, "NotSupportedPrivateRepositoryError", cause, False)
+
+
+class DatasetInBlockListError(NotSupportedError):
+    """The dataset is in the list of blocked datasets."""
+
+    def __init__(self, message: str, cause: Optional[BaseException] = None):
+        super().__init__(message, HTTPStatus.NOT_IMPLEMENTED, "DatasetInBlockListError", cause, False)

--- a/libs/libcommon/src/libcommon/operations.py
+++ b/libs/libcommon/src/libcommon/operations.py
@@ -2,86 +2,40 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
-from dataclasses import dataclass
 from typing import Optional
 
-from huggingface_hub.hf_api import DatasetInfo, HfApi
+from huggingface_hub.hf_api import HfApi
 
-from libcommon.exceptions import DatasetInBlockListError
+from libcommon.exceptions import DatasetInBlockListError, DatasetNotFoundError
 from libcommon.orchestrator import remove_dataset, set_revision
 from libcommon.storage_client import StorageClient
-from libcommon.utils import Priority, SupportStatus, raise_if_blocked
+from libcommon.utils import Priority, raise_if_blocked
 
 
-@dataclass
-class DatasetStatus:
-    dataset: str
-    revision: str
-    support_status: SupportStatus
+class NotSupportedError(Exception):
+    pass
 
 
-def is_blocked(
-    dataset: str,
-    blocked_datasets: Optional[list[str]] = None,
-) -> bool:
-    if not blocked_datasets:
-        logging.debug("No datasets block list.")
-        return False
-    try:
-        raise_if_blocked(dataset, blocked_datasets)
-        logging.debug(f"Dataset is not blocked. Block list is: {blocked_datasets}, dataset is: {dataset}")
-        return False
-    except DatasetInBlockListError:
-        logging.debug(f"Dataset is blocked. Block list is: {blocked_datasets}, dataset is: {dataset}")
-        return True
-
-
-def get_support_status(
-    dataset_info: DatasetInfo,
-    blocked_datasets: Optional[list[str]] = None,
-) -> SupportStatus:
-    """
-      blocked_datasets (list[str]): The list of blocked datasets. Supports Unix shell-style wildcards in the dataset
-    name, e.g. "open-llm-leaderboard/*" to block all the datasets in the `open-llm-leaderboard` namespace. They
-    are not allowed in the namespace name.
-    """
-    return (
-        SupportStatus.UNSUPPORTED
-        if (
-            is_blocked(dataset_info.id, blocked_datasets)
-            # ^ TODO: should we check here?
-            # As we don't keep the track of unsupported datasets,
-            # we lose the ability to send a meaningful error message to the user, as previously done:
-            #   "This dataset has been disabled for now. Please open an issue in"
-            #   " https://github.com/huggingface/datasets-server if you want this dataset to be supported."
-            # A solution is to double-check if the dataset is blocked in the API routes.
-            or dataset_info.disabled
-            or (dataset_info.cardData and not dataset_info.cardData.get("viewer", True))
-            or dataset_info.private
-        )
-        else SupportStatus.PUBLIC
-    )
-
-
-def get_dataset_status(
+def get_dataset_revision_if_supported_or_raise(
     dataset: str,
     hf_endpoint: str,
     hf_token: Optional[str] = None,
     hf_timeout_seconds: Optional[float] = None,
-    blocked_datasets: Optional[list[str]] = None,
-) -> DatasetStatus:
+) -> str:
     # let's the exceptions bubble up if any
     dataset_info = HfApi(endpoint=hf_endpoint).dataset_info(
         repo_id=dataset, token=hf_token, timeout=hf_timeout_seconds, files_metadata=False
     )
     revision = dataset_info.sha
     if not revision:
-        raise ValueError(f"Cannot get the git revision of dataset {dataset}. Let's do nothing.")
-    support_status = get_support_status(
-        dataset_info=dataset_info,
-        blocked_datasets=blocked_datasets,
-    )
-    return DatasetStatus(dataset=dataset, revision=revision, support_status=support_status)
+        raise NotSupportedError(f"Cannot get the git revision of dataset {dataset}. Let's do nothing.")
+    if (
+        dataset_info.disabled
+        or (dataset_info.cardData and not dataset_info.cardData.get("viewer", True))
+        or dataset_info.private
+    ):
+        raise NotSupportedError(f"Dataset {dataset} is not supported. Let's do nothing.")
+    return str(revision)
 
 
 def delete_dataset(dataset: str, storage_clients: Optional[list[StorageClient]] = None) -> None:
@@ -107,24 +61,34 @@ def update_dataset(
     priority: Priority = Priority.LOW,
     error_codes_to_retry: Optional[list[str]] = None,
     storage_clients: Optional[list[StorageClient]] = None,
-) -> bool:
+    let_raise_if_blocked: Optional[bool] = False,
+) -> None:
+    """
+      blocked_datasets (list[str]): The list of blocked datasets. Supports Unix shell-style wildcards in the dataset
+    name, e.g. "open-llm-leaderboard/*" to block all the datasets in the `open-llm-leaderboard` namespace. They
+    are not allowed in the namespace name.
+    """
     # let's the exceptions bubble up if any
-    dataset_status = get_dataset_status(
-        dataset=dataset,
-        hf_endpoint=hf_endpoint,
-        hf_token=hf_token,
-        hf_timeout_seconds=hf_timeout_seconds,
-        blocked_datasets=blocked_datasets,
-    )
-    if dataset_status.support_status == SupportStatus.UNSUPPORTED:
+    try:
+        revision = get_dataset_revision_if_supported_or_raise(
+            dataset=dataset,
+            hf_endpoint=hf_endpoint,
+            hf_token=hf_token,
+            hf_timeout_seconds=hf_timeout_seconds,
+        )
+        # we check if the dataset is blocked at last, to avoid disclosing the existence of a private dataset, if any is blocked
+        if blocked_datasets:
+            raise_if_blocked(dataset, blocked_datasets)
+    except (NotSupportedError, DatasetInBlockListError) as e:
         logging.warning(f"Dataset {dataset} is not supported. Let's delete the dataset.")
         delete_dataset(dataset=dataset, storage_clients=storage_clients)
-        return False
+        if isinstance(e, DatasetInBlockListError) and let_raise_if_blocked:
+            raise
+        raise DatasetNotFoundError(f"Dataset {dataset} does not exist or is not supported.")
     set_revision(
         dataset=dataset,
-        revision=dataset_status.revision,
+        revision=revision,
         priority=priority,
         error_codes_to_retry=error_codes_to_retry,
         cache_max_days=cache_max_days,
     )
-    return True

--- a/libs/libcommon/src/libcommon/operations.py
+++ b/libs/libcommon/src/libcommon/operations.py
@@ -4,16 +4,29 @@
 import logging
 from typing import Optional
 
-from huggingface_hub.hf_api import HfApi
+from huggingface_hub.hf_api import DatasetInfo, HfApi
 
-from libcommon.exceptions import DatasetInBlockListError, DatasetNotFoundError
+from libcommon.exceptions import (
+    NotSupportedDisabledRepositoryError,
+    NotSupportedDisabledViewerError,
+    NotSupportedError,
+    NotSupportedPrivateRepositoryError,
+)
 from libcommon.orchestrator import remove_dataset, set_revision
 from libcommon.storage_client import StorageClient
 from libcommon.utils import Priority, raise_if_blocked
 
 
-class NotSupportedError(Exception):
-    pass
+def get_dataset_info(
+    dataset: str,
+    hf_endpoint: str,
+    hf_token: Optional[str] = None,
+    hf_timeout_seconds: Optional[float] = None,
+) -> DatasetInfo:
+    # let's the exceptions bubble up if any
+    return HfApi(endpoint=hf_endpoint).dataset_info(
+        repo_id=dataset, token=hf_token, timeout=hf_timeout_seconds, files_metadata=False
+    )
 
 
 def get_dataset_revision_if_supported_or_raise(
@@ -21,20 +34,22 @@ def get_dataset_revision_if_supported_or_raise(
     hf_endpoint: str,
     hf_token: Optional[str] = None,
     hf_timeout_seconds: Optional[float] = None,
+    blocked_datasets: Optional[list[str]] = None,
 ) -> str:
-    # let's the exceptions bubble up if any
-    dataset_info = HfApi(endpoint=hf_endpoint).dataset_info(
-        repo_id=dataset, token=hf_token, timeout=hf_timeout_seconds, files_metadata=False
+    dataset_info = get_dataset_info(
+        dataset=dataset, hf_endpoint=hf_endpoint, hf_token=hf_token, hf_timeout_seconds=hf_timeout_seconds
     )
     revision = dataset_info.sha
     if not revision:
-        raise NotSupportedError(f"Cannot get the git revision of dataset {dataset}. Let's do nothing.")
-    if (
-        dataset_info.disabled
-        or (dataset_info.cardData and not dataset_info.cardData.get("viewer", True))
-        or dataset_info.private
-    ):
-        raise NotSupportedError(f"Dataset {dataset} is not supported. Let's do nothing.")
+        raise ValueError(f"Cannot get the git revision of dataset {dataset}.")
+    if dataset_info.disabled:
+        raise NotSupportedDisabledRepositoryError(f"Not supported: dataset repository {dataset} is disabled.")
+    if dataset_info.private:
+        raise NotSupportedPrivateRepositoryError(f"Not supported: dataset repository {dataset} is private.")
+    if dataset_info.cardData and not dataset_info.cardData.get("viewer", True):
+        raise NotSupportedDisabledViewerError(f"Not supported: dataset viewer is disabled in {dataset} configuration.")
+    if blocked_datasets:
+        raise_if_blocked(dataset=dataset, blocked_datasets=blocked_datasets)
     return str(revision)
 
 
@@ -61,7 +76,6 @@ def update_dataset(
     priority: Priority = Priority.LOW,
     error_codes_to_retry: Optional[list[str]] = None,
     storage_clients: Optional[list[StorageClient]] = None,
-    let_raise_if_blocked: Optional[bool] = False,
 ) -> None:
     """
       blocked_datasets (list[str]): The list of blocked datasets. Supports Unix shell-style wildcards in the dataset
@@ -75,16 +89,12 @@ def update_dataset(
             hf_endpoint=hf_endpoint,
             hf_token=hf_token,
             hf_timeout_seconds=hf_timeout_seconds,
+            blocked_datasets=blocked_datasets,
         )
-        # we check if the dataset is blocked at last, to avoid disclosing the existence of a private dataset, if any is blocked
-        if blocked_datasets:
-            raise_if_blocked(dataset, blocked_datasets)
-    except (NotSupportedError, DatasetInBlockListError) as e:
+    except NotSupportedError:
         logging.warning(f"Dataset {dataset} is not supported. Let's delete the dataset.")
         delete_dataset(dataset=dataset, storage_clients=storage_clients)
-        if isinstance(e, DatasetInBlockListError) and let_raise_if_blocked:
-            raise
-        raise DatasetNotFoundError(f"Dataset {dataset} does not exist or is not supported.")
+        raise
     set_revision(
         dataset=dataset,
         revision=revision,

--- a/libs/libcommon/src/libcommon/utils.py
+++ b/libs/libcommon/src/libcommon/utils.py
@@ -16,11 +16,6 @@ import pandas as pd
 from libcommon.exceptions import DatasetInBlockListError
 
 
-class SupportStatus(str, enum.Enum):
-    PUBLIC = "public"
-    UNSUPPORTED = "unsupported"
-
-
 class Status(str, enum.Enum):
     WAITING = "waiting"
     STARTED = "started"

--- a/services/admin/Makefile
+++ b/services/admin/Makefile
@@ -23,6 +23,7 @@ watch:
 # we cannot set the env var with pytest.MonkeyPatch, it's too late
 .PHONY: test
 test:
+	$(MAKE) down
 	$(MAKE) up
 	poetry run python -m pytest -vv -x ${ADDOPTS} $(TEST_PATH)
 	rm -rf /tmp/admin.prometheus
@@ -33,6 +34,7 @@ test:
 
 .PHONY: coverage
 coverage:
+	$(MAKE) down
 	$(MAKE) up
 	poetry run python -m pytest -s --cov --cov-report xml:coverage.xml --cov-report=term $(TEST_PATH)
 	$(MAKE) down

--- a/services/admin/src/admin/routes/force_refresh.py
+++ b/services/admin/src/admin/routes/force_refresh.py
@@ -22,7 +22,7 @@ from libcommon.operations import get_dataset_revision_if_supported_or_raise
 from libcommon.orchestrator import get_num_bytes_from_config_infos
 from libcommon.processing_graph import InputType
 from libcommon.queue import Queue
-from libcommon.utils import Priority, raise_if_blocked
+from libcommon.utils import Priority
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -83,9 +83,8 @@ def create_force_refresh_endpoint(
                 hf_endpoint=hf_endpoint,
                 hf_token=hf_token,
                 hf_timeout_seconds=hf_timeout_seconds,
+                blocked_datasets=blocked_datasets,
             )
-            if blocked_datasets:
-                raise_if_blocked(dataset, blocked_datasets)
             Queue().add_job(
                 job_type=job_type,
                 difficulty=total_difficulty,

--- a/services/admin/tests/routes/test_recreate_dataset.py
+++ b/services/admin/tests/routes/test_recreate_dataset.py
@@ -7,11 +7,10 @@ from http import HTTPStatus
 from pathlib import Path
 from unittest.mock import patch
 
-from libcommon.operations import DatasetStatus
 from libcommon.queue import Queue
 from libcommon.simple_cache import has_some_cache, upsert_response
 from libcommon.storage_client import StorageClient
-from libcommon.utils import Priority, Status, SupportStatus
+from libcommon.utils import Priority, Status
 
 from admin.routes.recreate_dataset import recreate_dataset
 
@@ -64,10 +63,7 @@ def test_recreate_dataset(tmp_path: Path) -> None:
 
     assert has_some_cache(dataset=dataset)
 
-    with patch(
-        "admin.routes.recreate_dataset.update_dataset",
-        return_value=DatasetStatus(dataset=dataset, revision=REVISION_NAME, support_status=SupportStatus.PUBLIC),
-    ):
+    with patch("admin.routes.recreate_dataset.update_dataset", return_value=None):
         recreate_dataset_report = recreate_dataset(
             hf_endpoint="hf_endpoint",
             hf_token="hf_token",

--- a/services/api/Makefile
+++ b/services/api/Makefile
@@ -22,6 +22,7 @@ watch:
 # we cannot set the env var with pytest.MonkeyPatch, it's too late
 .PHONY: test
 test:
+	$(MAKE) down
 	$(MAKE) up
 	poetry run python -m pytest -vv -x ${ADDOPTS} $(TEST_PATH)
 	rm -rf /tmp/api.prometheus
@@ -32,6 +33,7 @@ test:
 
 .PHONY: coverage
 coverage:
+	$(MAKE) down
 	$(MAKE) up
 	poetry run python -m pytest -s --cov --cov-report xml:coverage.xml --cov-report=term $(TEST_PATH)
 	$(MAKE) down

--- a/services/api/src/api/routes/endpoint.py
+++ b/services/api/src/api/routes/endpoint.py
@@ -21,6 +21,7 @@ from libapi.utils import (
     get_json_error_response,
     get_json_ok_response,
 )
+from libcommon.exceptions import NotSupportedError
 from libcommon.processing_graph import InputType, ProcessingGraph, ProcessingStep
 from libcommon.prometheus import StepProfiler
 from libcommon.storage_client import StorageClient
@@ -177,7 +178,9 @@ def create_endpoint(
                         revision=revision,
                     )
             except Exception as e:
-                error = e if isinstance(e, ApiError) else UnexpectedApiError("Unexpected error.", e)
+                error = (
+                    e if isinstance(e, (ApiError, NotSupportedError)) else UnexpectedApiError("Unexpected error.", e)
+                )
                 with StepProfiler(
                     method="processing_step_endpoint", step="generate API error response", context=context
                 ):

--- a/services/rows/Makefile
+++ b/services/rows/Makefile
@@ -22,6 +22,7 @@ watch:
 # we cannot set the env var with pytest.MonkeyPatch, it's too late
 .PHONY: test
 test:
+	$(MAKE) down
 	$(MAKE) up
 	poetry run python -m pytest -vv -x ${ADDOPTS} $(TEST_PATH)
 	rm -rf /tmp/rows.prometheus
@@ -32,6 +33,7 @@ test:
 
 .PHONY: coverage
 coverage:
+	$(MAKE) down
 	$(MAKE) up
 	poetry run python -m pytest -s --cov --cov-report xml:coverage.xml --cov-report=term $(TEST_PATH)
 	$(MAKE) down

--- a/services/search/Makefile
+++ b/services/search/Makefile
@@ -22,6 +22,7 @@ watch:
 # we cannot set the env var with pytest.MonkeyPatch, it's too late
 .PHONY: test
 test:
+	$(MAKE) down
 	$(MAKE) up
 	poetry run python -m pytest -vv -x ${ADDOPTS} $(TEST_PATH)
 	rm -rf /tmp/search.prometheus
@@ -32,6 +33,7 @@ test:
 
 .PHONY: coverage
 coverage:
+	$(MAKE) down
 	$(MAKE) up
 	poetry run python -m pytest -s --cov --cov-report xml:coverage.xml --cov-report=term $(TEST_PATH)
 	$(MAKE) down


### PR DESCRIPTION
See https://github.com/huggingface/datasets-server/pull/2244#discussion_r1445259783

Instead of returning DatasetNotFound, return the reason why the dataset is not supported: disabled repo, disabled viewer, private repo, or blocked dataset. When we do the check, the user is already authenticated and authorized to access the dataset, so: it makes no sense to hide the reason as if the dataset would not exist (the initial idea was to avoid disclosing the existence of a private dataset).

Also: refactoring to "simplify": we raise if a dataset is not supported. No need for a "DatasetStatus" abstraction

Also (unrelated): delete the docker network when running make test, to avoid errors.

