### PR TITLE
tweaking the threshold for autoscaling

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -453,7 +453,7 @@ workers:
       maxReplicas: 50
       targets:
         - targetQueueName: "worker_size_jobs_count"
-          targetQueueLength: 30
+          targetQueueLength: 20
           targetWorkerSize: "heavy"
     resources:
       requests:
@@ -481,7 +481,7 @@ workers:
       maxReplicas: 100
       targets:
         - targetQueueName: "worker_size_jobs_count"
-          targetQueueLength: 30
+          targetQueueLength: 100
           targetWorkerSize: "medium"
     resources:
       requests:
@@ -509,7 +509,7 @@ workers:
       maxReplicas: 50
       targets:
         - targetQueueName: "worker_size_jobs_count"
-          targetQueueLength: 30
+          targetQueueLength: 100
           targetWorkerSize: "light"
     resources:
       requests:


### PR DESCRIPTION
30 jobs is too low for the medium jobs (and for the light ones too). On the other side, I think we can lower the limit for the heavy ones to 20.

<img width="407" alt="Capture d’écran 2024-03-08 à 10 26 57" src="https://github.com/huggingface/datasets-server/assets/1676121/213e1943-3df5-473a-a481-da46396cf3ce">
