### PR TITLE
doc - Update minor details in the doc

### DIFF
--- a/docs/source/analyze_data.mdx
+++ b/docs/source/analyze_data.mdx
@@ -26,7 +26,7 @@ print(data)
     [
         {'dataset': 'codeparrot/codecomplex', 'config': 'default', 'split': 'train', 'url': 'https://huggingface.co/datasets/codeparrot/codecomplex/resolve/refs%2Fconvert%2Fparquet/default/train/0000.parquet', 'filename': '0000.parquet', 'size': 4115908}
     ], 
- 'pending': [], 'failed': []
+ 'pending': [], 'failed': [], 'partial: false
 }
 ```
 

--- a/docs/source/filter.mdx
+++ b/docs/source/filter.mdx
@@ -39,6 +39,162 @@ either the string "name" column is equal to 'Simone' or the integer "children" c
   for example: <code>'O''Hara'</code>.
 </Tip>
 
+For example, let's filter those rows with no_answer=false in the `train` split of the `SelfRC` configuration of the `ibm/duorc` dataset restricting the results to the slice 150-151:
+
+<inferencesnippet>
+<python>
+```python
+import requests
+headers = {"Authorization": f"Bearer {API_TOKEN}"}
+API_URL = "https://datasets-server.huggingface.co/filter?dataset=ibm/duorc&config=SelfRC&split=train&where=no_answer=true&offset=150&length=2"
+def query():
+    response = requests.get(API_URL, headers=headers)
+    return response.json()
+data = query()
+```
+</python>
+<js>
+```js
+import fetch from "node-fetch";
+async function query(data) {
+    const response = await fetch(
+        "https://datasets-server.huggingface.co/filter?dataset=ibm/duorc&config=SelfRC&split=train&where=no_answer=true&offset=150&length=2",
+        {
+            headers: { Authorization: `Bearer ${API_TOKEN}` },
+            method: "GET"
+        }
+    );
+    const result = await response.json();
+    return result;
+}
+query().then((response) => {
+    console.log(JSON.stringify(response));
+});
+```
+</js>
+<curl>
+```curl
+curl https://datasets-server.huggingface.co/filter?dataset=ibm/duorc&config=SelfRC&split=train&where=no_answer=true&offset=150&length=2 \
+        -X GET \
+        -H "Authorization: Bearer ${API_TOKEN}"
+```
+</curl>
+</inferencesnippet>
+
+The endpoint response is a JSON containing two keys (same format as [`/rows`](./rows)):
+
+- The [`features`](https://huggingface.co/docs/datasets/about_dataset_features) of a dataset, including the column's name and data type.
+- The slice of `rows` of a dataset and the content contained in each column of a specific row.
+
+The rows are ordered by the row index.
+
+For example, here are the `features` and the slice 150-151 of matching `rows` of the `ibm.duorc`/`SelfRC` train split for the `where` condition `no_answer=true`:
+
+```json
+{
+   "features":[
+      {
+         "feature_idx":0,
+         "name":"plot_id",
+         "type":{
+            "dtype":"string",
+            "_type":"Value"
+         }
+      },
+      {
+         "feature_idx":1,
+         "name":"plot",
+         "type":{
+            "dtype":"string",
+            "_type":"Value"
+         }
+      },
+      {
+         "feature_idx":2,
+         "name":"title",
+         "type":{
+            "dtype":"string",
+            "_type":"Value"
+         }
+      },
+      {
+         "feature_idx":3,
+         "name":"question_id",
+         "type":{
+            "dtype":"string",
+            "_type":"Value"
+         }
+      },
+      {
+         "feature_idx":4,
+         "name":"question",
+         "type":{
+            "dtype":"string",
+            "_type":"Value"
+         }
+      },
+      {
+         "feature_idx":5,
+         "name":"answers",
+         "type":{
+            "feature":{
+               "dtype":"string",
+               "_type":"Value"
+            },
+            "_type":"Sequence"
+         }
+      },
+      {
+         "feature_idx":6,
+         "name":"no_answer",
+         "type":{
+            "dtype":"bool",
+            "_type":"Value"
+         }
+      }
+   ],
+   "rows":[
+      {
+         "row_idx":12825,
+         "row":{
+            "plot_id":"/m/06qxsf",
+            "plot":"Prologue\nA creepy-looking coroner introduces three different horror tales involving his current work on cadavers in \"body bags\".\n\"The Gas Station\"[edit]\nAnne is a young college student who arrives for her first job working the night shift at an all-night filling station near Haddonfield, Illinois (a reference to the setting of Carpenter's two Halloween films). The attending worker, Bill, tells her that a serial killer has broken out of a mental hospital, and cautions her not to leave the booth at the station without the keys because the door locks automatically. After Bill leaves, Anne is alone and the tension mounts as she deals with various late-night customers seeking to buy gas for a quick fill-up, purchase cigarettes or just use the restroom key, unsure whether any of them might be the escaped maniac. Eventually, when Anne suspects that the escaped killer is lurking around the gas station, she tries to call the police, only to find that the phone line is dead. Soon after that, she finds an elaborately grotesque drawing in the Restroom and then the dead body of a transient sitting in a pickup truck on the lift in one of the garage bays. She makes a phone call for help which results in her realization that \"Bill\", the attending worker she met earlier, is in fact the escaped killer, who has killed the real Bill and is killing numerous passers-by. She finds the real Bill's dead body in one of the lockers. Serial Killer \"Bill\" then reappears and attempts to kill Anne with a machete, breaking into the locked booth by smashing out the glass with a sledgehammer and then chasing her around the deserted garage. Just as he is about to kill her, a customer returns, having forgotten his credit card, and he wrestles the killer, giving Anne time to crush him under the vehicle lift.\n\"Hair\"[edit]\nRichard Coberts is a middle-aged businessman who is very self-conscious about his thinning hair. This obsession has caused a rift between him and his long-suffering girlfriend Megan. Richard answers a television ad about a \"miracle\" hair transplant operation, pays a visit to the office, and meets the shady Dr. Lock, who, for a very large fee, agrees to give Richard a surgical procedure to make his hair grow back. The next day, Richard wakes up and removes the bandage around his head, and is overjoyed to find that he has a full head of hair. But soon he becomes increasingly sick and fatigued, and finds his hair continuing to grow and, additionally, growing out of parts of his body, where hair does not normally grow. Trying to cut some of the hair off, he finds that it \"bleeds\", and, examining some of the hairs under a magnifying glass, sees that they are alive and resemble tiny serpents. He goes back to Dr. Lock for an explanation, but finds himself a prisoner as Dr. Lock explains that he and his entire staff are aliens from another planet, seeking out narcissistic human beings and planting seeds of \"hair\" to take over their bodies for consumption as part of their plan to spread their essence to Earth.\n\"Eye\"[edit]\nBrent Matthews is a baseball player whose life and career take a turn for the worse when he gets into a serious car accident in which his right eye is gouged out. Unwilling to admit that his career is over, he jumps at the chance to undergo an experimental surgical procedure to replace his eye with one from a recently deceased person. But soon after the surgery he begins to see things out of his new eye that others cannot see, and begins having nightmares of killing women and having sex with them. Brent seeks out the doctor who operated on him, and the doctor tells him that the donor of his new eye was a recently executed serial killer and necrophile who killed several young women, and then had sex with their dead bodies. Brent becomes convinced that the spirit of the dead killer is taking over his body so that he can resume killing women. He flees back to his house and tells his skeptical wife, Cathy, about what is happening. Just then the spirit of the killer emerges and attempts to kill Cathy as well. Cathy fights back, subduing him long enough for Brent to re-emerge. Realizing that it is only a matter of time before the killer emerges again, Brent cuts out his donated eye, severing his link with the killer, but then bleeds to death.\nEpilogue The coroner is finishing telling his last tale when he hears a noise from outside the morgue. He crawls back inside a body bag, revealing that he himself is a living cadaver, as two other morgue workers begin to go to work on his \"John Doe\" corpse.",
+            "title":"John Carpenter presents Body Bags",
+            "question_id":"cf58489f-12ba-ace6-67a7-010d957b4ff4",
+            "question":"What happens soon after the surgery?",
+            "answers":[
+               
+            ],
+            "no_answer":true
+         },
+         "truncated_cells":[
+            
+         ]
+      },
+      {
+         "row_idx":12836,
+         "row":{
+            "plot_id":"/m/04z_3pm",
+            "plot":"In 1976, eight-year-old Mary Daisy Dinkle (Bethany Whitmore) lives a lonely life in Mount Waverley, Australia. At school, she is teased by her classmates because of an unfortunate birthmark on her forehead; while at home, her distant father, Noel, and alcoholic, kleptomaniac mother, Vera, provide little support. Her only comforts are her pet rooster, Ethel; her favourite food, sweetened condensed milk; and a Smurfs-like cartoon show called The Noblets. One day, while at the post office with her mother, Mary spots a New York City telephone book and, becoming curious about Americans, decides to write to one. She randomly chooses Max Jerry Horowitz's name from the phone book and writes him a letter telling him about herself, sending it off in the hope that he will become her pen friend.\nMax Jerry Horowitz (Philip Seymour Hoffman) is a morbidly obese 44-year-old ex-Jewish atheist who has trouble forming close bonds with other people, due to various mental and social problems. Though Mary's letter initially gives him an anxiety attack, he decides to write back to her, and the two quickly become friends (partly due to their shared love of chocolate and The Noblets). Due to Vera's disapproval of Max, Mary tells him to send his letters to her agoraphobic neighbour, Len Hislop, whose mail she collects regularly. When Mary later asks Max about love, he suffers a severe anxiety attack and is institutionalized for eight months. After his release, he is hesitant to write to Mary again for some time. On his 48th birthday, he wins the New York lottery, using his winnings to buy a lifetime supply of chocolate and an entire collection of Noblet figurines. He gives the rest of his money to his elderly neighbour Ivy, who uses most of it to pamper herself before dying in an accident with a malfunctioning jet pack. Meanwhile, Mary becomes despondent, thinking Max has abandoned her.\nOn the advice of his therapist, Max finally writes back to Mary and explains he has been diagnosed with Asperger syndrome. Mary is thrilled to hear from him again, and the two continue their correspondence for the next several years. When Noel retires from his job at a tea bag factory, he takes up metal detecting, but is soon swept away (and presumably killed) by a big tidal bore while on a beach. Mary (Toni Colette) goes to university and has her birthmark surgically removed, and develops a crush on her Greek Australian neighbour, Damien Popodopoulos (Eric Bana). Drunk and guilt-ridden over her husband's death, Vera accidentally kills herself after she drinks embalming fluid (which she mistook for cooking sherry). Mary and Damien grow closer following Vera's death and are later married.\nInspired by her friendship with Max, Mary studies psychology at university, writing her doctoral dissertation on Asperger syndrome with Max as her test subject. She plans to have her dissertation published as a book; but when Max receives a copy from her, he is infuriated that she has taken advantage of his condition, which he sees as an integral part of his personality and not a disability that needs to be cured. He breaks off communication with Mary (by removing the letter \"M\" from his typewriter), who, heartbroken, has the entire run of her book pulped, effectively ending her budding career. She sinks into depression and begins drinking cooking sherry, as her mother had done. While searching through a cabinet, she finds a can of condensed milk, and sends it to Max as an apology. She checks the post daily for a response and one day finds a note from Damien, informing her that he has left her for his own pen friend, Desmond, a sheep farmer in New Zealand.\nMeanwhile, after an incident in which he nearly chokes a homeless man (Ian \"Molly\" Meldrum) in anger, after throwing a used cigarette, Max realizes Mary is an imperfect human being, like himself, and sends her a package containing his Noblet figurine collection as a sign of forgiveness. Mary, however, has sunken into despair after Damien's departure, and fails to find the package on her doorstep for several days. Finding some Valium that had belonged to her mother, and unaware that she is pregnant with Damien's child, Mary decides to commit suicide. As she takes the Valium and is on the verge of hanging herself, Len knocks on her door, having conquered his agoraphobia to alert her of Max's package. Inside, she finds the Noblet figurines and a letter from Max, in which he tells her of his realization that they are not perfect and expresses his forgiveness. He also states how much their friendship means to him, and that he hopes their paths will cross one day.\nOne year later, Mary travels to New York with her infant child to finally visit Max. Entering his apartment, Mary discovers Max on his couch, gazing upward with a smile on his face, having died earlier that morning. Looking around the apartment, Mary is awestruck to find all the letters she had sent to Max over the years, laminated and taped to the ceiling. Realizing Max had been gazing at the letters when he died, and seeing how much he had valued their friendship, Mary cries tears of joy and joins him on the couch.",
+            "title":"Mary and Max",
+            "question_id":"1dc019ad-80cf-1d49-5a69-368f90fae2f8",
+            "question":"Why was Mary Daisy Dinkle teased in school?",
+            "answers":[
+               
+            ],
+            "no_answer":true
+         },
+         "truncated_cells":[
+            
+         ]
+      }
+   ],
+   "num_rows_total":627,
+   "num_rows_per_page":100,
+   "partial":false
+}
+```
+
 If the result has `partial: true` it means that the filtering couldn't be run on the full dataset because it's too big.
 
 Indeed, the indexing for `/filter` can be partial if the dataset is bigger than 5GB. In that case, it only uses the first 5GB.

--- a/docs/source/first_rows.mdx
+++ b/docs/source/first_rows.mdx
@@ -17,7 +17,7 @@ The `/first-rows` endpoint accepts three query parameters:
 ```python
 import requests
 headers = {"Authorization": f"Bearer {API_TOKEN}"}
-API_URL = "https://datasets-server.huggingface.co/first-rows?dataset=duorc&config=SelfRC&split=train"
+API_URL = "https://datasets-server.huggingface.co/first-rows?dataset=ibm/duorc&config=SelfRC&split=train"
 def query():
     response = requests.get(API_URL, headers=headers)
     return response.json()
@@ -29,7 +29,7 @@ data = query()
 import fetch from "node-fetch";
 async function query(data) {
     const response = await fetch(
-        "https://datasets-server.huggingface.co/first-rows?dataset=duorc&config=SelfRC&split=train",
+        "https://datasets-server.huggingface.co/first-rows?dataset=ibm/duorc&config=SelfRC&split=train",
         {
             headers: { Authorization: `Bearer ${API_TOKEN}` },
             method: "GET"
@@ -45,7 +45,7 @@ query().then((response) => {
 </js>
 <curl>
 ```curl
-curl https://datasets-server.huggingface.co/first-rows?dataset=duorc&config=SelfRC&split=train \
+curl https://datasets-server.huggingface.co/first-rows?dataset=ibm/duorc&config=SelfRC&split=train \
         -X GET \
         -H "Authorization: Bearer ${API_TOKEN}"
 ```
@@ -57,11 +57,11 @@ The endpoint response is a JSON containing two keys:
 - The [`features`](https://huggingface.co/docs/datasets/about_dataset_features) of a dataset, including the column's name and data type.
 - The first 100 `rows` of a dataset and the content contained in each column of a specific row.
 
-For example, here are the `features` and the first 100 `rows` of the `duorc`/`SelfRC` train split:
+For example, here are the `features` and the first 100 `rows` of the `ibm/duorc`/`SelfRC` train split:
 
 ```json
 {
-  "dataset": "duorc",
+  "dataset": "ibm/duorc",
   "config": "SelfRC",
   "split": "train",
   "features": [

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -13,6 +13,7 @@ Let Datasets Server take care of the heavy lifting so you can use a simple **RES
 - Get the **dataset size** (in number of rows or bytes)
 - Download and view **rows at any index** in the dataset
 - **Search** a word in the dataset
+- **Filter** rows based on a query string
 - Get insightful **statistics** about the data
 - Access the dataset as **parquet files** to use in your favorite **processing or analytics framework**
 

--- a/docs/source/info.mdx
+++ b/docs/source/info.mdx
@@ -12,7 +12,7 @@ The `/info` endpoint accepts two query parameters:
 ```python
 import requests
 headers = {"Authorization": f"Bearer {API_TOKEN}"}
-API_URL = "https://datasets-server.huggingface.co/info?dataset=duorc&config=SelfRC"
+API_URL = "https://datasets-server.huggingface.co/info?dataset=ibm/duorc&config=SelfRC"
 def query():
     response = requests.get(API_URL, headers=headers)
     return response.json()
@@ -24,7 +24,7 @@ data = query()
 import fetch from "node-fetch";
 async function query(data) {
     const response = await fetch(
-        "https://datasets-server.huggingface.co/info?dataset=duorc&config=SelfRC",
+        "https://datasets-server.huggingface.co/info?dataset=ibm/duorc&config=SelfRC",
         {
             headers: { Authorization: `Bearer ${API_TOKEN}` },
             method: "GET"
@@ -40,7 +40,7 @@ query().then((response) => {
 </js>
 <curl>
 ```curl
-curl https://datasets-server.huggingface.co/info?dataset=duorc&config=SelfRC \
+curl https://datasets-server.huggingface.co/info?dataset=ibm/duorc&config=SelfRC \
         -X GET \
         -H "Authorization: Bearer ${API_TOKEN}"
 ```
@@ -51,89 +51,76 @@ The endpoint response is a JSON with the `dataset_info` key. Its structure and c
 
 ```json
 {
-    "dataset_info": {
-        "description": "DuoRC contains 186,089 unique question-answer pairs created from a collection of 7680 pairs of movie plots where each pair in the collection reflects two versions of the same movie.\n",
-        "citation": "@inproceedings{DuoRC,\nauthor = { Amrita Saha and Rahul Aralikatte and Mitesh M. Khapra and Karthik Sankaranarayanan},title = {{DuoRC: Towards Complex Language Understanding with Paraphrased Reading Comprehension}},\nbooktitle = {Meeting of the Association for Computational Linguistics (ACL)},\nyear = {2018}\n}\n",
-        "homepage": "https://duorc.github.io/",
-        "license": "https://raw.githubusercontent.com/duorc/duorc/master/LICENSE",
-        "features": {
-            "plot_id": {
-                "dtype": "string",
-                "_type": "Value"
+   "dataset_info":{
+      "description":"",
+      "citation":"",
+      "homepage":"",
+      "license":"",
+      "features":{
+         "plot_id":{
+            "dtype":"string",
+            "_type":"Value"
+         },
+         "plot":{
+            "dtype":"string",
+            "_type":"Value"
+         },
+         "title":{
+            "dtype":"string",
+            "_type":"Value"
+         },
+         "question_id":{
+            "dtype":"string",
+            "_type":"Value"
+         },
+         "question":{
+            "dtype":"string",
+            "_type":"Value"
+         },
+         "answers":{
+            "feature":{
+               "dtype":"string",
+               "_type":"Value"
             },
-            "plot": {
-                "dtype": "string",
-                "_type": "Value"
-            },
-            "title": {
-                "dtype": "string",
-                "_type": "Value"
-            },
-            "question_id": {
-                "dtype": "string",
-                "_type": "Value"
-            },
-            "question": {
-                "dtype": "string",
-                "_type": "Value"
-            },
-            "answers": {
-                "feature": {
-                    "dtype": "string",
-                    "_type": "Value"
-                },
-                "_type": "Sequence"
-            },
-            "no_answer": {
-                "dtype": "bool",
-                "_type": "Value"
-            }
-        },
-        "builder_name": "duorc",
-        "config_name": "SelfRC",
-        "version": {
-            "version_str": "1.0.0",
-            "major": 1,
-            "minor": 0,
-            "patch": 0
-        },
-        "splits": {
-            "train": {
-                "name": "train",
-                "num_bytes": 239852729,
-                "num_examples": 60721,
-                "dataset_name": "duorc"
-            },
-            "validation": {
-                "name": "validation",
-                "num_bytes": 51662519,
-                "num_examples": 12961,
-                "dataset_name": "duorc"
-            },
-            "test": {
-                "name": "test",
-                "num_bytes": 49142710,
-                "num_examples": 12559,
-                "dataset_name": "duorc"
-            }
-        },
-        "download_checksums": {
-            "https://raw.githubusercontent.com/duorc/duorc/master/dataset/SelfRC_train.json": {
-                "num_bytes": 24388192,
-                "checksum": null
-            },
-            "https://raw.githubusercontent.com/duorc/duorc/master/dataset/SelfRC_dev.json": {
-                "num_bytes": 5051240,
-                "checksum": null
-            },
-            "https://raw.githubusercontent.com/duorc/duorc/master/dataset/SelfRC_test.json": {
-                "num_bytes": 5023228,
-                "checksum": null
-            }
-        },
-        "download_size": 34462660,
-        "dataset_size": 340657958,
-        "size_in_bytes": 375120618
-    }
+            "_type":"Sequence"
+         },
+         "no_answer":{
+            "dtype":"bool",
+            "_type":"Value"
+         }
+      },
+      "builder_name":"parquet",
+      "dataset_name":"duorc",
+      "config_name":"SelfRC",
+      "version":{
+         "version_str":"0.0.0",
+         "major":0,
+         "minor":0,
+         "patch":0
+      },
+      "splits":{
+         "train":{
+            "name":"train",
+            "num_bytes":248966361,
+            "num_examples":60721,
+            "dataset_name":null
+         },
+         "validation":{
+            "name":"validation",
+            "num_bytes":56359392,
+            "num_examples":12961,
+            "dataset_name":null
+         },
+         "test":{
+            "name":"test",
+            "num_bytes":51022318,
+            "num_examples":12559,
+            "dataset_name":null
+         }
+      },
+      "download_size":21001846,
+      "dataset_size":356348071
+   },
+   "partial":false
 }
 ```

--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -1767,37 +1767,37 @@
                 },
                 "examples": {
                   "all splits in a dataset": {
-                    "summary": "duorc: two configs, six splits",
-                    "description": "Try with https://datasets-server.huggingface.co/splits?dataset=duorc.",
+                    "summary": "ibm/duorc: two configs, six splits",
+                    "description": "Try with https://datasets-server.huggingface.co/splits?dataset=ibm/duorc.",
                     "value": {
                       "splits": [
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "ParaphraseRC",
                           "split": "train"
                         },
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "ParaphraseRC",
                           "split": "validation"
                         },
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "ParaphraseRC",
                           "split": "test"
                         },
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "SelfRC",
                           "split": "train"
                         },
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "SelfRC",
                           "split": "validation"
                         },
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "SelfRC",
                           "split": "test"
                         }
@@ -4111,54 +4111,54 @@
                 "examples": {
                   "duorc": {
                     "summary": "duorc: six parquet files, one per split",
-                    "description": "Try with https://datasets-server.huggingface.co/parquet?dataset=duorc",
+                    "description": "Try with https://datasets-server.huggingface.co/parquet?dataset=ibm/duorc",
                     "value": {
                       "parquet_files": [
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "ParaphraseRC",
                           "split": "test",
-                          "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/test/0000.parquet",
+                          "url": "https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/test/0000.parquet",
                           "filename": "duorc-test.parquet",
                           "size": 6136591
                         },
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "ParaphraseRC",
                           "split": "train",
-                          "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/train/0000.parquet",
+                          "url": "https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/train/0000.parquet",
                           "filename": "duorc-train.parquet",
                           "size": 26005668
                         },
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "ParaphraseRC",
                           "split": "validation",
-                          "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/validation/0000.parquet",
+                          "url": "https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/validation/0000.parquet",
                           "filename": "duorc-validation.parquet",
                           "size": 5566868
                         },
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "SelfRC",
                           "split": "test",
-                          "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/SelfRC/test/0000.parquet",
+                          "url": "https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/SelfRC/test/0000.parquet",
                           "filename": "duorc-test.parquet",
                           "size": 3035736
                         },
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "SelfRC",
                           "split": "train",
-                          "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/SelfRC/train/0000.parquet",
+                          "url": "https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/SelfRC/train/0000.parquet",
                           "filename": "duorc-train.parquet",
                           "size": 14851720
                         },
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "SelfRC",
                           "split": "validation",
-                          "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/SelfRC/validation/0000.parquet",
+                          "url": "https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/SelfRC/validation/0000.parquet",
                           "filename": "duorc-validation.parquet",
                           "size": 3114390
                         }
@@ -4170,30 +4170,30 @@
                   },
                   "duorc with ParaphraseRC config": {
                     "summary": "duorc: three parquet files for ParaphraseRC, one per split",
-                    "description": "Try with https://datasets-server.huggingface.co/parquet?dataset=duorc&config=ParaphraseRC",
+                    "description": "Try with https://datasets-server.huggingface.co/parquet?dataset=ibm/duorc&config=ParaphraseRC",
                     "value": {
                       "parquet_files": [
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "ParaphraseRC",
                           "split": "test",
-                          "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/test/0000.parquet",
+                          "url": "https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/test/0000.parquet",
                           "filename": "duorc-test.parquet",
                           "size": 6136591
                         },
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "ParaphraseRC",
                           "split": "train",
-                          "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/train/0000.parquet",
+                          "url": "https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/train/0000.parquet",
                           "filename": "duorc-train.parquet",
                           "size": 26005668
                         },
                         {
-                          "dataset": "duorc",
+                          "dataset": "ibm/duorc",
                           "config": "ParaphraseRC",
                           "split": "validation",
-                          "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/validation/0000.parquet",
+                          "url": "https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/validation/0000.parquet",
                           "filename": "duorc-validation.parquet",
                           "size": 5566868
                         }

--- a/docs/source/parquet.mdx
+++ b/docs/source/parquet.mdx
@@ -17,7 +17,7 @@ The `/parquet` endpoint accepts the dataset name as its query parameter:
 ```python
 import requests
 headers = {"Authorization": f"Bearer {API_TOKEN}"}
-API_URL = "https://datasets-server.huggingface.co/parquet?dataset=duorc"
+API_URL = "https://datasets-server.huggingface.co/parquet?dataset=ibm/duorc"
 def query():
     response = requests.get(API_URL, headers=headers)
     return response.json()
@@ -29,7 +29,7 @@ data = query()
 import fetch from "node-fetch";
 async function query(data) {
     const response = await fetch(
-        "https://datasets-server.huggingface.co/parquet?dataset=duorc",
+        "https://datasets-server.huggingface.co/parquet?dataset=ibm/duorc",
         {
             headers: { Authorization: `Bearer ${API_TOKEN}` },
             method: "GET"
@@ -45,69 +45,76 @@ query().then((response) => {
 </js>
 <curl>
 ```curl
-curl https://datasets-server.huggingface.co/parquet?dataset=duorc \
+curl https://datasets-server.huggingface.co/parquet?dataset=ibm/duorc \
         -X GET \
         -H "Authorization: Bearer ${API_TOKEN}"
 ```
 </curl>
 </inferencesnippet>
 
-The endpoint response is a JSON containing a list of the dataset's files in the Parquet format. For example, the [`duorc`](https://huggingface.co/datasets/duorc) dataset has six Parquet files, which corresponds to the `test`, `train` and `validation` splits of its two configurations, `ParaphraseRC` and `SelfRC` (see the [List splits and configurations](./splits) guide for more details about splits and configurations).
+The endpoint response is a JSON containing a list of the dataset's files in the Parquet format. For example, the [`ibm/duorc`](https://huggingface.co/datasets/ibm/duorc) dataset has six Parquet files, which corresponds to the `test`, `train` and `validation` splits of its two configurations, `ParaphraseRC` and `SelfRC` (see the [List splits and configurations](./splits) guide for more details about splits and configurations).
 
 The endpoint also gives the filename and size of each file:
 
 ```json
 {
-  "parquet_files": [
-    {
-      "dataset": "duorc",
-      "config": "ParaphraseRC",
-      "split": "test",
-      "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/test/0000.parquet",
-      "filename": "0000.parquet",
-      "size": 6136590
-    },
-    {
-      "dataset": "duorc",
-      "config": "ParaphraseRC",
-      "split": "train",
-      "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/train/0000.parquet",
-      "filename": "0000.parquet",
-      "size": 26005667
-    },
-    {
-      "dataset": "duorc",
-      "config": "ParaphraseRC",
-      "split": "validation",
-      "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/validation/0000.parquet",
-      "filename": "0000.parquet",
-      "size": 5566867
-    },
-    {
-      "dataset": "duorc",
-      "config": "SelfRC",
-      "split": "test",
-      "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/SelfRC/test/0000.parquet",
-      "filename": "0000.parquet",
-      "size": 3035735
-    },
-    {
-      "dataset": "duorc",
-      "config": "SelfRC",
-      "split": "train",
-      "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/SelfRC/train/0000.parquet",
-      "filename": "0000.parquet",
-      "size": 14851719
-    },
-    {
-      "dataset": "duorc",
-      "config": "SelfRC",
-      "split": "validation",
-      "url": "https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/SelfRC/validation/0000.parquet",
-      "filename": "0000.parquet",
-      "size": 3114389
-    }
-  ]
+   "parquet_files":[
+      {
+         "dataset":"ibm/duorc",
+         "config":"ParaphraseRC",
+         "split":"test",
+         "url":"https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/test/0000.parquet",
+         "filename":"0000.parquet",
+         "size":6136591
+      },
+      {
+         "dataset":"ibm/duorc",
+         "config":"ParaphraseRC",
+         "split":"train",
+         "url":"https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/train/0000.parquet",
+         "filename":"0000.parquet",
+         "size":26005668
+      },
+      {
+         "dataset":"ibm/duorc",
+         "config":"ParaphraseRC",
+         "split":"validation",
+         "url":"https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/validation/0000.parquet",
+         "filename":"0000.parquet",
+         "size":5566868
+      },
+      {
+         "dataset":"ibm/duorc",
+         "config":"SelfRC",
+         "split":"test",
+         "url":"https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/SelfRC/test/0000.parquet",
+         "filename":"0000.parquet",
+         "size":3035736
+      },
+      {
+         "dataset":"ibm/duorc",
+         "config":"SelfRC",
+         "split":"train",
+         "url":"https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/SelfRC/train/0000.parquet",
+         "filename":"0000.parquet",
+         "size":14851720
+      },
+      {
+         "dataset":"ibm/duorc",
+         "config":"SelfRC",
+         "split":"validation",
+         "url":"https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/SelfRC/validation/0000.parquet",
+         "filename":"0000.parquet",
+         "size":3114390
+      }
+   ],
+   "pending":[
+      
+   ],
+   "failed":[
+      
+   ],
+   "partial":false
 }
 ```
 
@@ -117,50 +124,55 @@ Big datasets are partitioned into Parquet files (shards) of about 500MB each. Th
 
 ```json
 {
-  "parquet_files": [
-    {
-      "dataset": "amazon_polarity",
-      "config": "amazon_polarity",
-      "split": "test",
-      "url": "https://huggingface.co/datasets/amazon_polarity/resolve/refs%2Fconvert%2Fparquet/amazon_polarity/test/0000.parquet",
-      "filename": "0000.parquet",
-      "size": 117422359
-    },
-    {
-      "dataset": "amazon_polarity",
-      "config": "amazon_polarity",
-      "split": "train",
-      "url": "https://huggingface.co/datasets/amazon_polarity/resolve/refs%2Fconvert%2Fparquet/amazon_polarity/train/0000.parquet",
-      "filename": "0000.parquet",
-      "size": 320281121
-    },
-    {
-      "dataset": "amazon_polarity",
-      "config": "amazon_polarity",
-      "split": "train",
-      "url": "https://huggingface.co/datasets/amazon_polarity/resolve/refs%2Fconvert%2Fparquet/amazon_polarity/train/0001.parquet",
-      "filename": "0001.parquet",
-      "size": 320627716
-    },
-    {
-      "dataset": "amazon_polarity",
-      "config": "amazon_polarity",
-      "split": "train",
-      "url": "https://huggingface.co/datasets/amazon_polarity/resolve/refs%2Fconvert%2Fparquet/amazon_polarity/train/0002.parquet",
-      "filename": "0002.parquet",
-      "size": 320587882
-    },
-    {
-      "dataset": "amazon_polarity",
-      "config": "amazon_polarity",
-      "split": "train",
-      "url": "https://huggingface.co/datasets/amazon_polarity/resolve/refs%2Fconvert%2Fparquet/amazon_polarity/train/0003.parquet",
-      "filename": "0003.parquet",
-      "size": 66515954
-    }
-  ],
-  "pending": [],
-  "failed": []
+   "parquet_files":[
+      {
+         "dataset":"amazon_polarity",
+         "config":"amazon_polarity",
+         "split":"test",
+         "url":"https://huggingface.co/datasets/amazon_polarity/resolve/refs%2Fconvert%2Fparquet/amazon_polarity/test/0000.parquet",
+         "filename":"0000.parquet",
+         "size":117422360
+      },
+      {
+         "dataset":"amazon_polarity",
+         "config":"amazon_polarity",
+         "split":"train",
+         "url":"https://huggingface.co/datasets/amazon_polarity/resolve/refs%2Fconvert%2Fparquet/amazon_polarity/train/0000.parquet",
+         "filename":"0000.parquet",
+         "size":259761770
+      },
+      {
+         "dataset":"amazon_polarity",
+         "config":"amazon_polarity",
+         "split":"train",
+         "url":"https://huggingface.co/datasets/amazon_polarity/resolve/refs%2Fconvert%2Fparquet/amazon_polarity/train/0001.parquet",
+         "filename":"0001.parquet",
+         "size":258363554
+      },
+      {
+         "dataset":"amazon_polarity",
+         "config":"amazon_polarity",
+         "split":"train",
+         "url":"https://huggingface.co/datasets/amazon_polarity/resolve/refs%2Fconvert%2Fparquet/amazon_polarity/train/0002.parquet",
+         "filename":"0002.parquet",
+         "size":255471883
+      },
+      {
+         "dataset":"amazon_polarity",
+         "config":"amazon_polarity",
+         "split":"train",
+         "url":"https://huggingface.co/datasets/amazon_polarity/resolve/refs%2Fconvert%2Fparquet/amazon_polarity/train/0003.parquet",
+         "filename":"0003.parquet",
+         "size":254410930
+      }
+   ],
+   "pending":[
+      
+   ],
+   "failed":[
+      
+   ],
+   "partial":false
 }
 ```
 
@@ -185,7 +197,7 @@ For convenience, you can directly use the Hugging Face Hub `/api/parquet` endpoi
 ```python
 import requests
 headers = {"Authorization": f"Bearer {API_TOKEN}"}
-API_URL = "https://huggingface.co/api/datasets/duorc/parquet"
+API_URL = "https://huggingface.co/api/datasets/ibm/duorc/parquet"
 def query():
     response = requests.get(API_URL, headers=headers)
     return response.json()
@@ -197,7 +209,7 @@ urls = query()
 import fetch from "node-fetch";
 async function query(data) {
     const response = await fetch(
-        "https://huggingface.co/api/datasets/duorc/parquet",
+        "https://huggingface.co/api/datasets/ibm/duorc/parquet",
         {
             headers: { Authorization: `Bearer ${API_TOKEN}` },
             method: "GET"
@@ -213,39 +225,39 @@ query().then((response) => {
 </js>
 <curl>
 ```curl
-curl https://huggingface.co/api/datasets/duorc/parquet \
+curl https://huggingface.co/api/datasets/ibm/duorc/parquet \
         -X GET \
         -H "Authorization: Bearer ${API_TOKEN}"
 ```
 </curl>
 </inferencesnippet>
 
-The endpoint response is a JSON containing a list of the dataset's files URLs in the Parquet format for each split and configuration. For example, the [`duorc`](https://huggingface.co/datasets/duorc) dataset has one Parquet file for the train split of the "ParaphraseRC" configuration (see the [List splits and configurations](./splits) guide for more details about splits and configurations).
+The endpoint response is a JSON containing a list of the dataset's files URLs in the Parquet format for each split and configuration. For example, the [`ibm/duorc`](https://huggingface.co/datasets/ibm/duorc) dataset has one Parquet file for the train split of the "ParaphraseRC" configuration (see the [List splits and configurations](./splits) guide for more details about splits and configurations).
 
 ```json
 {
-  "ParaphraseRC": {
-    "test": [
-      "https://huggingface.co/api/datasets/duorc/parquet/ParaphraseRC/test/0.parquet"
-    ],
-    "train": [
-      "https://huggingface.co/api/datasets/duorc/parquet/ParaphraseRC/train/0.parquet"
-    ],
-    "validation": [
-      "https://huggingface.co/api/datasets/duorc/parquet/ParaphraseRC/validation/0.parquet"
-    ]
-  },
-  "SelfRC": {
-    "test": [
-      "https://huggingface.co/api/datasets/duorc/parquet/SelfRC/test/0.parquet"
-    ],
-    "train": [
-      "https://huggingface.co/api/datasets/duorc/parquet/SelfRC/train/0.parquet"
-    ],
-    "validation": [
-      "https://huggingface.co/api/datasets/duorc/parquet/SelfRC/validation/0.parquet"
-    ]
-  }
+   "ParaphraseRC":{
+      "test":[
+         "https://huggingface.co/api/datasets/ibm/duorc/parquet/ParaphraseRC/test/0.parquet"
+      ],
+      "train":[
+         "https://huggingface.co/api/datasets/ibm/duorc/parquet/ParaphraseRC/train/0.parquet"
+      ],
+      "validation":[
+         "https://huggingface.co/api/datasets/ibm/duorc/parquet/ParaphraseRC/validation/0.parquet"
+      ]
+   },
+   "SelfRC":{
+      "test":[
+         "https://huggingface.co/api/datasets/ibm/duorc/parquet/SelfRC/test/0.parquet"
+      ],
+      "train":[
+         "https://huggingface.co/api/datasets/ibm/duorc/parquet/SelfRC/train/0.parquet"
+      ],
+      "validation":[
+         "https://huggingface.co/api/datasets/ibm/duorc/parquet/SelfRC/validation/0.parquet"
+      ]
+   }
 }
 ```
 
@@ -256,7 +268,7 @@ Optionally you can specify which configuration name to return, as well as which 
 ```python
 import requests
 headers = {"Authorization": f"Bearer {API_TOKEN}"}
-API_URL = "https://huggingface.co/api/datasets/duorc/parquet/ParaphraseRC/train"
+API_URL = "https://huggingface.co/api/datasets/ibm/duorc/parquet/ParaphraseRC/train"
 def query():
     response = requests.get(API_URL, headers=headers)
     return response.json()
@@ -268,7 +280,7 @@ urls = query()
 import fetch from "node-fetch";
 async function query(data) {
     const response = await fetch(
-        "https://huggingface.co/api/datasets/duorc/parquet/ParaphraseRC/train",
+        "https://huggingface.co/api/datasets/ibm/duorc/parquet/ParaphraseRC/train",
         {
             headers: { Authorization: `Bearer ${API_TOKEN}` },
             method: "GET"
@@ -284,7 +296,7 @@ query().then((response) => {
 </js>
 <curl>
 ```curl
-curl https://huggingface.co/api/datasets/duorc/parquet/ParaphraseRC/train \
+curl https://huggingface.co/api/datasets/ibm/duorc/parquet/ParaphraseRC/train \
         -X GET \
         -H "Authorization: Bearer ${API_TOKEN}"
 ```
@@ -293,8 +305,8 @@ curl https://huggingface.co/api/datasets/duorc/parquet/ParaphraseRC/train \
 
 ```json
 [
-  "https://huggingface.co/api/datasets/duorc/parquet/ParaphraseRC/train/0.parquet"
+  "https://huggingface.co/api/datasets/ibm/duorc/parquet/ParaphraseRC/train/0.parquet"
 ]
 ```
 
-Each parquet file can also be accessed using its shard index: `https://huggingface.co/api/datasets/duorc/parquet/ParaphraseRC/train/0.parquet` redirects to `https://huggingface.co/datasets/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/train/0000.parquet` for example.
+Each parquet file can also be accessed using its shard index: `https://huggingface.co/api/datasets/ibm/duorc/parquet/ParaphraseRC/train/0.parquet` redirects to `https://huggingface.co/datasets/ibm/duorc/resolve/refs%2Fconvert%2Fparquet/ParaphraseRC/train/0000.parquet` for example.

--- a/docs/source/quick_start.mdx
+++ b/docs/source/quick_start.mdx
@@ -9,7 +9,10 @@ In this quickstart, you'll learn how to use the Datasets Server's REST API to:
 - Preview the first 100 rows of a dataset.
 - Download slices of rows of a dataset.
 - Search a word in a dataset.
+- Filter rows based on a query string.
 - Access the dataset as parquet files.
+- Get the dataset size (in number of rows or bytes).
+- Get statistics about the dataset.
 
 ## API endpoints
 
@@ -25,6 +28,7 @@ Each feature is served through an endpoint summarized in the table below:
 | [/filter](./filter)         | GET    | Filter rows in a dataset split.                         | - `dataset`: name of the dataset<br>- `config`: name of the config<br>- `split`: name of the split<br>- `where`: filter query<br>- `offset`: offset of the slice<br>- `length`: length of the slice (maximum 100) |
 | [/parquet](./parquet)       | GET    | Get the list of parquet files of a dataset.             | `dataset`: name of the dataset                                                                                                                                                                                    |
 | [/size](./size)             | GET    | Get the size of a dataset.                              | `dataset`: name of the dataset                                                                                                                                                                                    |
+| [/statistics](./statistics) | GET    | Get statistics about a dataset split.                   | - `dataset`: name of the dataset<br>- `config`: name of the config<br>- `split`: name of the split                                                                          |
 
 There is no installation or setup required to use Datasets Server.
 
@@ -372,7 +376,8 @@ The response looks like:
     ...
   ],
   "num_rows_total": 8530,
-  "num_rows_per_page": 100
+  "num_rows_per_page": 100,
+  "partial": false
 }
 ```
 
@@ -458,7 +463,8 @@ The response looks like:
     ...
   ],
   "num_rows_total": 12,
-  "num_rows_per_page": 100
+  "num_rows_per_page": 100,
+  "partial": false
 }
 ```
 
@@ -581,7 +587,7 @@ curl https://datasets-server.huggingface.co/size?dataset=rotten_tomatoes \
 </curl>
 </inferencesnippet>
 
-This returns a URL to the Parquet file for each split:
+This returns the size of the dataset, and for every configuration and split:
 
 ```json
 {

--- a/docs/source/rows.mdx
+++ b/docs/source/rows.mdx
@@ -32,7 +32,7 @@ The `/rows` endpoint accepts five query parameters:
 ```python
 import requests
 headers = {"Authorization": f"Bearer {API_TOKEN}"}
-API_URL = "https://datasets-server.huggingface.co/rows?dataset=duorc&config=SelfRC&split=train&offset=150&length=10"
+API_URL = "https://datasets-server.huggingface.co/rows?dataset=ibm/duorc&config=SelfRC&split=train&offset=150&length=10"
 def query():
     response = requests.get(API_URL, headers=headers)
     return response.json()
@@ -44,7 +44,7 @@ data = query()
 import fetch from "node-fetch";
 async function query(data) {
     const response = await fetch(
-        "https://datasets-server.huggingface.co/rows?dataset=duorc&config=SelfRC&split=train&offset=150&length=10",
+        "https://datasets-server.huggingface.co/rows?dataset=ibm/duorc&config=SelfRC&split=train&offset=150&length=10",
         {
             headers: { Authorization: `Bearer ${API_TOKEN}` },
             method: "GET"
@@ -60,7 +60,7 @@ query().then((response) => {
 </js>
 <curl>
 ```curl
-curl https://datasets-server.huggingface.co/rows?dataset=duorc&config=SelfRC&split=train&offset=150&length=10 \
+curl https://datasets-server.huggingface.co/rows?dataset=ibm/duorc&config=SelfRC&split=train&offset=150&length=10 \
         -X GET \
         -H "Authorization: Bearer ${API_TOKEN}"
 ```
@@ -72,10 +72,10 @@ The endpoint response is a JSON containing two keys:
 - The [`features`](https://huggingface.co/docs/datasets/about_dataset_features) of a dataset, including the column's name and data type.
 - The slice of `rows` of a dataset and the content contained in each column of a specific row.
 
-For example, here are the `features` and the slice of `rows` of the `duorc`/`SelfRC` train split from 150 to 151:
+For example, here are the `features` and the slice of `rows` of the `ibm/duorc`/`SelfRC` train split from 150 to 151:
 
 ```json
-// https://datasets-server.huggingface.co/rows?dataset=duorc&config=SelfRC&split=train&offset=150&length=2
+// https://datasets-server.huggingface.co/rows?dataset=ibm/duorc&config=SelfRC&split=train&offset=150&length=2
 {
   "features": [
     {
@@ -144,7 +144,10 @@ For example, here are the `features` and the slice of `rows` of the `duorc`/`Sel
       },
       "truncated_cells": []
     }
-  ]
+  ],
+  "num_rows_total":60721,
+  "num_rows_per_page":100,
+  "partial":false
 }
 ```
 
@@ -183,9 +186,15 @@ Here is an example of image, from the first row of the cifar100 dataset:
       },
       "truncated_cells": []
     }
-  ]
+  ],
+  "num_rows_total":50000,
+  "num_rows_per_page":100,
+  "partial":false
 }
 ```
+
+If the result has `partial: true` it means that the slices couldn't be run on the full dataset because it's too big.
+
 
 ### Caching
 

--- a/docs/source/search.mdx
+++ b/docs/source/search.mdx
@@ -22,14 +22,14 @@ The `/search` endpoint accepts five query parameters:
 - `offset`: the offset of the slice, for example `150`
 - `length`: the length of the slice, for example `10` (maximum: `100`)
 
-For example, let's search for the text `"dog"` in the `train` split of the `SelfRC` configuration of the `duorc` dataset, restricting the results to the slice 150-151:
+For example, let's search for the text `"dog"` in the `train` split of the `SelfRC` configuration of the `ibm/duorc` dataset, restricting the results to the slice 150-151:
 
 <inferencesnippet>
 <python>
 ```python
 import requests
 headers = {"Authorization": f"Bearer {API_TOKEN}"}
-API_URL = "https://datasets-server.huggingface.co/search?dataset=duorc&config=SelfRC&split=train&query=dog&offset=150&length=2"
+API_URL = "https://datasets-server.huggingface.co/search?dataset=ibm/duorc&config=SelfRC&split=train&query=dog&offset=150&length=2"
 def query():
     response = requests.get(API_URL, headers=headers)
     return response.json()
@@ -41,7 +41,7 @@ data = query()
 import fetch from "node-fetch";
 async function query(data) {
     const response = await fetch(
-        "https://datasets-server.huggingface.co/search?dataset=duorc&config=SelfRC&split=train&query=dog&offset=150&length=2",
+        "https://datasets-server.huggingface.co/search?dataset=ibm/duorc&config=SelfRC&split=train&query=dog&offset=150&length=2",
         {
             headers: { Authorization: `Bearer ${API_TOKEN}` },
             method: "GET"
@@ -57,7 +57,7 @@ query().then((response) => {
 </js>
 <curl>
 ```curl
-curl https://datasets-server.huggingface.co/search?dataset=duorc&config=SelfRC&split=train&query=dog&offset=150&length=2 \
+curl https://datasets-server.huggingface.co/search?dataset=ibm/duorc&config=SelfRC&split=train&query=dog&offset=150&length=2 \
         -X GET \
         -H "Authorization: Bearer ${API_TOKEN}"
 ```

--- a/docs/source/size.mdx
+++ b/docs/source/size.mdx
@@ -9,7 +9,7 @@ The `/size` endpoint accepts the dataset name as its query parameter:
 ```python
 import requests
 headers = {"Authorization": f"Bearer {API_TOKEN}"}
-API_URL = "https://datasets-server.huggingface.co/size?dataset=duorc"
+API_URL = "https://datasets-server.huggingface.co/size?dataset=ibm/duorc"
 def query():
     response = requests.get(API_URL, headers=headers)
     return response.json()
@@ -21,7 +21,7 @@ data = query()
 import fetch from "node-fetch";
 async function query(data) {
     const response = await fetch(
-        "https://datasets-server.huggingface.co/size?dataset=duorc",
+        "https://datasets-server.huggingface.co/size?dataset=ibm/duorc",
         {
             headers: { Authorization: `Bearer ${API_TOKEN}` },
             method: "GET"
@@ -37,105 +37,109 @@ query().then((response) => {
 </js>
 <curl>
 ```curl
-curl https://datasets-server.huggingface.co/size?dataset=duorc \
+curl https://datasets-server.huggingface.co/size?dataset=ibm/duorc \
         -X GET \
         -H "Authorization: Bearer ${API_TOKEN}"
 ```
 </curl>
 </inferencesnippet>
 
-The endpoint response is a JSON containing the size of the dataset, as well as each of its configurations and splits. It provides the number of rows, the number of colums (where applicable) and the size in bytes for the different forms of the data: original files, size in memory (RAM) and auto-converted parquet files. For example, the [duorc](https://huggingface.co/datasets/duorc) dataset has 187.213 rows along all its configurations and splits, for a total of 97MB.
+The endpoint response is a JSON containing the size of the dataset, as well as each of its configurations and splits. It provides the number of rows, the number of colums (where applicable) and the size in bytes for the different forms of the data: original files, size in memory (RAM) and auto-converted parquet files. For example, the [ibm/duorc](https://huggingface.co/datasets/ibm/duorc) dataset has 187.213 rows along all its configurations and splits, for a total of 97MB.
 
 ```json
 {
-  "size": {
-    "dataset": {
-      "dataset": "duorc",
-      "num_bytes_original_files": 97383710,
-      "num_bytes_parquet_files": 58710973,
-      "num_bytes_memory": 1059067116,
-      "num_rows": 187213
-    },
-    "configs": [
-      {
-        "dataset": "duorc",
-        "config": "ParaphraseRC",
-        "num_bytes_original_files": 62921050,
-        "num_bytes_parquet_files": 37709127,
-        "num_bytes_memory": 718409158,
-        "num_rows": 100972,
-        "num_columns": 7
+   "size":{
+      "dataset":{
+         "dataset":"ibm/duorc",
+         "num_bytes_original_files":58710973,
+         "num_bytes_parquet_files":58710973,
+         "num_bytes_memory":1060742354,
+         "num_rows":187213
       },
-      {
-        "dataset": "duorc",
-        "config": "SelfRC",
-        "num_bytes_original_files": 34462660,
-        "num_bytes_parquet_files": 21001846,
-        "num_bytes_memory": 340657958,
-        "num_rows": 86241,
-        "num_columns": 7
-      }
-    ],
-    "splits": [
-      {
-        "dataset": "duorc",
-        "config": "ParaphraseRC",
-        "split": "train",
-        "num_bytes_parquet_files": 26005668,
-        "num_bytes_memory": 496682909,
-        "num_rows": 69524,
-        "num_columns": 7
-      },
-      {
-        "dataset": "duorc",
-        "config": "ParaphraseRC",
-        "split": "validation",
-        "num_bytes_parquet_files": 5566868,
-        "num_bytes_memory": 106510489,
-        "num_rows": 15591,
-        "num_columns": 7
-      },
-      {
-        "dataset": "duorc",
-        "config": "ParaphraseRC",
-        "split": "test",
-        "num_bytes_parquet_files": 6136591,
-        "num_bytes_memory": 115215760,
-        "num_rows": 15857,
-        "num_columns": 7
-      },
-      {
-        "dataset": "duorc",
-        "config": "SelfRC",
-        "split": "train",
-        "num_bytes_parquet_files": 14851720,
-        "num_bytes_memory": 239852729,
-        "num_rows": 60721,
-        "num_columns": 7
-      },
-      {
-        "dataset": "duorc",
-        "config": "SelfRC",
-        "split": "validation",
-        "num_bytes_parquet_files": 3114390,
-        "num_bytes_memory": 51662519,
-        "num_rows": 12961,
-        "num_columns": 7
-      },
-      {
-        "dataset": "duorc",
-        "config": "SelfRC",
-        "split": "test",
-        "num_bytes_parquet_files": 3035736,
-        "num_bytes_memory": 49142710,
-        "num_rows": 12559,
-        "num_columns": 7
-      }
-    ]
-  },
-  "pending": [],
-  "failed": [],
-  "partial": false
+      "configs":[
+         {
+            "dataset":"ibm/duorc",
+            "config":"ParaphraseRC",
+            "num_bytes_original_files":37709127,
+            "num_bytes_parquet_files":37709127,
+            "num_bytes_memory":704394283,
+            "num_rows":100972,
+            "num_columns":7
+         },
+         {
+            "dataset":"ibm/duorc",
+            "config":"SelfRC",
+            "num_bytes_original_files":21001846,
+            "num_bytes_parquet_files":21001846,
+            "num_bytes_memory":356348071,
+            "num_rows":86241,
+            "num_columns":7
+         }
+      ],
+      "splits":[
+         {
+            "dataset":"ibm/duorc",
+            "config":"ParaphraseRC",
+            "split":"train",
+            "num_bytes_parquet_files":26005668,
+            "num_bytes_memory":494389683,
+            "num_rows":69524,
+            "num_columns":7
+         },
+         {
+            "dataset":"ibm/duorc",
+            "config":"ParaphraseRC",
+            "split":"validation",
+            "num_bytes_parquet_files":5566868,
+            "num_bytes_memory":106733319,
+            "num_rows":15591,
+            "num_columns":7
+         },
+         {
+            "dataset":"ibm/duorc",
+            "config":"ParaphraseRC",
+            "split":"test",
+            "num_bytes_parquet_files":6136591,
+            "num_bytes_memory":103271281,
+            "num_rows":15857,
+            "num_columns":7
+         },
+         {
+            "dataset":"ibm/duorc",
+            "config":"SelfRC",
+            "split":"train",
+            "num_bytes_parquet_files":14851720,
+            "num_bytes_memory":248966361,
+            "num_rows":60721,
+            "num_columns":7
+         },
+         {
+            "dataset":"ibm/duorc",
+            "config":"SelfRC",
+            "split":"validation",
+            "num_bytes_parquet_files":3114390,
+            "num_bytes_memory":56359392,
+            "num_rows":12961,
+            "num_columns":7
+         },
+         {
+            "dataset":"ibm/duorc",
+            "config":"SelfRC",
+            "split":"test",
+            "num_bytes_parquet_files":3035736,
+            "num_bytes_memory":51022318,
+            "num_rows":12559,
+            "num_columns":7
+         }
+      ]
+   },
+   "pending":[
+      
+   ],
+   "failed":[
+      
+   ],
+   "partial":false
 }
 ```
 

--- a/docs/source/splits.mdx
+++ b/docs/source/splits.mdx
@@ -11,7 +11,7 @@ The `/splits` endpoint accepts the dataset name as its query parameter:
 ```python
 import requests
 headers = {"Authorization": f"Bearer {API_TOKEN}"}
-API_URL = "https://datasets-server.huggingface.co/splits?dataset=duorc"
+API_URL = "https://datasets-server.huggingface.co/splits?dataset=ibm/duorc"
 def query():
     response = requests.get(API_URL, headers=headers)
     return response.json()
@@ -23,7 +23,7 @@ data = query()
 import fetch from "node-fetch";
 async function query(data) {
     const response = await fetch(
-        "https://datasets-server.huggingface.co/splits?dataset=duorc",
+        "https://datasets-server.huggingface.co/splits?dataset=ibm/duorc",
         {
             headers: { Authorization: `Bearer ${API_TOKEN}` },
             method: "GET"
@@ -39,24 +39,24 @@ query().then((response) => {
 </js>
 <curl>
 ```curl
-curl https://datasets-server.huggingface.co/splits?dataset=duorc \
+curl https://datasets-server.huggingface.co/splits?dataset=ibm/duorc \
         -X GET \
         -H "Authorization: Bearer ${API_TOKEN}"
 ```
 </curl>
 </inferencesnippet>
 
-The endpoint response is a JSON containing a list of the dataset's splits and configurations. For example, the [duorc](https://huggingface.co/datasets/duorc) dataset has six splits and two configurations:
+The endpoint response is a JSON containing a list of the dataset's splits and configurations. For example, the [ibm/duorc](https://huggingface.co/datasets/ibm/duorc) dataset has six splits and two configurations:
 
 ```json
 {
   "splits": [
-    { "dataset": "duorc", "config": "ParaphraseRC", "split": "train" },
-    { "dataset": "duorc", "config": "ParaphraseRC", "split": "validation" },
-    { "dataset": "duorc", "config": "ParaphraseRC", "split": "test" },
-    { "dataset": "duorc", "config": "SelfRC", "split": "train" },
-    { "dataset": "duorc", "config": "SelfRC", "split": "validation" },
-    { "dataset": "duorc", "config": "SelfRC", "split": "test" }
+    { "dataset": "ibm/duorc", "config": "ParaphraseRC", "split": "train" },
+    { "dataset": "ibm/duorc", "config": "ParaphraseRC", "split": "validation" },
+    { "dataset": "ibm/duorc", "config": "ParaphraseRC", "split": "test" },
+    { "dataset": "ibm/duorc", "config": "SelfRC", "split": "train" },
+    { "dataset": "ibm/duorc", "config": "SelfRC", "split": "validation" },
+    { "dataset": "ibm/duorc", "config": "SelfRC", "split": "test" }
   ],
   "pending": [],
   "failed": []

--- a/docs/source/valid.mdx
+++ b/docs/source/valid.mdx
@@ -65,7 +65,31 @@ The response looks like this if a dataset is valid:
 ```json
 {
   "viewer": true,
-  "preview": true
+  "preview": true,
+  "search": true,
+  "filter": true,
+}
+```
+
+The response looks like this if a dataset is valid but /search is not available for it:
+
+```json
+{
+  "viewer": true,
+  "preview": true,
+  "search": false,
+  "filter": true,
+}
+```
+
+The response looks like this if a dataset is valid but /filter is not available for it:
+
+```json
+{
+  "viewer": true,
+  "preview": true,
+  "search": true,
+  "filter": false,
 }
 ```
 
@@ -74,7 +98,9 @@ If only the first rows of a dataset are available, then the response looks like:
 ```json
 {
   "viewer": false,
-  "preview": true
+  "preview": true,
+  "search": true,
+  "filter": true,
 }
 ```
 
@@ -83,7 +109,9 @@ Finally, if the dataset is not valid at all, then the response is:
 ```json
 {
   "viewer": false,
-  "preview": false
+  "preview": false,
+  "search": false,
+  "filter": false,
 }
 ```
 

--- a/e2e/tests/test_12_splits.py
+++ b/e2e/tests/test_12_splits.py
@@ -9,7 +9,7 @@ from .utils import get, get_openapi_body_example, poll, poll_splits, post_refres
 @pytest.mark.parametrize(
     "status,name,dataset,config,error_code",
     [
-        #  (200, "all splits in a dataset", "duorc", None, None),
+        #  (200, "all splits in a dataset", "ibm/duorc", None, None),
         #  (200, "splits for a single config", "emotion", "unsplit", None)
         (
             401,
@@ -64,7 +64,7 @@ def test_splits_using_openapi(status: int, name: str, dataset: str, config: str,
 @pytest.mark.parametrize(
     "status,dataset,config,error_code",
     [
-        # (200, "duorc", "SelfRC", None),
+        # (200, "ibm/duorc", "SelfRC", None),
         (401, "missing-parameter", None, "ExternalUnauthenticatedError")
         # missing config will result in asking dataset but it does not exist
     ],


### PR DESCRIPTION
Update minor details in the doc:
- partial field for some responses
- filter example
- rename `duorc` by `ibm/duorc` instead (even though the hub redirects to the correct organization, datasets-server API does not)

Note.- I haven't update yet `Server infrastructure` page, I will do it in another PR 