### PR TITLE
backfill retryable errors every 20 minutes

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -192,13 +192,30 @@ backfill:
     level: "debug"
   action: "backfill"
   schedule: "45 21 * * *"
-  # every four hours
+  # every day
   nodeSelector:
     role-datasets-server: "true"
   resources:
     requests:
       cpu: 1
-      memory: "4Gi"
+      memory: "1Gi"
+    limits:
+      cpu: 2
+      memory: "8Gi"
+
+backfillRetryableErrors:
+  enabled: true
+  log:
+    level: "debug"
+  action: "backfill-retryable-errors"
+  schedule: "*/20 * * * *"
+  # every 20 minutes hours
+  nodeSelector:
+    role-datasets-server: "true"
+  resources:
+    requests:
+      cpu: 1
+      memory: "1Gi"
     limits:
       cpu: 2
       memory: "8Gi"

--- a/chart/templates/_common/_helpers.tpl
+++ b/chart/templates/_common/_helpers.tpl
@@ -104,6 +104,11 @@ app.kubernetes.io/component: "{{ include "name" . }}-cache-metrics-collector"
 app.kubernetes.io/component: "{{ include "name" . }}-backfill"
 {{- end -}}
 
+{{- define "labels.backfillRetryableErrors" -}}
+{{ include "hf.labels.commons" . }}
+app.kubernetes.io/component: "{{ include "name" . }}-backfill-retryable-errors"
+{{- end -}}
+
 {{- define "labels.cleanDuckdbIndexCache" -}}
 {{ include "hf.labels.commons" . }}
 app.kubernetes.io/component: "{{ include "name" . }}-clean-duckdb-cache"

--- a/chart/templates/cron-jobs/backfill-retryable-errors/_container.tpl
+++ b/chart/templates/cron-jobs/backfill-retryable-errors/_container.tpl
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+{{- define "containerBackfillRetryableErrors" -}}
+- name: "{{ include "name" . }}-backfill-retryable-errors"
+  image: {{ include "jobs.cacheMaintenance.image" . }}
+  imagePullPolicy: {{ .Values.images.pullPolicy }}
+  securityContext:
+    allowPrivilegeEscalation: false
+  resources: {{ toYaml .Values.backfillRetryableErrors.resources | nindent 4 }}
+  env:
+    {{ include "envCache" . | nindent 2 }}
+    {{ include "envQueue" . | nindent 2 }}
+    {{ include "envCommon" . | nindent 2 }}
+    {{ include "envS3" . | nindent 2 }}
+    {{ include "envAssets" . | nindent 2 }}
+    {{ include "envCachedAssets" . | nindent 2 }}
+  - name: CACHE_MAINTENANCE_ACTION
+    value: {{ .Values.backfillRetryableErrors.action | quote }}
+  - name: LOG_LEVEL
+    value: {{ .Values.backfillRetryableErrors.log.level | quote }}
+{{- end -}}

--- a/chart/templates/cron-jobs/backfill-retryable-errors/job.yaml
+++ b/chart/templates/cron-jobs/backfill-retryable-errors/job.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The HuggingFace Authors.
+
+{{- if and .Values.images.jobs.cacheMaintenance .Values.backfillRetryableErrors.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels: {{ include "labels.backfillRetryableErrors" . | nindent 4 }}
+  name: "{{ include "name" . }}-job-backfill-retryable-errors"
+  namespace: {{ .Release.Namespace }}
+spec:
+  schedule: {{ .Values.backfillRetryableErrors.schedule | quote }}
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 1200
+      template:
+        spec:
+          restartPolicy: OnFailure
+          {{- include "dnsConfig" . | nindent 10 }}
+          {{- include "image.imagePullSecrets" . | nindent 6 }}
+          nodeSelector: {{ toYaml .Values.backfillRetryableErrors.nodeSelector | nindent 12 }}
+          tolerations: {{ toYaml .Values.backfillRetryableErrors.tolerations | nindent 12 }}
+          containers: {{ include "containerBackfillRetryableErrors" . | nindent 12 }}
+          securityContext: {{ include "securityContext" . | nindent 12 }}
+{{- end}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -325,6 +325,21 @@ backfill:
       cpu: 0
   tolerations: []
 
+backfillRetryableErrors:
+  enabled: false
+  log:
+    level: "info"
+  action: "backfill-retryable-errors"
+  schedule: "*/20 * * * *"
+  # every 20 minutes
+  nodeSelector: {}
+  resources:
+    requests:
+      cpu: 0
+    limits:
+      cpu: 0
+  tolerations: []
+
 cleanHfDatasetsCache:
   enabled: true
   log:

--- a/jobs/cache_maintenance/README.md
+++ b/jobs/cache_maintenance/README.md
@@ -5,6 +5,7 @@
 Available actions:
 
 - `backfill`: backfill the cache (i.e. create jobs to add the missing entries or update the outdated entries)
+- `backfill-retryable-errors`: backfill the cache for retryable errors
 - `collect-cache-metrics`: compute and store the cache metrics
 - `collect-queue-metrics`: compute and store the queue metrics
 - `clean-directory`: clean obsolete files/directories for a given path
@@ -15,7 +16,7 @@ Available actions:
 
 The script can be configured using environment variables. They are grouped by scope.
 
-- `CACHE_MAINTENANCE_ACTION`: the action to launch, among `backfill`, `collect-cache-metrics`, `collect-queue-metrics`, `clean-directory` and `post-messages`. Defaults to `skip`.
+- `CACHE_MAINTENANCE_ACTION`: the action to launch, among `backfill`, `backfill-retryable-errors`, `collect-cache-metrics`, `collect-queue-metrics`, `clean-directory` and `post-messages`. Defaults to `skip`.
 
 ### Backfill job configurations
 

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -29,6 +29,7 @@ from libcommon.constants import (
     CACHE_COLLECTION_RESPONSES,
     CACHE_METRICS_COLLECTION,
     CACHE_MONGOENGINE_ALIAS,
+    ERROR_CODES_TO_RETRY,
 )
 from libcommon.dtos import JobParams
 from libcommon.utils import get_datetime
@@ -575,6 +576,10 @@ def get_previous_step_or_raise(
 
 def get_all_datasets() -> set[str]:
     return set(CachedResponseDocument.objects().distinct("dataset"))
+
+
+def get_datasets_with_retryable_errors() -> set[str]:
+    return set(CachedResponseDocument.objects(error_code__in=list(ERROR_CODES_TO_RETRY)).distinct("dataset"))
 
 
 def is_successful_response(kind: str, dataset: str, config: Optional[str] = None, split: Optional[str] = None) -> bool:


### PR DESCRIPTION
fixes #2439.

For example, if a Parquet file commit to the Hub fails, we want to retry quickly (but not immediately, in case the Hub has an issue). So... checking and retrying every 20 minutes seems a good compromise.