### PR TITLE
Delete obsolete split duckdb files

### DIFF
--- a/services/worker/src/worker/job_runners/config/opt_in_out_urls_count.py
+++ b/services/worker/src/worker/job_runners/config/opt_in_out_urls_count.py
@@ -7,25 +7,16 @@ from http import HTTPStatus
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import (
     CacheEntryDoesNotExistError,
-    get_previous_step_or_raise,
     get_response,
 )
 
 from worker.dtos import JobResult, OptInOutUrlsCountResponse
 from worker.job_runners.config.config_job_runner import ConfigJobRunner
+from worker.utils import get_split_names
 
 
 def compute_opt_in_out_urls_scan_response(dataset: str, config: str) -> tuple[OptInOutUrlsCountResponse, float]:
     logging.info(f"get config-opt-in-out-urls-count for dataset={dataset} config={config}")
-
-    split_names_response = get_previous_step_or_raise(
-        kinds=["config-split-names-from-streaming", "config-split-names-from-info"],
-        dataset=dataset,
-        config=config,
-    )
-    content = split_names_response.response["content"]
-    if "splits" not in content:
-        raise PreviousStepFormatError("Previous step did not return the expected content: 'splits'.")
 
     urls_columns = []
     num_opt_in_urls = 0
@@ -36,8 +27,7 @@ def compute_opt_in_out_urls_scan_response(dataset: str, config: str) -> tuple[Op
     try:
         total = 0
         pending = 0
-        for split_item in content["splits"]:
-            split = split_item["split"]
+        for split in get_split_names(dataset=dataset, config=config):
             total += 1
             try:
                 response = get_response(

--- a/services/worker/src/worker/job_runners/dataset/split_names.py
+++ b/services/worker/src/worker/job_runners/dataset/split_names.py
@@ -4,6 +4,7 @@
 import logging
 from http import HTTPStatus
 
+from libcommon.constants import CONFIG_SPLIT_NAMES_KINDS
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import get_best_response, get_previous_step_or_raise
 
@@ -44,7 +45,6 @@ def compute_dataset_split_names_response(dataset: str) -> tuple[DatasetSplitName
     if any(not isinstance(config_name, str) for config_name in config_names):
         raise PreviousStepFormatError("Previous step 'dataset-config-names' did not return a list of config names.")
 
-    split_names_cache_kinds = ["config-split-names-from-info", "config-split-names-from-streaming"]
     try:
         splits: list[FullSplitItem] = []
         pending: list[FullConfigItem] = []
@@ -52,16 +52,16 @@ def compute_dataset_split_names_response(dataset: str) -> tuple[DatasetSplitName
         total = 0
         for config in config_names:
             total += 1
-            best_response = get_best_response(split_names_cache_kinds, dataset=dataset, config=config)
+            best_response = get_best_response(CONFIG_SPLIT_NAMES_KINDS, dataset=dataset, config=config)
             if best_response.response["error_code"] == "CachedResponseNotFound":
                 logging.debug(
                     "No response (successful or erroneous) found in cache for the previous steps"
-                    f" '{split_names_cache_kinds}' for this dataset."
+                    f" '{CONFIG_SPLIT_NAMES_KINDS}' for this dataset."
                 )
                 pending.append(FullConfigItem({"dataset": dataset, "config": config}))
                 continue
             if best_response.response["http_status"] != HTTPStatus.OK:
-                logging.debug(f"No successful response found in the previous steps {split_names_cache_kinds}.")
+                logging.debug(f"No successful response found in the previous steps {CONFIG_SPLIT_NAMES_KINDS}.")
                 failed.append(
                     FailedConfigItem(
                         {

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -4,6 +4,7 @@
 import copy
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Optional
 
@@ -44,6 +45,7 @@ from worker.utils import (
     HF_HUB_HTTP_ERROR_RETRY_SLEEPS,
     LOCK_GIT_BRANCH_RETRY_SLEEPS,
     create_branch,
+    get_split_names,
     hf_hub_url,
     retry,
 )
@@ -78,6 +80,29 @@ def get_indexable_columns(features: Features) -> list[str]:
         if indexable:
             indexable_columns.append(column)
     return indexable_columns
+
+
+def get_delete_operations(
+    all_repo_files: set[str], split_names: set[str], config: str, index_file_location: str
+) -> list[CommitOperationDelete]:
+    only_config_files: set[str] = {
+        file for file in all_repo_files if re.compile(f"^({re.escape(config)})/").match(file)
+    }
+    pattern_only_config_splits_files = re.compile(
+        f"^({'|'.join(re.escape(f'{config}/{split_name}') for split_name in split_names)})/"
+    )
+
+    # delete old files from non existent splits
+    files_to_ignore: set[str] = {
+        file
+        for file in only_config_files
+        # ignore existing files in all current splits
+        if pattern_only_config_splits_files.match(file)
+        # but not the old index in split
+        and file != index_file_location
+    }
+    files_to_delete = only_config_files - files_to_ignore
+    return [CommitOperationDelete(path_in_repo=file) for file in files_to_delete]
 
 
 def compute_index_rows(
@@ -225,9 +250,12 @@ def compute_index_rows(
             logging.debug(f"get dataset info for {dataset=} with {target_revision=}")
             target_dataset_info = hf_api.dataset_info(repo_id=dataset, revision=target_revision, files_metadata=False)
             all_repo_files: set[str] = {f.rfilename for f in target_dataset_info.siblings}
-            delete_operations: list[CommitOperation] = []
-            if index_file_location in all_repo_files:
-                delete_operations.append(CommitOperationDelete(path_in_repo=index_file_location))
+            delete_operations = get_delete_operations(
+                all_repo_files=all_repo_files,
+                split_names=get_split_names(dataset=dataset, config=config),
+                config=config,
+                index_file_location=index_file_location,
+            )
             logging.debug(f"delete operations for {dataset=} {delete_operations=}")
 
             # send the files to the target revision

--- a/services/worker/tests/job_runners/split/test_duckdb_index.py
+++ b/services/worker/tests/job_runners/split/test_duckdb_index.py
@@ -32,6 +32,7 @@ from worker.job_runners.split.duckdb_index import (
     CREATE_INDEX_COMMAND,
     CREATE_TABLE_COMMANDS,
     SplitDuckDbIndexJobRunner,
+    get_delete_operations,
     get_indexable_columns,
 )
 from worker.resources import LibrariesResource
@@ -396,6 +397,37 @@ def test_compute(
         con.close()
         os.remove(file_name)
     job_runner.post_compute()
+
+
+@pytest.mark.parametrize(
+    "split_names,config,deleted_files",
+    [
+        (
+            {"s1", "s2"},
+            "c1",
+            {"c1/s1/index.duckdb"},
+        ),
+        (
+            {"s1"},
+            "c2",
+            {"c2/s1/index.duckdb", "c2/s2/index.duckdb", "c2/s2/0.parquet"},
+        ),
+    ],
+)
+def test_get_delete_operations(split_names: set[str], config: str, deleted_files: set[str]) -> None:
+    all_repo_files = {
+        "c1/s1/0.parquet",
+        "c1/s1/index.duckdb",
+        "c2/s1/0.parquet",
+        "c2/s1/index.duckdb",
+        "c2/s2/0.parquet",
+        "c2/s2/index.duckdb",
+    }
+    index_file_location = f"{config}/s1/index.duckdb"
+    delete_operations = get_delete_operations(
+        all_repo_files=all_repo_files, split_names=split_names, config=config, index_file_location=index_file_location
+    )
+    assert set(delete_operation.path_in_repo for delete_operation in delete_operations) == deleted_files
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix for https://github.com/huggingface/datasets-server/issues/2053
Delete obsolete files for splits that no longer exist including `index.duckdb`