### PR TITLE
catch ValueError before ImportError

### DIFF
--- a/services/worker/src/worker/job_runners/dataset/config_names.py
+++ b/services/worker/src/worker/job_runners/dataset/config_names.py
@@ -75,17 +75,20 @@ def compute_config_names_response(
         ]
     except _EmptyDatasetError as err:
         raise EmptyDatasetError("The dataset is empty.", cause=err) from err
-    except ImportError as err:
-        raise DatasetModuleNotInstalledError(
-            "The dataset tries to import a module that is not installed.", cause=err
-        ) from err
-    except Exception as err:
-        if isinstance(err, ValueError) and "trust_remote_code" in str(err):
+    except ValueError as err:
+        if "trust_remote_code" in str(err):
             raise DatasetWithScriptNotSupportedError(
                 "The dataset viewer doesn't support this dataset because it runs "
                 "arbitrary python code. Please open a discussion in the discussion tab "
                 "if you think this is an error and tag @lhoestq and @severo."
             ) from err
+        raise ConfigNamesError("Cannot get the config names for the dataset.", cause=err) from err
+    except ImportError as err:
+        # this should only happen if the dataset is in the allow list, which should soon disappear
+        raise DatasetModuleNotInstalledError(
+            "The dataset tries to import a module that is not installed.", cause=err
+        ) from err
+    except Exception as err:
         raise ConfigNamesError("Cannot get the config names for the dataset.", cause=err) from err
 
     number_of_configs = len(config_name_items)


### PR DESCRIPTION
fixes #2385 

I didn't increment the job runner version, because it only happen in 235 datasets. We will update them manually.

```
db.cachedResponsesBlue.countDocuments({error_code: "DatasetWithScriptNotSupportedError", kind: "dataset-config-names"})
235
```