### PR TITLE
Fix filter no features in duckdb index cache

### DIFF
--- a/libs/libapi/src/libapi/response.py
+++ b/libs/libapi/src/libapi/response.py
@@ -34,7 +34,11 @@ async def create_response(
         )
     logging.debug(f"create response for {dataset=} {config=} {split=}")
     return {
-        "features": to_features_list(features),
+        "features": [
+            feature_item
+            for feature_item in to_features_list(features)
+            if not use_row_idx_column or feature_item["name"] != ROW_IDX_COLUMN
+        ],
         "rows": await to_rows_list(
             pa_table=pa_table,
             dataset=dataset,

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -138,6 +138,10 @@ def create_filter_endpoint(
                         hf_token=hf_token,
                     )
                 with StepProfiler(method="filter_endpoint", step="get features"):
+                    # Features can be missing in old cache entries,
+                    # but in this case it's ok to get them from the Arrow schema.
+                    # Indded at one point we refreshed all the datasets that need the features
+                    # to be cached (i.e. image and audio datasets).
                     if "features" in duckdb_index_cache_entry["content"] and isinstance(
                         duckdb_index_cache_entry["content"]["features"], dict
                     ):

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -166,7 +166,7 @@ def create_filter_endpoint(
                         storage_client=cached_assets_storage_client,
                         pa_table=pa_table,
                         offset=offset,
-                        features=features,
+                        features=features or Features.from_arrow_schema(pa_table.schema),
                         unsupported_columns=unsupported_columns,
                         num_rows_total=num_rows_total,
                         partial=partial,

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -203,6 +203,10 @@ def create_search_endpoint(
                     )
 
                 with StepProfiler(method="search_endpoint", step="create response"):
+                    # Features can be missing in old cache entries,
+                    # but in this case it's ok to get them from the Arrow schema.
+                    # Indded at one point we refreshed all the datasets that need the features
+                    # to be cached (i.e. image and audio datasets).
                     if "features" in duckdb_index_cache_entry["content"] and isinstance(
                         duckdb_index_cache_entry["content"]["features"], dict
                     ):

--- a/services/search/tests/routes/test_filter.py
+++ b/services/search/tests/routes/test_filter.py
@@ -4,13 +4,14 @@
 import os
 from collections.abc import Generator
 from pathlib import Path
+from typing import Literal, Union
 
 import duckdb
 import pyarrow as pa
 import pytest
 from datasets import Dataset
 from libapi.exceptions import InvalidParameterError
-from libapi.response import create_response
+from libapi.response import ROW_IDX_COLUMN, create_response
 from libcommon.storage_client import StorageClient
 
 from search.config import AppConfig
@@ -71,13 +72,18 @@ def test_validate_where_parameter_raises(where: str) -> None:
         validate_where_parameter(where)
 
 
-def test_execute_filter_query(index_file_location: str) -> None:
-    columns, where, limit, offset = ["name", "age"], "gender='female'", 1, 1
+@pytest.mark.parametrize("columns", ["*", ["name", "age"]])
+def test_execute_filter_query(index_file_location: str, columns: Union[list[str], Literal["*"]]) -> None:
+    where, limit, offset = "gender='female'", 1, 1
     num_rows_total, pa_table = execute_filter_query(
         index_file_location=index_file_location, columns=columns, where=where, limit=limit, offset=offset
     )
     assert num_rows_total == 2
-    assert pa_table == pa.Table.from_pydict({"__hf_index_id": [3], "name": ["Simone"], "age": [30]})
+    expected = pa.Table.from_pydict({"__hf_index_id": [3], "name": ["Simone"], "gender": ["female"], "age": [30]})
+    if isinstance(columns, list):
+        for column in set(expected.column_names) - set([ROW_IDX_COLUMN] + columns):
+            expected = expected.drop(column)
+    assert pa_table == expected
 
 
 @pytest.mark.parametrize("where", ["non-existing-column=30", "name=30", "name>30"])


### PR DESCRIPTION
fix https://huggingface.co/datasets/fka/awesome-chatgpt-prompts/viewer/default/train?f[act][min]=4&f[act][max]=8&f[act][transform]=length

![image](https://github.com/huggingface/datasets-server/assets/42851186/3c279643-04c8-4e08-8185-6c947d4a8274)

This was caused by `RuntimeError: The indexing process did not store the features.`