### PR TITLE
Fix extensions directory search

### DIFF
--- a/chart/templates/services/search/_container.tpl
+++ b/chart/templates/services/search/_container.tpl
@@ -35,6 +35,8 @@
     value: {{ .Values.duckDBIndex.targetRevision | quote }}
   - name: DUCKDB_INDEX_CACHE_DIRECTORY
     value: {{ .Values.duckDBIndex.cacheDirectory | quote }}
+  - name: DUCKDB_INDEX_EXTENSIONS_DIRECTORY
+    value: "/tmp/duckdb-extensions"
   volumeMounts:
   {{ include "volumeMountDuckDBIndexRW" . | nindent 2 }}
   securityContext:

--- a/services/search/README.md
+++ b/services/search/README.md
@@ -14,6 +14,7 @@ The service can be configured using environment variables. They are grouped by s
 
 - `DUCKDB_INDEX_CACHE_DIRECTORY`: directory where the temporal duckdb index files are downloaded. Defaults to empty.
 - `DUCKDB_INDEX_TARGET_REVISION`: the git revision of the dataset where the index file is stored in the dataset repository.
+- `DUCKDB_INDEX_EXTENSIONS_DIRECTORY`: directory where the duckdb extensions will be downloaded. Defaults to empty.
 
 ### API service
 

--- a/services/search/src/search/app.py
+++ b/services/search/src/search/app.py
@@ -101,6 +101,7 @@ def create_app_with_config(app_config: AppConfig) -> Starlette:
                 max_age_long=app_config.api.max_age_long,
                 max_age_short=app_config.api.max_age_short,
                 storage_clients=storage_clients,
+                extensions_directory=app_config.duckdb_index.extensions_directory,
             ),
         ),
         Route(
@@ -119,6 +120,7 @@ def create_app_with_config(app_config: AppConfig) -> Starlette:
                 max_age_long=app_config.api.max_age_long,
                 max_age_short=app_config.api.max_age_short,
                 storage_clients=storage_clients,
+                extensions_directory=app_config.duckdb_index.extensions_directory,
             ),
         ),
     ]

--- a/services/search/src/search/config.py
+++ b/services/search/src/search/config.py
@@ -19,12 +19,14 @@ from libcommon.config import (
 
 DUCKDB_INDEX_CACHE_DIRECTORY = None
 DUCKDB_INDEX_TARGET_REVISION = "refs/convert/duckdb"
+DUCKDB_INDEX_EXTENSIONS_DIRECTORY: Optional[str] = None
 
 
 @dataclass(frozen=True)
 class DuckDbIndexConfig:
     cache_directory: Optional[str] = DUCKDB_INDEX_CACHE_DIRECTORY
     target_revision: str = DUCKDB_INDEX_TARGET_REVISION
+    extensions_directory: Optional[str] = DUCKDB_INDEX_EXTENSIONS_DIRECTORY
 
     @classmethod
     def from_env(cls) -> "DuckDbIndexConfig":
@@ -33,6 +35,7 @@ class DuckDbIndexConfig:
             return cls(
                 cache_directory=env.str(name="CACHE_DIRECTORY", default=DUCKDB_INDEX_CACHE_DIRECTORY),
                 target_revision=env.str(name="TARGET_REVISION", default=DUCKDB_INDEX_TARGET_REVISION),
+                extensions_directory=env.str(name="EXTENSIONS_DIRECTORY", default=DUCKDB_INDEX_EXTENSIONS_DIRECTORY),
             )
 
 

--- a/services/search/src/search/duckdb_connection.py
+++ b/services/search/src/search/duckdb_connection.py
@@ -1,11 +1,14 @@
-from typing import Any
+from typing import Any, Optional
 
 import duckdb
 
 LOAD_FTS_SAFE_COMMAND = "INSTALL 'fts'; LOAD 'fts'; SET enable_external_access=false; SET lock_configuration=true;"
+SET_EXTENSIONS_DIRECTORY_COMMAND = "SET extension_directory='{directory}';"
 
 
-def duckdb_connect(**kwargs: Any) -> duckdb.DuckDBPyConnection:
+def duckdb_connect(extensions_directory: Optional[str] = None, **kwargs: Any) -> duckdb.DuckDBPyConnection:
     con = duckdb.connect(read_only=True, **kwargs)
+    if extensions_directory is not None:
+        con.execute(SET_EXTENSIONS_DIRECTORY_COMMAND.format(directory=extensions_directory))
     con.sql(LOAD_FTS_SAFE_COMMAND)
     return con

--- a/tools/docker-compose-datasets-server.yml
+++ b/tools/docker-compose-datasets-server.yml
@@ -121,6 +121,7 @@ services:
       - duckdb-index:${DUCKDB_INDEX_CACHE_DIRECTORY-/duckdb-index}
     environment:
       DUCKDB_INDEX_CACHE_DIRECTORY: ${DUCKDB_INDEX_CACHE_DIRECTORY-/duckdb-index}
+      DUCKDB_INDEX_EXTENSIONS_DIRECTORY: ${DUCKDB_INDEX_EXTENSIONS_DIRECTORY-/tmp/duckdb-extensions}
       # prometheus
       PROMETHEUS_MULTIPROC_DIR: ${PROMETHEUS_MULTIPROC_DIR-}
       # uvicorn

--- a/tools/docker-compose-dev-datasets-server.yml
+++ b/tools/docker-compose-dev-datasets-server.yml
@@ -129,6 +129,7 @@ services:
       - ../services/search/src:/src/services/search/src
     environment:
       DUCKDB_INDEX_CACHE_DIRECTORY: ${DUCKDB_INDEX_CACHE_DIRECTORY-/duckdb-index}
+      DUCKDB_INDEX_EXTENSIONS_DIRECTORY: ${DUCKDB_INDEX_EXTENSIONS_DIRECTORY-/tmp/duckdb-extensions}
       # prometheus
       PROMETHEUS_MULTIPROC_DIR: ${PROMETHEUS_MULTIPROC_DIR-}
       # uvicorn


### PR DESCRIPTION
While deploying https://github.com/huggingface/datasets-server/pull/2482 in staging, this error appeared:
```
INFO: 2024-02-23 17:03:36,387 - root - /search dataset='asoria/bolivian-recipes' config='default' split='same' query='beef' offset=0 length=100
DEBUG: 2024-02-23 17:03:36,413 - root - connect to index file /storage/duckdb-index/downloads/0.10.0/asoria-bolivian-recipes-5bb26f91/default/same/index.duckdb
ERROR: 2024-02-23 17:03:36,414 - root - Unexpected error.
Traceback (most recent call last):
  File "/src/services/search/src/search/routes/search.py", line 202, in search_endpoint
    num_rows_total, pa_table = await anyio.to_thread.run_sync(
  File "/src/services/search/.venv/lib/python3.9/site-packages/anyio/to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/src/services/search/.venv/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "/src/services/search/.venv/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "/src/services/search/src/search/routes/search.py", line 64, in full_text_search
    with duckdb_connect(database=index_file_location) as con:
  File "/src/services/search/src/search/duckdb_connection.py", line 10, in duckdb_connect
    con.sql(LOAD_FTS_SAFE_COMMAND)
duckdb.duckdb.IOException: IO Error: Failed to create directory "/.duckdb/"!
```
Will set the extensions directory to see if it fixes the issue same as in workers.