### PR TITLE
Default config first

### DIFF
--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -577,7 +577,7 @@ def launch_job_runner(job_runner_args: JobRunnerArgs) -> CompleteJobResult:
 
 
 def test_concurrency(
-    hub_public_n_configs: str,
+    hub_public_legacy_n_configs: str,
     app_config: AppConfig,
     tmp_path: Path,
     get_dataset_config_names_job_runner: GetDatasetConfigNamesJobRunner,
@@ -591,7 +591,7 @@ def test_concurrency(
     Ideally we would try for both quick and slow jobs.
     """
     app_config = replace(app_config, common=replace(app_config.common, dataset_scripts_allow_list=["*"]))
-    repo_id = hub_public_n_configs
+    repo_id = hub_public_legacy_n_configs
     hf_api = HfApi(endpoint=CI_HUB_ENDPOINT, token=CI_USER_TOKEN)
     revision = hf_api.dataset_info(repo_id=repo_id, files_metadata=False).sha
     if revision is None:

--- a/services/worker/tests/job_runners/dataset/test_config_names.py
+++ b/services/worker/tests/job_runners/dataset/test_config_names.py
@@ -77,12 +77,13 @@ def test_compute_too_many_configs(
     )
 
     with patch("worker.job_runners.dataset.config_names.get_dataset_config_names", return_value=configs):
-        if error_code:
-            with pytest.raises(CustomError) as exc_info:
-                job_runner.compute()
-            assert exc_info.value.code == error_code
-        else:
-            assert job_runner.compute() is not None
+        with patch("worker.job_runners.dataset.config_names.get_dataset_default_config_name", return_value=None):
+            if error_code:
+                with pytest.raises(CustomError) as exc_info:
+                    job_runner.compute()
+                assert exc_info.value.code == error_code
+            else:
+                assert job_runner.compute() is not None
 
 
 @pytest.mark.parametrize(

--- a/services/worker/tests/job_runners/dataset/test_config_names.py
+++ b/services/worker/tests/job_runners/dataset/test_config_names.py
@@ -94,6 +94,7 @@ def test_compute_too_many_configs(
         ("gated", True, None, None),
         ("private", True, None, None),
         ("empty", False, "EmptyDatasetError", "EmptyDatasetError"),
+        ("n_configs_with_default", False, None, None),
         # should we really test the following cases?
         # The assumption is that the dataset exists and is accessible with the token
         ("does_not_exist", False, "ConfigNamesError", "DatasetNotFoundError"),
@@ -101,13 +102,14 @@ def test_compute_too_many_configs(
         ("private", False, "ConfigNamesError", "DatasetNotFoundError"),
     ],
 )
-def test_compute_splits_response_simple_csv(
+def test_compute_splits_response(
     hub_responses_public: HubDatasetTest,
     hub_responses_audio: HubDatasetTest,
     hub_responses_gated: HubDatasetTest,
     hub_responses_private: HubDatasetTest,
     hub_responses_empty: HubDatasetTest,
     hub_responses_does_not_exist: HubDatasetTest,
+    hub_responses_n_configs_with_default: HubDatasetTest,
     get_job_runner: GetJobRunner,
     name: str,
     use_token: bool,
@@ -122,6 +124,7 @@ def test_compute_splits_response_simple_csv(
         "private": hub_responses_private,
         "empty": hub_responses_empty,
         "does_not_exist": hub_responses_does_not_exist,
+        "n_configs_with_default": hub_responses_n_configs_with_default,
     }
     dataset = hub_datasets[name]["name"]
     expected_configs_response = hub_datasets[name]["config_names_response"]


### PR DESCRIPTION
Show the default config first in the Viewer.

I did this by ordering the configs in `dataset-config-names` to have the default config in first position

fix https://github.com/huggingface/datasets-server/issues/2541

No need to recompute all the entries, it's fine to apply this to new / updated datasets imo

cc @HugoLaurencon for WebSight