### PR TITLE
hardcode the error codes to retry

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -182,7 +182,6 @@ backfill:
   log:
     level: "debug"
   action: "backfill"
-  errorCodesToRetry: "CreateCommitError,LockedDatasetTimeoutError,ExternalServerError,JobManagerCrashedError"
   schedule: "20 21 * * *"
   # every four hours
   nodeSelector:

--- a/chart/templates/cron-jobs/backfill/_container.tpl
+++ b/chart/templates/cron-jobs/backfill/_container.tpl
@@ -17,8 +17,6 @@
     {{ include "envCachedAssets" . | nindent 2 }}
   - name: CACHE_MAINTENANCE_ACTION
     value: {{ .Values.backfill.action | quote }}
-  - name: CACHE_MAINTENANCE_BACKFILL_ERROR_CODES_TO_RETRY
-    value: {{ .Values.backfill.errorCodesToRetry | quote }}
   - name: LOG_LEVEL
     value: {{ .Values.backfill.log.level | quote }}
 {{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -314,7 +314,6 @@ backfill:
   log:
     level: "info"
   action: "backfill"
-  errorCodesToRetry: ""
   schedule: "0 */3 * * *"
   # every 3 hours
   nodeSelector: {}

--- a/jobs/cache_maintenance/README.md
+++ b/jobs/cache_maintenance/README.md
@@ -25,10 +25,6 @@ Set environment variables to configure the job (`CACHE_MAINTENANCE_` prefix):
 
 - `CACHE_MAINTENANCE_ACTION`: the action to launch, among `backfill`, `metrics`, `skip`. Defaults to `skip`.
 
-Specific to the backfill action:
-
-- `CACHE_MAINTENANCE_BACKFILL_ERROR_CODES_TO_RETRY`: the list of error codes to retry. Defaults to None.
-
 ### Common
 
 See [../../libs/libcommon/README.md](../../libs/libcommon/README.md) for more information about the common configuration.

--- a/jobs/cache_maintenance/src/cache_maintenance/backfill.py
+++ b/jobs/cache_maintenance/src/cache_maintenance/backfill.py
@@ -15,7 +15,6 @@ def backfill_cache(
     hf_endpoint: str,
     blocked_datasets: list[str],
     hf_token: Optional[str] = None,
-    error_codes_to_retry: Optional[list[str]] = None,
     storage_clients: Optional[list[StorageClient]] = None,
 ) -> None:
     logging.info("backfill datasets in the database and delete non-supported ones")
@@ -43,7 +42,6 @@ def backfill_cache(
                 blocked_datasets=blocked_datasets,
                 hf_token=hf_token,
                 priority=Priority.LOW,
-                error_codes_to_retry=error_codes_to_retry,
                 hf_timeout_seconds=None,
                 storage_clients=storage_clients,
             )

--- a/jobs/cache_maintenance/src/cache_maintenance/config.py
+++ b/jobs/cache_maintenance/src/cache_maintenance/config.py
@@ -15,22 +15,6 @@ from libcommon.config import (
     S3Config,
 )
 
-CACHE_MAINTENANCE_BACKFILL_ERROR_CODES_TO_RETRY = None
-
-
-@dataclass(frozen=True)
-class BackfillConfig:
-    error_codes_to_retry: Optional[list[str]] = CACHE_MAINTENANCE_BACKFILL_ERROR_CODES_TO_RETRY
-
-    @classmethod
-    def from_env(cls) -> "BackfillConfig":
-        env = Env(expand_vars=True)
-
-        return cls(
-            error_codes_to_retry=env.list(name="CACHE_MAINTENANCE_BACKFILL_ERROR_CODES_TO_RETRY", default=""),
-        )
-
-
 DISCUSSIONS_BOT_ASSOCIATED_USER_NAME = None
 DISCUSSIONS_BOT_TOKEN = None
 DISCUSSIONS_PARQUET_REVISION = "refs/convert/parquet"
@@ -88,7 +72,6 @@ class JobConfig:
     cache: CacheConfig = field(default_factory=CacheConfig)
     queue: QueueConfig = field(default_factory=QueueConfig)
     common: CommonConfig = field(default_factory=CommonConfig)
-    backfill: BackfillConfig = field(default_factory=BackfillConfig)
     directory_cleaning: DirectoryCleaning = field(default_factory=DirectoryCleaning)
     discussions: DiscussionsConfig = field(default_factory=DiscussionsConfig)
     action: Optional[str] = CACHE_MAINTENANCE_ACTION
@@ -105,7 +88,6 @@ class JobConfig:
             cache=CacheConfig.from_env(),
             queue=QueueConfig.from_env(),
             common=CommonConfig.from_env(),
-            backfill=BackfillConfig.from_env(),
             directory_cleaning=DirectoryCleaning.from_env(),
             discussions=DiscussionsConfig.from_env(),
             action=env.str(name="CACHE_MAINTENANCE_ACTION", default=CACHE_MAINTENANCE_ACTION),

--- a/jobs/cache_maintenance/src/cache_maintenance/main.py
+++ b/jobs/cache_maintenance/src/cache_maintenance/main.py
@@ -67,7 +67,6 @@ def run_job() -> None:
                 hf_endpoint=job_config.common.hf_endpoint,
                 hf_token=job_config.common.hf_token,
                 blocked_datasets=job_config.common.blocked_datasets,
-                error_codes_to_retry=job_config.backfill.error_codes_to_retry,
                 storage_clients=[cached_assets_storage_client, assets_storage_client],
             )
         elif action == "clean-directory":

--- a/libs/libcommon/src/libcommon/constants.py
+++ b/libs/libcommon/src/libcommon/constants.py
@@ -34,7 +34,13 @@ PROCESSING_STEP_CONFIG_PARQUET_AND_INFO_ROW_GROUP_SIZE_FOR_IMAGE_DATASETS = 100
 PROCESSING_STEP_CONFIG_PARQUET_AND_INFO_ROW_GROUP_SIZE_FOR_BINARY_DATASETS = 100
 PARQUET_REVISION = "refs/convert/parquet"
 
-ERROR_CODES_TO_RETRY = "CreateCommitError,LockedDatasetTimeoutError,StreamingRowsError,JobManagerCrashedError"
+ERROR_CODES_TO_RETRY = {
+    "CreateCommitError",
+    "ExternalServerError",
+    "JobManagerCrashedError",
+    "LockedDatasetTimeoutError",
+    "StreamingRowsError",
+}
 
 EXTERNAL_DATASET_SCRIPT_PATTERN = "datasets_modules/datasets"
 

--- a/libs/libcommon/src/libcommon/operations.py
+++ b/libs/libcommon/src/libcommon/operations.py
@@ -80,7 +80,6 @@ def update_dataset(
     hf_token: Optional[str] = None,
     hf_timeout_seconds: Optional[float] = None,
     priority: Priority = Priority.LOW,
-    error_codes_to_retry: Optional[list[str]] = None,
     storage_clients: Optional[list[StorageClient]] = None,
 ) -> None:
     """
@@ -105,5 +104,4 @@ def update_dataset(
         dataset=dataset,
         revision=revision,
         priority=priority,
-        error_codes_to_retry=error_codes_to_retry,
     )

--- a/libs/libcommon/tests/test_backfill.py
+++ b/libs/libcommon/tests/test_backfill.py
@@ -366,8 +366,8 @@ def test_plan_compute_all(processing_graph: ProcessingGraph, up_to_date: list[st
 )
 def test_plan_retry_error_max_failed_runs(failed_runs: int, max_failed_runs: int, should_create: bool) -> None:
     with patch("libcommon.state.MAX_FAILED_RUNS", max_failed_runs):
-        error_code = list(ERROR_CODES_TO_RETRY)[0]
         processing_graph = PROCESSING_GRAPH_GENEALOGY
+        error_code = list(ERROR_CODES_TO_RETRY)[0]
         compute_all(processing_graph=processing_graph)
 
         put_cache(

--- a/libs/libcommon/tests/test_backfill.py
+++ b/libs/libcommon/tests/test_backfill.py
@@ -365,8 +365,8 @@ def test_plan_compute_all(processing_graph: ProcessingGraph, up_to_date: list[st
     ],
 )
 def test_plan_retry_error_max_failed_runs(failed_runs: int, max_failed_runs: int, should_create: bool) -> None:
-    error_code = list(ERROR_CODES_TO_RETRY)[0]
     with patch("libcommon.state.MAX_FAILED_RUNS", max_failed_runs):
+        error_code = list(ERROR_CODES_TO_RETRY)[0]
         processing_graph = PROCESSING_GRAPH_GENEALOGY
         compute_all(processing_graph=processing_graph)
 

--- a/libs/libcommon/tests/test_backfill.py
+++ b/libs/libcommon/tests/test_backfill.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
+from libcommon.constants import ERROR_CODES_TO_RETRY
 from libcommon.processing_graph import ProcessingGraph
 from libcommon.queue import Queue
 from libcommon.resources import CacheMongoResource, QueueMongoResource
@@ -364,10 +365,8 @@ def test_plan_compute_all(processing_graph: ProcessingGraph, up_to_date: list[st
     ],
 )
 def test_plan_retry_error_max_failed_runs(failed_runs: int, max_failed_runs: int, should_create: bool) -> None:
-    error_code = "ERROR_CODE_TO_RETRY"
-    with patch("libcommon.state.MAX_FAILED_RUNS", max_failed_runs), patch(
-        "libcommon.constants.ERROR_CODES_TO_RETRY", {error_code}
-    ):
+    error_code = list(ERROR_CODES_TO_RETRY)[0]
+    with patch("libcommon.state.MAX_FAILED_RUNS", max_failed_runs):
         processing_graph = PROCESSING_GRAPH_GENEALOGY
         compute_all(processing_graph=processing_graph)
 
@@ -398,31 +397,31 @@ def test_plan_retry_error_max_failed_runs(failed_runs: int, max_failed_runs: int
 def test_plan_retry_error_and_outdated_by_parent(
     processing_graph: ProcessingGraph, up_to_date: list[str], is_outdated_by_parent: list[str]
 ) -> None:
-    error_code = "ERROR_CODE_TO_RETRY"
-    with patch("libcommon.constants.ERROR_CODES_TO_RETRY", {error_code}):
-        compute_all(processing_graph=processing_graph)
+    error_code = list(ERROR_CODES_TO_RETRY)[0]
 
-        put_cache(step=STEP_DA, dataset=DATASET_NAME, revision=REVISION_NAME, error_code=error_code)
-        # in the case of PROCESSING_GRAPH_FAN_IN_OUT: the config names do not exist anymore:
-        # the cache entries (also the jobs, if any - not here) should be deleted.
-        # they are still here, and haunting the database
-        # TODO: Not supported yet
+    compute_all(processing_graph=processing_graph)
 
-        dataset_backfill_plan = get_dataset_backfill_plan(processing_graph=processing_graph)
-        assert_dataset_backfill_plan(
-            dataset_backfill_plan=dataset_backfill_plan,
-            config_names=[],
-            cache_status={
-                "cache_has_different_git_revision": [],
-                "cache_is_outdated_by_parent": is_outdated_by_parent,
-                "cache_is_empty": [],
-                "cache_is_error_to_retry": [ARTIFACT_DA],
-                "cache_is_job_runner_obsolete": [],
-                "up_to_date": up_to_date,
-            },
-            queue_status={"in_process": []},
-            tasks=[f"CreateJobs,{len(is_outdated_by_parent) + 1}"],
-        )
+    put_cache(step=STEP_DA, dataset=DATASET_NAME, revision=REVISION_NAME, error_code=error_code)
+    # in the case of PROCESSING_GRAPH_FAN_IN_OUT: the config names do not exist anymore:
+    # the cache entries (also the jobs, if any - not here) should be deleted.
+    # they are still here, and haunting the database
+    # TODO: Not supported yet
+
+    dataset_backfill_plan = get_dataset_backfill_plan(processing_graph=processing_graph)
+    assert_dataset_backfill_plan(
+        dataset_backfill_plan=dataset_backfill_plan,
+        config_names=[],
+        cache_status={
+            "cache_has_different_git_revision": [],
+            "cache_is_outdated_by_parent": is_outdated_by_parent,
+            "cache_is_empty": [],
+            "cache_is_error_to_retry": [ARTIFACT_DA],
+            "cache_is_job_runner_obsolete": [],
+            "up_to_date": up_to_date,
+        },
+        queue_status={"in_process": []},
+        tasks=[f"CreateJobs,{len(is_outdated_by_parent) + 1}"],
+    )
 
 
 @pytest.mark.parametrize(

--- a/libs/libcommon/tests/test_orchestrator.py
+++ b/libs/libcommon/tests/test_orchestrator.py
@@ -209,7 +209,6 @@ def test_set_revision(
         dataset=DATASET_NAME,
         revision=REVISION_NAME,
         priority=Priority.NORMAL,
-        error_codes_to_retry=[],
         processing_graph=processing_graph,
     )
 
@@ -247,7 +246,6 @@ def test_set_revision_handle_existing_jobs(
         dataset=DATASET_NAME,
         revision=REVISION_NAME,
         priority=Priority.NORMAL,
-        error_codes_to_retry=[],
         processing_graph=processing_graph,
     )
 

--- a/libs/libcommon/tests/utils.py
+++ b/libs/libcommon/tests/utils.py
@@ -220,13 +220,11 @@ def get_dataset_backfill_plan(
     processing_graph: ProcessingGraph,
     dataset: str = DATASET_NAME,
     revision: str = REVISION_NAME,
-    error_codes_to_retry: Optional[list[str]] = None,
 ) -> DatasetBackfillPlan:
     return DatasetBackfillPlan(
         dataset=dataset,
         revision=revision,
         processing_graph=processing_graph,
-        error_codes_to_retry=error_codes_to_retry,
     )
 
 
@@ -341,9 +339,8 @@ def compute_all(
     processing_graph: ProcessingGraph,
     dataset: str = DATASET_NAME,
     revision: str = REVISION_NAME,
-    error_codes_to_retry: Optional[list[str]] = None,
 ) -> None:
-    dataset_backfill_plan = get_dataset_backfill_plan(processing_graph, dataset, revision, error_codes_to_retry)
+    dataset_backfill_plan = get_dataset_backfill_plan(processing_graph, dataset, revision)
     max_runs = 100
     while len(dataset_backfill_plan.tasks) > 0 and max_runs >= 0:
         if max_runs == 0:
@@ -356,7 +353,7 @@ def compute_all(
                 raise ValueError(f"Unexpected task id {task.id}: should contain a comma")
             if task_type == "CreateJobs":
                 process_all_jobs()
-        dataset_backfill_plan = get_dataset_backfill_plan(processing_graph, dataset, revision, error_codes_to_retry)
+        dataset_backfill_plan = get_dataset_backfill_plan(processing_graph, dataset, revision)
 
 
 def artifact_id_to_job_info(artifact_id: str) -> JobInfo:


### PR DESCRIPTION
There is no need to have this as an environment variable, and it clutters the code.

Note that the two lists we had (default one and backfill one) were different, by the way