### PR TITLE
remove obsolete error code

### DIFF
--- a/libs/libcommon/src/libcommon/constants.py
+++ b/libs/libcommon/src/libcommon/constants.py
@@ -37,7 +37,6 @@ PARQUET_REVISION = "refs/convert/parquet"
 
 ERROR_CODES_TO_RETRY = {
     "ConnectionError",
-    "SplitWithTooBigParquetError",  # TODO: to be removed after cache with this error is recomputed
     "CreateCommitError",
     "ExternalServerError",
     "JobManagerCrashedError",


### PR DESCRIPTION
Follows #2227

To be merged next week, when all the occurrences will have been recomputed.

Currently:

```
use datasets_server_cache
db.cachedResponsesBlue.countDocuments({kind: "split-descriptive-statistics", error_code: "SplitWithTooBigParquetError"})
2937
```
