### PR TITLE
Update GitHub Actions to Node 20

### DIFF
--- a/.github/workflows/_e2e_tests.yml
+++ b/.github/workflows/_e2e_tests.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry==${{ env.poetry-version }}
       - name: Use Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.python-version }}
           cache: "poetry"

--- a/.github/workflows/_quality-python.yml
+++ b/.github/workflows/_quality-python.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry==${{ env.poetry-version }}
       - name: Use Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.python-version }}
           cache: "poetry"

--- a/.github/workflows/_unit-tests-python.yml
+++ b/.github/workflows/_unit-tests-python.yml
@@ -72,3 +72,4 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
           flags: ${{ env.codecov_flag }}
+          token: ${{ secrets.CODECOV_TOKEN }} # required in v4

--- a/.github/workflows/_unit-tests-python.yml
+++ b/.github/workflows/_unit-tests-python.yml
@@ -72,4 +72,5 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
           flags: ${{ env.codecov_flag }}
-          token: ${{ secrets.CODECOV_TOKEN }} # required in v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} # required in v4

--- a/.github/workflows/_unit-tests-python.yml
+++ b/.github/workflows/_unit-tests-python.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           dir="${{ inputs.working-directory }}"
           echo "codecov_flag=${dir/\//_}" >> $GITHUB_ENV
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v4-beta
         with:
           working-directory: ${{ inputs.working-directory }}
           files: ./coverage.xml

--- a/.github/workflows/_unit-tests-python.yml
+++ b/.github/workflows/_unit-tests-python.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           dir="${{ inputs.working-directory }}"
           echo "codecov_flag=${dir/\//_}" >> $GITHUB_ENV
-      - uses: codecov/codecov-action@v4-beta
+      - uses: codecov/codecov-action@v4
         with:
           working-directory: ${{ inputs.working-directory }}
           files: ./coverage.xml

--- a/.github/workflows/_unit-tests-python.yml
+++ b/.github/workflows/_unit-tests-python.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry==${{ env.poetry-version }}
       - name: Use Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.python-version }}
           cache: "poetry"

--- a/.github/workflows/_unit-tests-python.yml
+++ b/.github/workflows/_unit-tests-python.yml
@@ -72,5 +72,4 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
           flags: ${{ env.codecov_flag }}
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} # required in v4
+          token: ${{ secrets.CODECOV_TOKEN }} # required in v4

--- a/.github/workflows/_unit-tests-python.yml
+++ b/.github/workflows/_unit-tests-python.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           dir="${{ inputs.working-directory }}"
           echo "codecov_flag=${dir/\//_}" >> $GITHUB_ENV
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           working-directory: ${{ inputs.working-directory }}
           files: ./coverage.xml

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,24 +44,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Set outputs
         id: vars
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.repository-prefix }}${{ matrix.directory }}-${{ matrix.project }}
           tags: |
             type=raw,value=sha-${{ steps.vars.outputs.sha_short }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ${{ matrix.directory }}/${{ matrix.project }}/Dockerfile

--- a/.github/workflows/openapi-spec.yml
+++ b/.github/workflows/openapi-spec.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry==${{ env.poetry-version }}
       - name: Use Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.python-version }}
           cache: "poetry"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.7
 


### PR DESCRIPTION
Update GitHub Actions to Node 20.

See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Fix #2467.