### PR TITLE
Fix: Add datasets cache to loading tags job runner

### DIFF
--- a/services/worker/src/worker/job_runner_factory.py
+++ b/services/worker/src/worker/job_runner_factory.py
@@ -228,6 +228,7 @@ class JobRunnerFactory(BaseJobRunnerFactory):
             return DatasetLoadingTagsJobRunner(
                 job_info=job_info,
                 app_config=self.app_config,
+                hf_datasets_cache=self.hf_datasets_cache,
             )
 
         supported_job_types = [

--- a/services/worker/src/worker/job_runners/dataset/loading_tags.py
+++ b/services/worker/src/worker/job_runners/dataset/loading_tags.py
@@ -41,7 +41,7 @@ from worker.dtos import (
     DatasetTag,
     LoadingCode,
 )
-from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
+from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunnerWithDatasetsCache
 
 NON_WORD_GLOB_SEPARATOR = f"[{NON_WORDS_CHARS}/]"
 NON_WORD_REGEX_SEPARATOR = NON_WORD_GLOB_SEPARATOR.replace(".", "\.").replace("/", "\/")
@@ -621,7 +621,7 @@ def compute_loading_tags_response(dataset: str, hf_token: Optional[str] = None) 
     return DatasetLoadingTagsResponse(tags=tags, libraries=libraries)
 
 
-class DatasetLoadingTagsJobRunner(DatasetJobRunner):
+class DatasetLoadingTagsJobRunner(DatasetJobRunnerWithDatasetsCache):
     @staticmethod
     def get_job_type() -> str:
         return "dataset-loading-tags"

--- a/services/worker/tests/job_runners/dataset/test_loading_tags.py
+++ b/services/worker/tests/job_runners/dataset/test_loading_tags.py
@@ -18,6 +18,7 @@ from worker.job_runners.dataset.loading_tags import (
     DatasetLoadingTagsJobRunner,
     get_builder_configs_with_simplified_data_files,
 )
+from worker.resources import LibrariesResource
 
 from ..utils import REVISION_NAME, UpstreamResponse
 
@@ -207,6 +208,7 @@ def mock_hffs(tmp_path_factory: TempPathFactory) -> Iterator[fsspec.AbstractFile
 
 @pytest.fixture
 def get_job_runner(
+    libraries_resource: LibrariesResource,
     cache_mongo_resource: CacheMongoResource,
     queue_mongo_resource: QueueMongoResource,
 ) -> GetJobRunner:
@@ -228,6 +230,7 @@ def get_job_runner(
                 "difficulty": 20,
             },
             app_config=app_config,
+            hf_datasets_cache=libraries_resource.hf_datasets_cache,
         )
 
     return _get_job_runner


### PR DESCRIPTION
`dataset-hub-cache` is failing because of `dataset-loading-tags` - PermissionError - [Errno 13] Permission denied: '/.cache'
Currently 754 affected datasets.
