### PR TITLE
increase resources to 10/80/10

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -413,7 +413,7 @@ workers:
     workerJobTypesOnly: ""
     nodeSelector:
       role-datasets-server-worker: "true"
-    replicas: 4
+    replicas: 10
     resources:
       requests:
         cpu: 8
@@ -433,7 +433,7 @@ workers:
     workerJobTypesOnly: ""
     nodeSelector:
       role-datasets-server-worker: "true"
-    replicas: 10
+    replicas: 80
     resources:
       requests:
         cpu: 2
@@ -453,7 +453,7 @@ workers:
     workerJobTypesOnly: ""
     nodeSelector:
       role-datasets-server-worker-light: "true"
-    replicas: 4
+    replicas: 10
     resources:
       requests:
         cpu: 200m


### PR DESCRIPTION
we have 5K long jobs (statistics and duckdb), so: increasing here in the code, instead of scaling manually, to be sure to keep these values if we deploy again in the next hours or days