### PR TITLE
Restore missing triggers between steps

### DIFF
--- a/libs/libcommon/src/libcommon/processing_graph.py
+++ b/libs/libcommon/src/libcommon/processing_graph.py
@@ -40,9 +40,10 @@ def guard_int(x: Any) -> int:
 
 
 def check_one_of_parents_is_same_or_higher_level(processing_graph: ProcessingGraph) -> None:
+    first_steps = processing_graph.get_first_processing_steps()
     for step in processing_graph.get_topologically_ordered_processing_steps():
         parents = processing_graph.get_parents(step.name)
-        if len(parents) > 0:
+        if parents:
             parent_input_types = [p.input_type for p in parents]
             if step.input_type == "dataset":
                 if "dataset" not in parent_input_types:
@@ -55,6 +56,12 @@ def check_one_of_parents_is_same_or_higher_level(processing_graph: ProcessingGra
                         f"Step {step.name} is a config-level step but none of its parents are config-level or dataset-level."
                     )
             # no need to check for splits
+        else:
+            # probably redundant checks
+            if step not in first_steps:
+                raise ValueError(f"Step {step.name} has not parents, but is not a root step.")
+            if step.input_type != "dataset":
+                raise ValueError(f"Step {step.name} is a root step but is not a dataset-level step.")
 
 
 class ProcessingStepSpecification(TypedDict, total=False):

--- a/libs/libcommon/src/libcommon/processing_graph.py
+++ b/libs/libcommon/src/libcommon/processing_graph.py
@@ -39,6 +39,24 @@ def guard_int(x: Any) -> int:
     raise ValueError(f"Invalid int: {x}")
 
 
+def check_one_of_parents_is_same_or_higher_level(processing_graph: ProcessingGraph) -> None:
+    for step in processing_graph.get_topologically_ordered_processing_steps():
+        parents = processing_graph.get_parents(step.name)
+        if len(parents) > 0:
+            parent_input_types = [p.input_type for p in parents]
+            if step.input_type == "dataset":
+                if "dataset" not in parent_input_types:
+                    raise ValueError(
+                        f"Step {step.name} is a dataset-level step but none of its parents are dataset-level."
+                    )
+            elif step.input_type == "config":
+                if "dataset" not in parent_input_types and "config" not in parent_input_types:
+                    raise ValueError(
+                        f"Step {step.name} is a config-level step but none of its parents are config-level or dataset-level."
+                    )
+            # no need to check for splits
+
+
 class ProcessingStepSpecification(TypedDict, total=False):
     input_type: InputType
     triggered_by: Union[list[str], str, None]
@@ -115,7 +133,11 @@ class ProcessingGraph:
     The graph can have multiple roots.
 
     Args:
-        specification (ProcessingGraphSpecification): The specification of the graph.
+        specification (`ProcessingGraphSpecification`): The specification of the graph.
+        min_bytes_for_bonus_difficulty (`int`, *optional*, defaults to `MIN_BYTES_FOR_BONUS_DIFFICULTY`): The minimum
+            number of bytes for a dataset to be considered big and get the bonus difficulty.
+        check_one_of_parents_is_same_or_higher_level (`bool`, *optional*, defaults to `True`): Whether to check that
+            one of the parents of a processing step is of the same input type or a higher input type.
 
     Raises:
         [`ValueError`]: If the graph is not a DAG.
@@ -126,6 +148,7 @@ class ProcessingGraph:
 
     specification: ProcessingGraphSpecification
     min_bytes_for_bonus_difficulty: int = MIN_BYTES_FOR_BONUS_DIFFICULTY
+    check_one_of_parents_is_same_or_higher_level: bool = True
 
     _nx_graph: nx.DiGraph = field(init=False)
     _processing_steps: Mapping[str, ProcessingStep] = field(init=False)
@@ -193,6 +216,8 @@ class ProcessingGraph:
         self._alphabetically_ordered_processing_steps = [
             self.get_processing_step(processing_step_name) for processing_step_name in sorted(_nx_graph.nodes())
         ]
+        if self.check_one_of_parents_is_same_or_higher_level:
+            check_one_of_parents_is_same_or_higher_level(self)
 
     def get_processing_step(self, processing_step_name: str) -> ProcessingStep:
         """
@@ -451,6 +476,10 @@ class Artifact:
         return dataset, revision, config, split, prefix
 
 
+# Note: apart from the root steps:
+# - every dataset-level step should be triggered by at least one dataset-level step
+# - every config-level step should be triggered by at least one dataset-level or config-level step
+# to be sure the steps are processed even if a dataset has no configs, or if a config has no splits.
 specification: ProcessingGraphSpecification = {
     "dataset-config-names": {
         "input_type": "dataset",
@@ -459,7 +488,10 @@ specification: ProcessingGraphSpecification = {
     },
     "split-first-rows": {
         "input_type": "split",
-        "triggered_by": ["config-split-names", "config-parquet-metadata"],
+        "triggered_by": [
+            "config-split-names",  # to compute with streaming when possible
+            "config-parquet-metadata",  # to compute with parquet
+        ],
         "job_runner_version": 4,
         "difficulty": 70,
     },
@@ -483,7 +515,10 @@ specification: ProcessingGraphSpecification = {
     },
     "dataset-parquet": {
         "input_type": "dataset",
-        "triggered_by": ["config-parquet", "dataset-config-names"],
+        "triggered_by": [
+            "dataset-config-names",  # required in case the dataset has no configs (error in previous step)
+            "config-parquet",
+        ],
         "job_runner_version": 2,
         "difficulty": 20,
     },
@@ -495,13 +530,19 @@ specification: ProcessingGraphSpecification = {
     },
     "dataset-info": {
         "input_type": "dataset",
-        "triggered_by": ["config-info", "dataset-config-names"],
+        "triggered_by": [
+            "dataset-config-names",  # required in case the dataset has no configs (error in previous step)
+            "config-info",
+        ],
         "job_runner_version": 2,
         "difficulty": 20,
     },
     "config-split-names": {
         "input_type": "config",
-        "triggered_by": ["dataset-config-names", "config-info"],
+        "triggered_by": [
+            "dataset-config-names",  # compute with streaming
+            "config-info",  # compute from parquet conversion
+        ],
         "job_runner_version": 3,
         "difficulty": 60,
     },
@@ -513,15 +554,18 @@ specification: ProcessingGraphSpecification = {
     },
     "dataset-size": {
         "input_type": "dataset",
-        "triggered_by": ["config-size", "dataset-config-names"],
+        "triggered_by": [
+            "dataset-config-names",  # required in case the dataset has no configs (error in previous step)
+            "config-size",
+        ],
         "job_runner_version": 2,
         "difficulty": 20,
     },
     "dataset-split-names": {
         "input_type": "dataset",
         "triggered_by": [
+            "dataset-config-names",  # required in case the dataset has no configs (error in previous step)
             "config-split-names",
-            "dataset-config-names",
         ],
         "job_runner_version": 3,
         "difficulty": 20,
@@ -535,14 +579,18 @@ specification: ProcessingGraphSpecification = {
     },
     "split-is-valid": {
         "input_type": "split",
-        "triggered_by": ["config-size", "split-first-rows", "split-duckdb-index"],
+        "triggered_by": [
+            "config-size",
+            "split-first-rows",
+            "split-duckdb-index",
+        ],
         "job_runner_version": 3,
         "difficulty": 20,
     },
     "config-is-valid": {
         "input_type": "config",
         "triggered_by": [
-            "config-split-names",
+            "config-split-names",  # required in case the config has no splits (error in previous step)
             "split-is-valid",
         ],
         "job_runner_version": 2,
@@ -551,7 +599,7 @@ specification: ProcessingGraphSpecification = {
     "dataset-is-valid": {
         "input_type": "dataset",
         "triggered_by": [
-            "dataset-config-names",
+            "dataset-config-names",  # required in case the dataset has no configs (error in previous step)
             "config-is-valid",
         ],
         "job_runner_version": 6,
@@ -565,20 +613,20 @@ specification: ProcessingGraphSpecification = {
     },
     "split-opt-in-out-urls-scan": {
         "input_type": "split",
-        "triggered_by": ["split-image-url-columns"],
+        "triggered_by": "split-image-url-columns",
         "job_runner_version": 4,
         "difficulty": 70,
     },
     "split-opt-in-out-urls-count": {
         "input_type": "split",
-        "triggered_by": ["split-opt-in-out-urls-scan"],
+        "triggered_by": "split-opt-in-out-urls-scan",
         "job_runner_version": 2,
         "difficulty": 20,
     },
     "config-opt-in-out-urls-count": {
         "input_type": "config",
         "triggered_by": [
-            "config-split-names",
+            "config-split-names",  # required in case the config has no splits (error in previous step)
             "split-opt-in-out-urls-count",
         ],
         "job_runner_version": 3,
@@ -586,41 +634,51 @@ specification: ProcessingGraphSpecification = {
     },
     "dataset-opt-in-out-urls-count": {
         "input_type": "dataset",
-        "triggered_by": ["dataset-config-names", "config-opt-in-out-urls-count"],
+        "triggered_by": [
+            "dataset-config-names",  # required in case the dataset has no configs (error in previous step)
+            "config-opt-in-out-urls-count",
+        ],
         "job_runner_version": 2,
         "difficulty": 20,
     },
     "split-duckdb-index": {
         "input_type": "split",
-        "triggered_by": [
-            "config-split-names",
-            "config-parquet-metadata",
-        ],
+        "triggered_by": "config-parquet-metadata",
         "job_runner_version": 2,
         "difficulty": 70,
         "bonus_difficulty_if_dataset_is_big": 20,
     },
     "config-duckdb-index-size": {
         "input_type": "config",
-        "triggered_by": "split-duckdb-index",
+        "triggered_by": [
+            "config-split-names",  # required in case the config has no splits (error in previous step)
+            "split-duckdb-index",
+        ],
         "job_runner_version": 2,
         "difficulty": 20,
     },
     "dataset-duckdb-index-size": {
         "input_type": "dataset",
-        "triggered_by": ["config-duckdb-index-size"],
+        "triggered_by": [
+            "dataset-config-names",  # required in case the dataset has no configs (error in previous step)
+            "config-duckdb-index-size",
+        ],
         "job_runner_version": 1,
         "difficulty": 20,
     },
     "dataset-hub-cache": {
         "input_type": "dataset",
-        "triggered_by": ["dataset-is-valid", "dataset-size", "dataset-loading-tags"],
+        "triggered_by": [
+            "dataset-is-valid",
+            "dataset-size",
+            "dataset-loading-tags",
+        ],
         "job_runner_version": 1,
         "difficulty": 20,
     },
     "dataset-loading-tags": {
         "input_type": "dataset",
-        "triggered_by": ["dataset-info"],
+        "triggered_by": "dataset-info",
         "job_runner_version": 1,
         "difficulty": 20,
     },

--- a/libs/libcommon/src/libcommon/processing_graph.py
+++ b/libs/libcommon/src/libcommon/processing_graph.py
@@ -483,7 +483,7 @@ specification: ProcessingGraphSpecification = {
     },
     "dataset-parquet": {
         "input_type": "dataset",
-        "triggered_by": "config-parquet",
+        "triggered_by": ["config-parquet", "dataset-config-names"],
         "job_runner_version": 2,
         "difficulty": 20,
     },
@@ -495,7 +495,7 @@ specification: ProcessingGraphSpecification = {
     },
     "dataset-info": {
         "input_type": "dataset",
-        "triggered_by": "config-info",
+        "triggered_by": ["config-info", "dataset-config-names"],
         "job_runner_version": 2,
         "difficulty": 20,
     },
@@ -513,13 +513,16 @@ specification: ProcessingGraphSpecification = {
     },
     "dataset-size": {
         "input_type": "dataset",
-        "triggered_by": "config-size",
+        "triggered_by": ["config-size", "dataset-config-names"],
         "job_runner_version": 2,
         "difficulty": 20,
     },
     "dataset-split-names": {
         "input_type": "dataset",
-        "triggered_by": "config-split-names",
+        "triggered_by": [
+            "config-split-names",
+            "dataset-config-names",
+        ],
         "job_runner_version": 3,
         "difficulty": 20,
     },
@@ -538,13 +541,19 @@ specification: ProcessingGraphSpecification = {
     },
     "config-is-valid": {
         "input_type": "config",
-        "triggered_by": "split-is-valid",
+        "triggered_by": [
+            "config-split-names",
+            "split-is-valid",
+        ],
         "job_runner_version": 2,
         "difficulty": 20,
     },
     "dataset-is-valid": {
         "input_type": "dataset",
-        "triggered_by": "config-is-valid",
+        "triggered_by": [
+            "dataset-config-names",
+            "config-is-valid",
+        ],
         "job_runner_version": 6,
         "difficulty": 20,
     },
@@ -556,31 +565,37 @@ specification: ProcessingGraphSpecification = {
     },
     "split-opt-in-out-urls-scan": {
         "input_type": "split",
-        "triggered_by": "split-image-url-columns",
+        "triggered_by": ["split-image-url-columns"],
         "job_runner_version": 4,
         "difficulty": 70,
     },
     "split-opt-in-out-urls-count": {
         "input_type": "split",
-        "triggered_by": "split-opt-in-out-urls-scan",
+        "triggered_by": ["split-opt-in-out-urls-scan"],
         "job_runner_version": 2,
         "difficulty": 20,
     },
     "config-opt-in-out-urls-count": {
         "input_type": "config",
-        "triggered_by": "split-opt-in-out-urls-count",
+        "triggered_by": [
+            "config-split-names",
+            "split-opt-in-out-urls-count",
+        ],
         "job_runner_version": 3,
         "difficulty": 20,
     },
     "dataset-opt-in-out-urls-count": {
         "input_type": "dataset",
-        "triggered_by": "config-opt-in-out-urls-count",
+        "triggered_by": ["dataset-config-names", "config-opt-in-out-urls-count"],
         "job_runner_version": 2,
         "difficulty": 20,
     },
     "split-duckdb-index": {
         "input_type": "split",
-        "triggered_by": "config-parquet-metadata",
+        "triggered_by": [
+            "config-split-names",
+            "config-parquet-metadata",
+        ],
         "job_runner_version": 2,
         "difficulty": 70,
         "bonus_difficulty_if_dataset_is_big": 20,
@@ -593,7 +608,7 @@ specification: ProcessingGraphSpecification = {
     },
     "dataset-duckdb-index-size": {
         "input_type": "dataset",
-        "triggered_by": "config-duckdb-index-size",
+        "triggered_by": ["config-duckdb-index-size"],
         "job_runner_version": 1,
         "difficulty": 20,
     },
@@ -605,7 +620,7 @@ specification: ProcessingGraphSpecification = {
     },
     "dataset-loading-tags": {
         "input_type": "dataset",
-        "triggered_by": "dataset-info",
+        "triggered_by": ["dataset-info"],
         "job_runner_version": 1,
         "difficulty": 20,
     },

--- a/libs/libcommon/tests/test_operations.py
+++ b/libs/libcommon/tests/test_operations.py
@@ -346,7 +346,7 @@ def test_2274_only_one_entry(
         }
         finish_job(job_result=job_result)
 
-        assert len(queue.get_pending_jobs_df(dataset=dataset)) == 6
+        assert len(queue.get_pending_jobs_df(dataset=dataset)) == 7
         assert len(get_cache_entries_df(dataset=dataset)) == 1
 
         # let's delete all the jobs, to get in the same state as the bug

--- a/libs/libcommon/tests/test_operations.py
+++ b/libs/libcommon/tests/test_operations.py
@@ -346,7 +346,7 @@ def test_2274_only_one_entry(
         }
         finish_job(job_result=job_result)
 
-        assert len(queue.get_pending_jobs_df(dataset=dataset)) == 0
+        assert len(queue.get_pending_jobs_df(dataset=dataset)) == 6
         assert len(get_cache_entries_df(dataset=dataset)) == 1
 
         # let's delete all the jobs, to get in the same state as the bug

--- a/libs/libcommon/tests/test_processing_graph.py
+++ b/libs/libcommon/tests/test_processing_graph.py
@@ -55,6 +55,12 @@ def test_graph() -> None:
             [
                 "config-split-names",
                 "config-parquet-and-info",
+                "dataset-opt-in-out-urls-count",
+                "dataset-split-names",
+                "dataset-parquet",
+                "dataset-info",
+                "dataset-size",
+                "dataset-is-valid",
             ],
             [],
             [],
@@ -72,9 +78,13 @@ def test_graph() -> None:
         (
             "config-split-names",
             [
+                "config-opt-in-out-urls-count",
                 "split-first-rows",
                 "dataset-split-names",
+                "split-duckdb-index",
+                "split-duckdb-index-010",
                 "split-descriptive-statistics",
+                "config-is-valid",
             ],
             ["dataset-config-names", "config-info"],
             ["dataset-config-names", "config-parquet-and-info", "config-info"],
@@ -83,6 +93,7 @@ def test_graph() -> None:
             "dataset-split-names",
             [],
             [
+                "dataset-config-names",
                 "config-split-names",
             ],
             [
@@ -120,19 +131,19 @@ def test_graph() -> None:
         (
             "dataset-parquet",
             [],
-            ["config-parquet"],
+            ["dataset-config-names", "config-parquet"],
             ["dataset-config-names", "config-parquet-and-info", "config-parquet"],
         ),
         (
             "config-info",
-            ["config-split-names", "dataset-info"],
+            ["dataset-info", "config-split-names"],
             ["config-parquet-and-info"],
             ["dataset-config-names", "config-parquet-and-info"],
         ),
         (
             "dataset-info",
             ["dataset-loading-tags"],
-            ["config-info"],
+            ["dataset-config-names", "config-info"],
             ["dataset-config-names", "config-parquet-and-info", "config-info"],
         ),
         (
@@ -144,7 +155,7 @@ def test_graph() -> None:
         (
             "dataset-size",
             ["dataset-hub-cache"],
-            ["config-size"],
+            ["dataset-config-names", "config-size"],
             ["dataset-config-names", "config-parquet-and-info", "config-size"],
         ),
         (
@@ -158,6 +169,7 @@ def test_graph() -> None:
             ["dataset-hub-cache"],
             [
                 "config-is-valid",
+                "dataset-config-names",
             ],
             [
                 "dataset-config-names",
@@ -221,7 +233,7 @@ def test_graph() -> None:
         (
             "config-opt-in-out-urls-count",
             ["dataset-opt-in-out-urls-count"],
-            ["split-opt-in-out-urls-count"],
+            ["split-opt-in-out-urls-count", "config-split-names"],
             [
                 "dataset-config-names",
                 "config-split-names",
@@ -238,7 +250,7 @@ def test_graph() -> None:
         (
             "dataset-opt-in-out-urls-count",
             [],
-            ["config-opt-in-out-urls-count"],
+            ["config-opt-in-out-urls-count", "dataset-config-names"],
             [
                 "dataset-config-names",
                 "config-split-names",
@@ -256,11 +268,13 @@ def test_graph() -> None:
         (
             "split-duckdb-index",
             ["config-duckdb-index-size", "split-is-valid"],
-            ["config-parquet-metadata"],
+            ["config-split-names", "config-parquet-metadata"],
             [
+                "config-split-names",
                 "config-parquet",
                 "config-parquet-and-info",
                 "config-parquet-metadata",
+                "config-info",
                 "dataset-config-names",
             ],
         ),
@@ -269,9 +283,11 @@ def test_graph() -> None:
             ["dataset-duckdb-index-size"],
             ["split-duckdb-index"],
             [
+                "config-split-names",
                 "config-parquet",
                 "config-parquet-and-info",
                 "config-parquet-metadata",
+                "config-info",
                 "dataset-config-names",
                 "split-duckdb-index",
             ],
@@ -282,9 +298,11 @@ def test_graph() -> None:
             ["config-duckdb-index-size"],
             [
                 "config-duckdb-index-size",
+                "config-split-names",
                 "config-parquet",
                 "config-parquet-and-info",
                 "config-parquet-metadata",
+                "config-info",
                 "dataset-config-names",
                 "split-duckdb-index",
             ],

--- a/libs/libcommon/tests/test_processing_graph.py
+++ b/libs/libcommon/tests/test_processing_graph.py
@@ -55,6 +55,7 @@ def test_graph() -> None:
             [
                 "config-split-names",
                 "config-parquet-and-info",
+                "dataset-duckdb-index-size",
                 "dataset-opt-in-out-urls-count",
                 "dataset-split-names",
                 "dataset-parquet",
@@ -78,11 +79,10 @@ def test_graph() -> None:
         (
             "config-split-names",
             [
+                "config-duckdb-index-size",
                 "config-opt-in-out-urls-count",
                 "split-first-rows",
                 "dataset-split-names",
-                "split-duckdb-index",
-                "split-duckdb-index-010",
                 "split-descriptive-statistics",
                 "config-is-valid",
             ],
@@ -268,20 +268,18 @@ def test_graph() -> None:
         (
             "split-duckdb-index",
             ["config-duckdb-index-size", "split-is-valid"],
-            ["config-split-names", "config-parquet-metadata"],
+            ["config-parquet-metadata"],
             [
-                "config-split-names",
                 "config-parquet",
                 "config-parquet-and-info",
                 "config-parquet-metadata",
-                "config-info",
                 "dataset-config-names",
             ],
         ),
         (
             "config-duckdb-index-size",
             ["dataset-duckdb-index-size"],
-            ["split-duckdb-index"],
+            ["split-duckdb-index", "config-split-names"],
             [
                 "config-split-names",
                 "config-parquet",
@@ -295,7 +293,7 @@ def test_graph() -> None:
         (
             "dataset-duckdb-index-size",
             [],
-            ["config-duckdb-index-size"],
+            ["config-duckdb-index-size", "dataset-config-names"],
             [
                 "config-duckdb-index-size",
                 "config-split-names",

--- a/libs/libcommon/tests/utils.py
+++ b/libs/libcommon/tests/utils.py
@@ -187,7 +187,8 @@ PROCESSING_GRAPH_FAN_IN_OUT = ProcessingGraph(
         STEP_DE: {"input_type": "dataset", "triggered_by": STEP_CA},  # fan-in (C -> D)
         STEP_CB: {"input_type": "config", "triggered_by": STEP_SA},  # fan-in (S -> C)
         STEP_DF: {"input_type": "dataset", "triggered_by": STEP_SA},  # fan-in (S -> D)
-    }
+    },
+    check_one_of_parents_is_same_or_higher_level=False,
 )
 
 # Graph to test parallel steps (ie. two steps that compute the same thing, and abort if the other already exists)

--- a/services/worker/tests/test_job_manager.py
+++ b/services/worker/tests/test_job_manager.py
@@ -142,7 +142,10 @@ def test_backfill(priority: Priority, app_config: AppConfig) -> None:
 
     child = processing_graph.get_children("dataset-config-names").pop()
     dataset_child_jobs = queue.get_dump_with_status(job_type=child.job_type, status=Status.WAITING)
-    assert len(dataset_child_jobs) == 0
+    assert len(dataset_child_jobs) == 1
+    assert dataset_child_jobs[0]["dataset"] == "dataset"
+    assert dataset_child_jobs[0]["revision"] == "revision"
+    assert dataset_child_jobs[0]["priority"] is priority.value
 
 
 def test_job_runner_set_crashed(app_config: AppConfig) -> None:


### PR DESCRIPTION
fixes #2530

it:
- reverts #2489
- adds the missing triggering step
- adds a check when creating the processing graph, to ensure all the config- and dataset-level steps have at least one triggering step of the same level, to handle the case where we couldn't get the configs or the splits.

