### PR TITLE
set updated_at field to the same value for all steps of a dataset

### DIFF
--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -72,6 +72,9 @@ from mongodb_migration.migrations._20240221103200_cache_merge_config_split_names
 from mongodb_migration.migrations._20240221160700_cache_merge_split_first_rows import (
     MigrationMergeSplitFirstRowsResponses,
 )
+from mongodb_migration.migrations._20240221160800_cache_set_updated_at_to_root_step import (
+    MigrationSetUpdatedAtToOldestStep,
+)
 from mongodb_migration.renaming_migrations import (
     CacheRenamingMigration,
     QueueRenamingMigration,
@@ -329,5 +332,9 @@ class MigrationsCollector:
             MigrationMergeSplitFirstRowsResponses(
                 version="20240221160700",
                 description="merge 'split-first-rows-from-streaming' and 'split-first-rows-from-parquet' responses to 'split-first-rows'",
+            ),
+            MigrationSetUpdatedAtToOldestStep(
+                version="20240221160800",
+                description="set 'updated_at' of the root step to all the cache entries for each dataset",
             ),
         ]

--- a/jobs/mongodb_migration/src/mongodb_migration/migrations/_20240221160800_cache_set_updated_at_to_root_step.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/migrations/_20240221160800_cache_set_updated_at_to_root_step.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 The HuggingFace Authors.
+
+import logging
+
+from libcommon.constants import CACHE_COLLECTION_RESPONSES, CACHE_MONGOENGINE_ALIAS
+from mongoengine.connection import get_db
+
+from mongodb_migration.migration import IrreversibleMigrationError, Migration
+
+ROOT_STEP = "dataset-config-names"
+
+
+# connection already occurred in the main.py (caveat: we use globals)
+class MigrationSetUpdatedAtToOldestStep(Migration):
+    """
+    After the migrations:
+     - '_20240221103200_cache_merge_config_split_names'
+     - '_20240221160700_cache_merge_split_first_rows'
+    the updated_at field is not accurate anymore, leading to backfilling a lot of them (in the daily cronjob), leading to
+    unnecessary jobs.
+
+    To fix that, we take the updated_at value for the root step, and set it to all the steps for the same dataset.
+    """
+
+    def up(self) -> None:
+        db = get_db(CACHE_MONGOENGINE_ALIAS)
+        logging.info("Setting the updated_at value for all the steps to the one of the root step, for each dataset")
+        for root_entry in db[CACHE_COLLECTION_RESPONSES].find({"kind": ROOT_STEP}):
+            db[CACHE_COLLECTION_RESPONSES].update_many(
+                {"dataset": root_entry["dataset"]},
+                {"$set": {"updated_at": root_entry["updated_at"]}},
+            )
+
+    def down(self) -> None:
+        raise IrreversibleMigrationError("This migration does not support rollback")
+
+    def validate(self) -> None:
+        logging.info("No need to validate.")

--- a/jobs/mongodb_migration/tests/migrations/test_20240221160800_cache_set_updated_at_to_root_step.py
+++ b/jobs/mongodb_migration/tests/migrations/test_20240221160800_cache_set_updated_at_to_root_step.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 The HuggingFace Authors.
+from typing import Any
+
+import pytest
+from libcommon.constants import CACHE_COLLECTION_RESPONSES, CACHE_MONGOENGINE_ALIAS
+from libcommon.resources import MongoResource
+from mongoengine.connection import get_db
+
+from mongodb_migration.migration import IrreversibleMigrationError
+from mongodb_migration.migrations._20240221160800_cache_set_updated_at_to_root_step import (
+    ROOT_STEP,
+    MigrationSetUpdatedAtToOldestStep,
+)
+
+STEP_1 = "step-1"
+STEP_2 = "step-2"
+
+DATE_0 = "2024-02-01T00:00:00.000000Z"
+DATE_1 = "2024-02-02T00:00:00.000000Z"
+DATE_2 = "2024-02-03T00:00:00.000000Z"
+
+DATASET_1 = "dataset1"
+DATASET_2 = "dataset2"
+
+
+@pytest.mark.parametrize(
+    "entries,expected_entries",
+    [
+        ([], []),
+        (
+            [{"kind": ROOT_STEP, "dataset": DATASET_1, "updated_at": DATE_1}],
+            [{"kind": ROOT_STEP, "dataset": DATASET_1, "updated_at": DATE_1}],
+        ),
+        (
+            [
+                {"kind": ROOT_STEP, "dataset": DATASET_1, "updated_at": DATE_1},
+                {"kind": STEP_1, "dataset": DATASET_1, "updated_at": DATE_2},
+                {"kind": STEP_2, "dataset": DATASET_1, "updated_at": DATE_0},
+            ],
+            [
+                {"kind": ROOT_STEP, "dataset": DATASET_1, "updated_at": DATE_1},
+                {"kind": STEP_1, "dataset": DATASET_1, "updated_at": DATE_1},
+                {"kind": STEP_2, "dataset": DATASET_1, "updated_at": DATE_1},
+            ],
+        ),
+        (
+            [
+                {"kind": ROOT_STEP, "dataset": DATASET_1, "updated_at": DATE_1},
+                {"kind": STEP_1, "dataset": DATASET_1, "updated_at": DATE_2},
+                {"kind": ROOT_STEP, "dataset": DATASET_2, "updated_at": DATE_2},
+                {"kind": STEP_1, "dataset": DATASET_2, "updated_at": DATE_0},
+            ],
+            [
+                {"kind": ROOT_STEP, "dataset": DATASET_1, "updated_at": DATE_1},
+                {"kind": STEP_1, "dataset": DATASET_1, "updated_at": DATE_1},
+                {"kind": ROOT_STEP, "dataset": DATASET_2, "updated_at": DATE_2},
+                {"kind": STEP_1, "dataset": DATASET_2, "updated_at": DATE_2},
+            ],
+        ),
+    ],
+)
+def test_migration(mongo_host: str, entries: list[dict[str, Any]], expected_entries: list[dict[str, Any]]) -> None:
+    with MongoResource(database="test_cache_set_updated_at_to_root_step", host=mongo_host, mongoengine_alias="cache"):
+        db = get_db(CACHE_MONGOENGINE_ALIAS)
+
+        if entries:
+            db[CACHE_COLLECTION_RESPONSES].insert_many(entries)
+
+        migration = MigrationSetUpdatedAtToOldestStep(
+            version="20240221160800",
+            description="set 'updated_at' of the root step to all the cache entries for each dataset",
+        )
+        migration.up()
+
+        assert (
+            list({k: v for k, v in entry.items() if k != "_id"} for entry in db[CACHE_COLLECTION_RESPONSES].find())
+            == expected_entries
+        )
+
+        with pytest.raises(IrreversibleMigrationError):
+            migration.down()
+
+        db[CACHE_COLLECTION_RESPONSES].drop()


### PR DESCRIPTION
After the migrations:
- '_20240221103200_cache_merge_config_split_names'
- '_20240221160700_cache_merge_split_first_rows'

the updated_at field is not accurate anymore, leading to backfilling a lot of them (in the daily cronjob), leading to unnecessary jobs.

To fix that, we take the updated_at value for the root step, and set it to all the steps for the same dataset.

See https://huggingface.slack.com/archives/C04L6P8KNQ5/p1708640247358519?thread_ts=1708637658.767199&cid=C04L6P8KNQ5 (internal)

