### PR TITLE
Add extract_split_name_from_parquet_url function to parquet utils

### DIFF
--- a/libs/libapi/src/libapi/duckdb.py
+++ b/libs/libapi/src/libapi/duckdb.py
@@ -12,7 +12,7 @@ import anyio
 from anyio import Path
 from huggingface_hub import hf_hub_download
 from libcommon.constants import DUCKDB_INDEX_DOWNLOADS_SUBDIRECTORY, SPLIT_DUCKDB_INDEX_KINDS
-from libcommon.parquet_utils import extract_split_name_from_url
+from libcommon.parquet_utils import extract_split_name_from_parquet_url
 from libcommon.prometheus import StepProfiler
 from libcommon.simple_cache import CacheEntry
 from libcommon.storage import StrPath, init_dir

--- a/libs/libapi/src/libapi/duckdb.py
+++ b/libs/libapi/src/libapi/duckdb.py
@@ -12,6 +12,7 @@ import anyio
 from anyio import Path
 from huggingface_hub import hf_hub_download
 from libcommon.constants import DUCKDB_INDEX_DOWNLOADS_SUBDIRECTORY, SPLIT_DUCKDB_INDEX_KINDS
+from libcommon.parquet_utils import extract_split_name_from_url
 from libcommon.prometheus import StepProfiler
 from libcommon.simple_cache import CacheEntry
 from libcommon.storage import StrPath, init_dir
@@ -39,7 +40,7 @@ async def get_index_file_location_and_download_if_missing(
         # For directories like "partial-train" for the file
         # at "en/partial-train/0000.parquet" in the C4 dataset.
         # Note that "-" is forbidden for split names, so it doesn't create directory names collisions.
-        split_directory = url.rsplit("/", 2)[1]
+        split_directory = extract_split_name_from_url(url)
         repo_file_location = f"{config}/{split_directory}/{filename}"
         index_file_location = f"{index_folder}/{repo_file_location}"
         index_path = Path(index_file_location)

--- a/libs/libapi/src/libapi/duckdb.py
+++ b/libs/libapi/src/libapi/duckdb.py
@@ -40,7 +40,7 @@ async def get_index_file_location_and_download_if_missing(
         # For directories like "partial-train" for the file
         # at "en/partial-train/0000.parquet" in the C4 dataset.
         # Note that "-" is forbidden for split names, so it doesn't create directory names collisions.
-        split_directory = extract_split_name_from_url(url)
+        split_directory = extract_split_name_from_parquet_url(url)
         repo_file_location = f"{config}/{split_directory}/{filename}"
         index_file_location = f"{index_folder}/{repo_file_location}"
         index_path = Path(index_file_location)

--- a/libs/libcommon/src/libcommon/parquet_utils.py
+++ b/libs/libcommon/src/libcommon/parquet_utils.py
@@ -78,8 +78,22 @@ def parquet_export_is_partial(parquet_file_url: str) -> bool:
         partial (bool): True is the Parquet export is partial,
             or False if it's the full dataset.
     """
-    split_directory_name_for_parquet_export = parquet_file_url.rsplit("/", 2)[1]
+    split_directory_name_for_parquet_export = extract_split_name_from_url(parquet_file_url)
     return split_directory_name_for_parquet_export.startswith(PARTIAL_PREFIX)
+
+
+def extract_split_name_from_url(url: str) -> str:
+    """
+    Extracts the split name from a dataset URL.
+
+    Args:
+        url (str): The URL to extract the split name from.
+
+    Returns:
+        str: The extracted split name.
+    """
+    split_name = url.rsplit("/", 2)[1]
+    return split_name
 
 
 @dataclass

--- a/libs/libcommon/src/libcommon/parquet_utils.py
+++ b/libs/libcommon/src/libcommon/parquet_utils.py
@@ -78,7 +78,7 @@ def parquet_export_is_partial(parquet_file_url: str) -> bool:
         partial (bool): True is the Parquet export is partial,
             or False if it's the full dataset.
     """
-    split_directory_name_for_parquet_export = extract_split_name_from_url(parquet_file_url)
+    split_directory_name_for_parquet_export = extract_split_name_from_parquet_url(parquet_file_url)
     return split_directory_name_for_parquet_export.startswith(PARTIAL_PREFIX)
 
 

--- a/libs/libcommon/src/libcommon/parquet_utils.py
+++ b/libs/libcommon/src/libcommon/parquet_utils.py
@@ -94,7 +94,7 @@ def extract_split_name_from_parquet_url(parquet_url: str) -> str:
     Returns:
         str: The extracted split name.
     """
-    split_name = url.rsplit("/", 2)[1]
+    split_name = parquet_url.rsplit("/", 2)[1]
     return split_name
 
 

--- a/libs/libcommon/src/libcommon/parquet_utils.py
+++ b/libs/libcommon/src/libcommon/parquet_utils.py
@@ -82,12 +82,14 @@ def parquet_export_is_partial(parquet_file_url: str) -> bool:
     return split_directory_name_for_parquet_export.startswith(PARTIAL_PREFIX)
 
 
-def extract_split_name_from_url(url: str) -> str:
+def extract_split_name_from_parquet_url(parquet_url: str) -> str:
     """
-    Extracts the split name from a dataset URL.
+    Extracts the split name from a parquet file URL
+    stored in the `refs/convert/parquet` branch of a
+    dataset repository on the Hub
 
     Args:
-        url (str): The URL to extract the split name from.
+        parquet_url (str): The URL to extract the split name from.
 
     Returns:
         str: The extracted split name.

--- a/libs/libcommon/tests/test_parquet_utils.py
+++ b/libs/libcommon/tests/test_parquet_utils.py
@@ -496,7 +496,7 @@ def test_indexer_schema_mistmatch_error(
         ("https://hf.co/datasets/squad/resolve/refs%2Fconvert%2Fparquet/plain_text/train/0000.parquet", "train"),
     ],
 )
-def test_extract_split_name_from_url(url:str, expected:str) -> None:
-    split_name = extract_split_name_from_url(url)
+def test_extract_split_name_from_parquet_url(parquet_url:str, expected:str) -> None:
+    split_name = extract_split_name_from_parquet_url(parquet_url)
 
     assert split_name == expected

--- a/libs/libcommon/tests/test_parquet_utils.py
+++ b/libs/libcommon/tests/test_parquet_utils.py
@@ -491,7 +491,7 @@ def test_indexer_schema_mistmatch_error(
 
 
 @pytest.mark.parametrize(
-    "url,expected",
+    "parquet_url,expected",
     [
         ("https://hf.co/datasets/squad/resolve/refs%2Fconvert%2Fparquet/plain_text/train/0000.parquet", "train"),
     ],

--- a/libs/libcommon/tests/test_parquet_utils.py
+++ b/libs/libcommon/tests/test_parquet_utils.py
@@ -22,6 +22,7 @@ from libcommon.parquet_utils import (
     RowsIndex,
     SchemaMismatchError,
     TooBigRows,
+    extract_split_name_from_url,
     parquet_export_is_partial,
 )
 from libcommon.resources import CacheMongoResource
@@ -487,3 +488,15 @@ def test_indexer_schema_mistmatch_error(
                 index = indexer.get_rows_index("ds_sharded", "default", "train")
                 with pytest.raises(SchemaMismatchError):
                     index.query(offset=0, length=3)
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://hf.co/datasets/squad/resolve/refs%2Fconvert%2Fparquet/plain_text/train/0000.parquet", "train"),
+    ],
+)
+def test_extract_split_name_from_url(url:str, expected:str) -> None:
+    split_name = extract_split_name_from_url(url)
+
+    assert split_name == expected

--- a/libs/libcommon/tests/test_parquet_utils.py
+++ b/libs/libcommon/tests/test_parquet_utils.py
@@ -22,7 +22,7 @@ from libcommon.parquet_utils import (
     RowsIndex,
     SchemaMismatchError,
     TooBigRows,
-    extract_split_name_from_url,
+    extract_split_name_from_parquet_url,
     parquet_export_is_partial,
 )
 from libcommon.resources import CacheMongoResource

--- a/libs/libcommon/tests/test_parquet_utils.py
+++ b/libs/libcommon/tests/test_parquet_utils.py
@@ -496,7 +496,7 @@ def test_indexer_schema_mistmatch_error(
         ("https://hf.co/datasets/squad/resolve/refs%2Fconvert%2Fparquet/plain_text/train/0000.parquet", "train"),
     ],
 )
-def test_extract_split_name_from_parquet_url(parquet_url:str, expected:str) -> None:
+def test_extract_split_name_from_parquet_url(parquet_url: str, expected: str) -> None:
     split_name = extract_split_name_from_parquet_url(parquet_url)
 
     assert split_name == expected

--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -542,7 +542,7 @@ def compute_descriptive_statistics_response(
     logging.info(f"Downloading remote parquet files to a local directory {local_parquet_directory}. ")
     # For directories like "partial-train" for the file at "en/partial-train/0000.parquet" in the C4 dataset.
     # Note that "-" is forbidden for split names so it doesn't create directory names collisions.
-    split_directory = extract_split_name_from_url(split_parquet_files[0]["url"])
+    split_directory = extract_split_name_from_parquet_url(split_parquet_files[0]["url"])
     for parquet_file in split_parquet_files:
         retry_download_hub_file = retry(on=[ReadTimeout], sleeps=HF_HUB_HTTP_ERROR_RETRY_SLEEPS)(hf_hub_download)
         retry_download_hub_file(

--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -20,7 +20,7 @@ from libcommon.exceptions import (
     SplitWithTooBigParquetError,
     StatisticsComputationError,
 )
-    extract_split_name_from_parquet_url,
+from libcommon.parquet_utils import extract_split_name_from_parquet_url
 from libcommon.simple_cache import get_previous_step_or_raise
 from libcommon.storage import StrPath
 from requests.exceptions import ReadTimeout

--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -20,7 +20,7 @@ from libcommon.exceptions import (
     SplitWithTooBigParquetError,
     StatisticsComputationError,
 )
-from libcommon.parquet_utils import extract_split_name_from_url
+    extract_split_name_from_parquet_url,
 from libcommon.simple_cache import get_previous_step_or_raise
 from libcommon.storage import StrPath
 from requests.exceptions import ReadTimeout

--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -20,6 +20,7 @@ from libcommon.exceptions import (
     SplitWithTooBigParquetError,
     StatisticsComputationError,
 )
+from libcommon.parquet_utils import extract_split_name_from_url
 from libcommon.simple_cache import get_previous_step_or_raise
 from libcommon.storage import StrPath
 from requests.exceptions import ReadTimeout
@@ -541,7 +542,7 @@ def compute_descriptive_statistics_response(
     logging.info(f"Downloading remote parquet files to a local directory {local_parquet_directory}. ")
     # For directories like "partial-train" for the file at "en/partial-train/0000.parquet" in the C4 dataset.
     # Note that "-" is forbidden for split names so it doesn't create directory names collisions.
-    split_directory = split_parquet_files[0]["url"].rsplit("/", 2)[1]
+    split_directory = extract_split_name_from_url(split_parquet_files[0]["url"])
     for parquet_file in split_parquet_files:
         retry_download_hub_file = retry(on=[ReadTimeout], sleeps=HF_HUB_HTTP_ERROR_RETRY_SLEEPS)(hf_hub_download)
         retry_download_hub_file(

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -32,7 +32,7 @@ from libcommon.exceptions import (
     ParquetResponseEmptyError,
     PreviousStepFormatError,
 )
-from libcommon.parquet_utils import parquet_export_is_partial
+from libcommon.parquet_utils import parquet_export_is_partial, extract_split_name_from_url
 from libcommon.queue import lock
 from libcommon.simple_cache import get_previous_step_or_raise
 from libcommon.storage import StrPath
@@ -132,7 +132,7 @@ def compute_index_rows(
 
         # For directories like "partial-train" for the file at "en/partial-train/0000.parquet" in the C4 dataset.
         # Note that "-" is forbidden for split names so it doesn't create directory names collisions.
-        split_directory = split_parquet_files[0]["url"].rsplit("/", 2)[1]
+        split_directory = extract_split_name_from_url(split_parquet_files[0]["url"])
         partial_parquet_export = parquet_export_is_partial(split_parquet_files[0]["url"])
 
         num_parquet_files_to_index = 0

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -132,7 +132,7 @@ def compute_index_rows(
 
         # For directories like "partial-train" for the file at "en/partial-train/0000.parquet" in the C4 dataset.
         # Note that "-" is forbidden for split names so it doesn't create directory names collisions.
-        split_directory = extract_split_name_from_url(split_parquet_files[0]["url"])
+        split_directory = extract_split_name_from_parquet_url(split_parquet_files[0]["url"])
         partial_parquet_export = parquet_export_is_partial(split_parquet_files[0]["url"])
 
         num_parquet_files_to_index = 0

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -32,7 +32,7 @@ from libcommon.exceptions import (
     ParquetResponseEmptyError,
     PreviousStepFormatError,
 )
-from libcommon.parquet_utils import parquet_export_is_partial, extract_split_name_from_parquet_url
+from libcommon.parquet_utils import extract_split_name_from_parquet_url, parquet_export_is_partial
 from libcommon.queue import lock
 from libcommon.simple_cache import get_previous_step_or_raise
 from libcommon.storage import StrPath

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -32,7 +32,7 @@ from libcommon.exceptions import (
     ParquetResponseEmptyError,
     PreviousStepFormatError,
 )
-from libcommon.parquet_utils import parquet_export_is_partial, extract_split_name_from_url
+from libcommon.parquet_utils import parquet_export_is_partial, extract_split_name_from_parquet_url
 from libcommon.queue import lock
 from libcommon.simple_cache import get_previous_step_or_raise
 from libcommon.storage import StrPath


### PR DESCRIPTION
Fixes #1755 

This PR adds `extract_split_name_from_url` function to parquet utils and function is called when necessary.