### PR TITLE
requirements.txt is used by spaces, pyproject.yaml is ignored

### DIFF
--- a/front/admin_ui/README.md
+++ b/front/admin_ui/README.md
@@ -4,7 +4,7 @@ emoji: 📊
 colorFrom: gray
 colorTo: purple
 sdk: gradio
-sdk_version: 4.16.0
+sdk_version: 4.18.0
 python_version: 3.9.18
 app_file: app.py
 pinned: false

--- a/front/admin_ui/requirements.txt
+++ b/front/admin_ui/requirements.txt
@@ -1,4 +1,4 @@
-gradio==4.16.0
+gradio>=4.17.0,<5
 libcommon @ git+https://github.com/huggingface/datasets-server@main#subdirectory=libs/libcommon
 matplotlib>=3.7.0
 pygraphviz==1.10


### PR DESCRIPTION
follows #2445. cc @albertvillanova fyi. I already did the same error... We should find a way to have only one source of truth for the packages, instead of ... 3!