### PR TITLE
try to aling with google style docstring

### DIFF
--- a/jobs/cache_maintenance/tests/utils.py
+++ b/jobs/cache_maintenance/tests/utils.py
@@ -70,7 +70,7 @@ def update_repo_settings(
     Returns:
         The HTTP response in json.
     <Tip>
-    Raises the following errors:
+    Raises:
         - [`~huggingface_hub.utils.RepositoryNotFoundError`]
             If the repository to download from cannot be found. This may be because it doesn't exist,
             or because it is set to `private` and you do not have access.

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -724,7 +724,7 @@ def get_cache_reports(kind: str, cursor: Optional[str], limit: int) -> CacheRepo
     Returns:
         [`CacheReportsPage`]: A dict with the list of reports and the next cursor. The next cursor is
         an empty string if there are no more items to be fetched.
-    Raises the following errors:
+    Raises:
         - [`~simple_cache.InvalidCursor`]
           If the cursor is invalid.
         - [`~simple_cache.InvalidLimit`]
@@ -817,7 +817,7 @@ def get_cache_reports_with_content(kind: str, cursor: Optional[str], limit: int)
     Returns:
         [`CacheReportsWithContentPage`]: A dict with the list of reports and the next cursor. The next cursor is
         an empty string if there are no more items to be fetched.
-    Raises the following errors:
+    Raises:
         - [`~simple_cache.InvalidCursor`]
           If the cursor is invalid.
         - [`~simple_cache.InvalidLimit`]

--- a/libs/libcommon/src/libcommon/utils.py
+++ b/libs/libcommon/src/libcommon/utils.py
@@ -115,7 +115,7 @@ def raise_if_blocked(
 
     Returns:
         `None`
-    Raises the following errors:
+    Raises:
         - [`libcommon.exceptions.DatasetInBlockListError`]
           If the dataset is in the list of blocked datasets.
     """

--- a/services/admin/tests/fixtures/hub.py
+++ b/services/admin/tests/fixtures/hub.py
@@ -54,7 +54,7 @@ def update_repo_settings(
     Returns:
         The HTTP response in json.
     <Tip>
-    Raises the following errors:
+    Raises:
         - [`~huggingface_hub.utils.RepositoryNotFoundError`]
             If the repository to download from cannot be found. This may be because it doesn't exist,
             or because it is set to `private` and you do not have access.

--- a/services/worker/src/worker/job_runners/config/duckdb_index_size.py
+++ b/services/worker/src/worker/job_runners/config/duckdb_index_size.py
@@ -31,7 +31,7 @@ def compute_config_duckdb_index_size_response(dataset: str, config: str) -> Conf
             A configuration name.
     Returns:
         `ConfigDuckdbIndexSizeResponse`: An object with the duckdb_index_size_response.
-    Raises the following errors:
+    Raises:
         - [`libcommon.simple_cache.CachedArtifactError`]
           If the previous step gave an error.
         - [`libcommon.exceptions.PreviousStepFormatError`]

--- a/services/worker/src/worker/job_runners/config/info.py
+++ b/services/worker/src/worker/job_runners/config/info.py
@@ -18,7 +18,7 @@ def compute_config_info_response(dataset: str, config: str) -> ConfigInfoRespons
             Dataset configuration name
     Returns:
         `ConfigInfoResponse`: An object with the dataset_info response for requested config.
-    Raises the following errors:
+    Raises:
         - [`libcommon.simple_cache.CachedArtifactError`]
           If the previous step gave an error.
         - [`libcommon.exceptions.PreviousStepFormatError`]

--- a/services/worker/src/worker/job_runners/config/parquet.py
+++ b/services/worker/src/worker/job_runners/config/parquet.py
@@ -21,7 +21,7 @@ def compute_parquet_response(dataset: str, config: str) -> ConfigParquetResponse
             A configuration name.
     Returns:
         `ConfigParquetResponse`: An object with the parquet_response (list of parquet files).
-    Raises the following errors:
+    Raises:
         - [`libcommon.simple_cache.CachedArtifactError`]
           If the previous step gave an error.
         - [`libcommon.exceptions.PreviousStepFormatError`]

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -284,7 +284,7 @@ def is_dataset_too_big(
     Returns:
         `ParquetResponseResult`: An object with the parquet_response
           (dataset and list of parquet files) and the dataset_git_revision (sha) if any.
-    Raises the following errors:
+    Raises:
         - [`libcommon.exceptions.UnsupportedExternalFilesError`]
           If we failed to get the external files sizes to make sure we can convert the dataset to parquet
         - [`libcommon.exceptions.ExternalFilesSizeRequestHTTPError`]
@@ -1080,7 +1080,7 @@ def compute_config_parquet_and_info_response(
     Returns:
         `ConfigParquetAndInfoResponse`: An object with the config_parquet_and_info_response
           (dataset info and list of parquet files).
-    Raises the following errors:
+    Raises:
         - [`libcommon.exceptions.DatasetNotFoundError`]:
           if the dataset does not exist, or if the token does not give the sufficient access to the dataset,
         - ['requests.exceptions.HTTPError'](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError)

--- a/services/worker/src/worker/job_runners/config/parquet_metadata.py
+++ b/services/worker/src/worker/job_runners/config/parquet_metadata.py
@@ -71,8 +71,7 @@ def compute_parquet_metadata_response(
             The directory where the parquet metadata files are stored.
     Returns:
         `ConfigParquetMetadataResponse`: An object with the list of parquet metadata files.
-    <Tip>
-    Raises the following errors:
+    Raises:
         - [`~libcommon.simple_cache.CachedArtifactError`]
             If the previous step gave an error.
         - [`~libcommon.exceptions.PreviousStepFormatError`]
@@ -81,7 +80,6 @@ def compute_parquet_metadata_response(
             If the previous step provided an empty list of parquet files.
         - [`~libcommon.exceptions.FileSystemError`]
             If the HfFileSystem couldn't access the parquet files.
-    </Tip>
     """
     logging.info(f"get parquet files for dataset={dataset}, config={config}")
 

--- a/services/worker/src/worker/job_runners/config/size.py
+++ b/services/worker/src/worker/job_runners/config/size.py
@@ -21,7 +21,7 @@ def compute_config_size_response(dataset: str, config: str) -> ConfigSizeRespons
             A configuration name.
     Returns:
         `ConfigSizeResponse`: An object with the size_response.
-    Raises the following errors:
+    Raises:
         - [`libcommon.simple_cache.CachedArtifactError`]
           If the previous step gave an error.
         - [`libcommon.exceptions.PreviousStepFormatError`]

--- a/services/worker/src/worker/job_runners/config/split_names_from_info.py
+++ b/services/worker/src/worker/job_runners/config/split_names_from_info.py
@@ -27,7 +27,7 @@ def compute_split_names_from_info_response(dataset: str, config: str) -> SplitsL
             A configuration name.
     Returns:
         `SplitsList`: An object with the list of split names for the dataset and config.
-    Raises the following errors:
+    Raises:
         - [`libcommon.simple_cache.CachedArtifactError`]
           If the previous step gave an error.
         - [`libcommon.exceptions.PreviousStepFormatError`]

--- a/services/worker/src/worker/job_runners/config/split_names_from_streaming.py
+++ b/services/worker/src/worker/job_runners/config/split_names_from_streaming.py
@@ -27,8 +27,7 @@ def compute_split_names_from_streaming_response(
     hf_token: Optional[str] = None,
 ) -> SplitsList:
     """
-    Get the response of config-split-names-from-streaming for one specific dataset and config on huggingface.co.
-    Dataset can be private or gated if you pass an acceptable token.
+    Get the response of `config-split-names-from-streaming` for one specific dataset and config on huggingface.co.
 
     It is assumed that the dataset exists and can be accessed using the token, and that the config exists in
     the dataset.
@@ -54,7 +53,7 @@ def compute_split_names_from_streaming_response(
             An authentication token (See https://huggingface.co/settings/token)
     Returns:
         `SplitsList`: An object with the list of split names for the dataset and config.
-    Raises the following errors:
+    Raises:
         - [`libcommon.exceptions.DatasetManualDownloadError`]:
           If the dataset requires manual download.
         - [`libcommon.exceptions.EmptyDatasetError`]

--- a/services/worker/src/worker/job_runners/dataset/config_names.py
+++ b/services/worker/src/worker/job_runners/dataset/config_names.py
@@ -28,35 +28,36 @@ def compute_config_names_response(
     hf_token: Optional[str] = None,
 ) -> DatasetConfigNamesResponse:
     """
-    Get the response of dataset-config-names for one specific dataset on huggingface.co.
-    Dataset can be private or gated if you pass an acceptable token.
-
+    Get the response of `dataset-config-names` for one specific dataset on huggingface.co.
     It is assumed that the dataset exists and can be accessed using the token.
 
     Args:
-        dataset (`str`):
-            A namespace (user or an organization) and a repo name separated
-            by a `/`.
-        dataset_scripts_allow_list (`list[str]`):
+        dataset (:obj:`str`):
+            A namespace (user or an organization) and a repo name separated by a `/`.
+        max_number (:obj:`int`):
+            The maximum number of configs allowed for a dataset.
+        dataset_scripts_allow_list (:obj:`list[str]`):
             List of datasets for which we support dataset scripts.
             Unix shell-style wildcards also work in the dataset name for namespaced datasets,
             for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
             The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` refers to all the datasets without namespace.
-        hf_token (`str`, *optional*):
+        hf_token (:obj:`str`, `optional`):
             An authentication token (See https://huggingface.co/settings/token)
+
     Returns:
-        `DatasetConfigNamesResponse`: An object with the list of config names.
-    Raises the following errors:
-        - [`libcommon.exceptions.EmptyDatasetError`]
+        :obj:`DatasetConfigNamesResponse`: An object with the list of config names.
+    
+    Raises:
+        :obj:`EmptyDatasetError`:
           The dataset is empty.
-        - [`libcommon.exceptions.DatasetModuleNotInstalledError`]
+        :obj:`DatasetModuleNotInstalledError`:
           The dataset tries to import a module that is not installed.
-        - [`libcommon.exceptions.ConfigNamesError`]
+        :obj:`ConfigNamesError`:
           If the list of configs could not be obtained using the datasets library.
-        - [`libcommon.exceptions.DatasetWithScriptNotSupportedError`]
+        :obj:`DatasetWithScriptNotSupportedError`:
             If the dataset has a dataset script and is not in the allow list.
     """
-    logging.info(f"get config names for dataset={dataset}")
+    logging.info(f"get 'dataset-config-names' for {dataset=}")
     # get the list of splits in streaming mode
     try:
         config_name_items: list[ConfigNameItem] = [

--- a/services/worker/src/worker/job_runners/dataset/duckdb_index_size.py
+++ b/services/worker/src/worker/job_runners/dataset/duckdb_index_size.py
@@ -25,20 +25,23 @@ from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 
 def compute_dataset_duckdb_index_size_response(dataset: str) -> tuple[DatasetDuckdbIndexSizeResponse, float]:
     """
-    Get the response of config-duckdb-index-size for one specific dataset on huggingface.co.
+    Get the response of `config-duckdb-index-size` for one specific dataset on huggingface.co.
+
     Args:
-        dataset (`str`):
-            A namespace (user or an organization) and a repo name separated
-            by a `/`.
+        dataset (:obj:`str`):
+            A namespace (user or an organization) and a repo name separated by a `/`.
+
     Returns:
-        `DatasetDuckdbIndexSizeResponse`: An object with the duckdb_index_size_response.
-    Raises the following errors:
-        - [`libcommon.simple_cache.CachedArtifactError`]
+        :obj:`tuple[DatasetHubCacheResponse, float]`:
+            A tuple containing the response and the progress.
+
+    Raises:
+        :obj:`CachedArtifactError`:
           If the previous step gave an error.
-        - [`libcommon.exceptions.PreviousStepFormatError`]
+        :obj:`PreviousStepFormatError`:
           If the content of the previous step has not the expected format
     """
-    logging.info(f"get duckdb_index_size for dataset={dataset}")
+    logging.info(f"get 'config-duckdb-index-size' for {dataset=}")
 
     config_names_best_response = get_previous_step_or_raise(kinds=["dataset-config-names"], dataset=dataset)
     content = config_names_best_response.response["content"]

--- a/services/worker/src/worker/job_runners/dataset/hub_cache.py
+++ b/services/worker/src/worker/job_runners/dataset/hub_cache.py
@@ -12,21 +12,25 @@ from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 
 def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, float]:
     """
-    Get the content of a /sse/hub-cache SSE for one specific dataset on huggingface.co.
-
+    Get the response of `dataset-hub-cache` for one specific dataset on huggingface.co.
     Its purpose is specific to the Hub, and we won't ensure backward compatibility for this step.
     It provides information about:
     - the capabilities of the dataset: preview and viewer
     - the number of rows and if the dataset is partial
 
     Args:
-        dataset (`str`):
-            A namespace (user or an organization) and a repo name separated
-            by a `/`.
+        dataset (:obj:`str`):
+            A namespace (user or an organization) and a repo name separated by a `/`.
+
+    Raises:
+        PreviousStepFormatError:
+            If the content of the previous step has not the expected format
+
     Returns:
-        `tuple[DatasetHubCacheResponse, float]`: The response and the progress.
+        :obj:`tuple[DatasetHubCacheResponse, float]`: 
+            A tuple containing the response and the progress.
     """
-    logging.info(f"get hub_cache response for {dataset=}")
+    logging.info(f"get 'dataset-hub-cache' response for {dataset=}")
 
     is_valid_response = get_previous_step_or_raise(kinds=["dataset-is-valid"], dataset=dataset)
     content = is_valid_response.response["content"]

--- a/services/worker/src/worker/job_runners/dataset/info.py
+++ b/services/worker/src/worker/job_runners/dataset/info.py
@@ -18,7 +18,7 @@ from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 
 def compute_dataset_info_response(dataset: str) -> tuple[DatasetInfoResponse, float]:
     """
-    Get the response of dataset-info for one specific dataset on huggingface.co.
+    Get the response of `dataset-info` for one specific dataset on huggingface.co.
     Args:
         dataset (`str`):
             A namespace (user or an organization) and a repo name separated
@@ -28,7 +28,7 @@ def compute_dataset_info_response(dataset: str) -> tuple[DatasetInfoResponse, fl
         progress float value from 0. to 1. which corresponds to the percentage of dataset configs
         correctly processed and included in current response (some configs might not exist in cache yet
         or raise errors).
-    Raises the following errors:
+    Raises:
         - [`libcommon.simple_cache.CachedArtifactError`]
             If the previous step gave an error.
         - [`libcommon.exceptions.PreviousStepFormatError`]

--- a/services/worker/src/worker/job_runners/dataset/is_valid.py
+++ b/services/worker/src/worker/job_runners/dataset/is_valid.py
@@ -17,9 +17,7 @@ from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 
 def compute_is_valid_response(dataset: str) -> tuple[IsValidResponse, float]:
     """
-    Get the response of /is-valid for one specific dataset on huggingface.co.
-
-
+    Get the response of `dataset-is-valid` for one specific dataset on huggingface.co.
     A dataset is valid if at least one response of any of the artifacts for any of the
     steps (for viewer and preview) is valid.
     The deprecated `valid` field is an "or" of the `preview` and `viewer` fields.

--- a/services/worker/src/worker/job_runners/dataset/parquet.py
+++ b/services/worker/src/worker/job_runners/dataset/parquet.py
@@ -30,7 +30,7 @@ def compute_parquet_response(dataset: str) -> tuple[DatasetParquetResponse, floa
             by a `/`.
     Returns:
         `DatasetParquetResponse`: An object with the parquet_response (list of parquet files).
-    Raises the following errors:
+    Raises:
         - [`libcommon.simple_cache.CachedArtifactError`]
           If the previous step gave an error.
         - [`libcommon.exceptions.PreviousStepFormatError`]

--- a/services/worker/src/worker/job_runners/dataset/size.py
+++ b/services/worker/src/worker/job_runners/dataset/size.py
@@ -33,7 +33,7 @@ def compute_sizes_response(dataset: str) -> tuple[DatasetSizeResponse, float]:
             by a `/`.
     Returns:
         `DatasetSizeResponse`: An object with the sizes_response.
-    Raises the following errors:
+    Raises:
         - [`libcommon.simple_cache.CachedArtifactError`]
           If the previous step gave an error.
         - [`libcommon.exceptions.PreviousStepFormatError`]

--- a/services/worker/src/worker/job_runners/dataset/split_names.py
+++ b/services/worker/src/worker/job_runners/dataset/split_names.py
@@ -27,7 +27,7 @@ def compute_dataset_split_names_response(dataset: str) -> tuple[DatasetSplitName
     Returns:
         `DatasetSplitNamesResponse`: An object with a list of split names for the dataset [splits],
          a list of pending configs to be processed [pending] and the list of errors [failed] by config.
-    Raises the following errors:
+    Raises:
         - [`libcommon.simple_cache.CachedArtifactError`]
           If the the previous step gave an error.
         - [`libcommon.exceptions.PreviousStepFormatError`]

--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -482,7 +482,7 @@ def compute_descriptive_statistics_response(
         `SplitDescriptiveStatisticsResponse`: An object with the statistics response for a requested split, per each
         numerical (int and float) or ClassLabel feature.
 
-    Raises the following errors:
+    Raises:
         - [`libcommon.exceptions.PreviousStepFormatError`]
             If the content of the previous step does not have the expected format.
         - [`libcommon.exceptions.ParquetResponseEmptyError`]

--- a/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/first_rows_from_streaming.py
@@ -74,7 +74,7 @@ def compute_first_rows_response(
             The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` refers to all the datasets without namespace.
     Returns:
         [`SplitFirstRowsResponse`]: The list of first rows of the split.
-    Raises the following errors:
+    Raises:
         - [`libcommon.exceptions.SplitNotFoundError`]
           If the split does not exist in the dataset.
         - [`libcommon.exceptions.InfoError`]

--- a/services/worker/src/worker/job_runners/split/image_url_columns.py
+++ b/services/worker/src/worker/job_runners/split/image_url_columns.py
@@ -35,7 +35,7 @@ def compute_image_url_columns(
             A split name.
     Returns:
         [`ImageUrlColumnsResponse`]: The list of image url columns.
-    Raises the following errors:
+    Raises:
         - [`libcommon.simple_cache.CachedArtifactError`]
           If the previous step gave an error.
         - [`libcommon.exceptions.PreviousStepFormatError`]

--- a/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
@@ -138,7 +138,7 @@ def compute_opt_in_out_urls_scan_response(
 
     Returns:
         [`OptInOutUrlsScanResponse`]
-    Raises the following errors:
+    Raises:
         - [`libcommon.simple_cache.CachedArtifactError`]
           If the previous step gave an error.
         - [`libcommon.exceptions.PreviousStepFormatError`]

--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -62,7 +62,7 @@ def update_repo_settings(
     Returns:
         The HTTP response in json.
     <Tip>
-    Raises the following errors:
+    Raises:
         - [`~huggingface_hub.utils.RepositoryNotFoundError`]
             If the repository to download from cannot be found. This may be because it doesn't exist,
             or because it is set to `private` and you do not have access.


### PR DESCRIPTION
_Not a critical PR_
This PR is a suggestion to start aligning docstrings using Google-style docstring format (I saw most of our code uses this one so it will be easier to change all the occurrences).
See https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html and https://google.github.io/styleguide/pyguide.html for more information.
Please let me know what you think in regards to the following:
- Use of `Raises` instead of `Raises the following errors`
- Use of the notation `:obj:` for the data types in Args, Return, and Raises (See https://stackoverflow.com/questions/41127200/in-python-docstrings-what-does-obj-do for more information).
- Use of direct name of exception instead of full path e.g:`obj:`DatasetModuleNotInstalledError`` (I find this more readable)