### PR TITLE
Fix size of splits

### DIFF
--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -681,8 +681,8 @@ def fill_builder_info(
     builder.info.download_size = 0
     builder.info.dataset_size = 0
     logging.info("Start validation of parquet files.")
-    num_examples = 0
     for split, urls in data_files.items():
+        num_examples = 0
         split = str(split)  # in case it's a NamedSplit
         first_url = urls[0]
         try:

--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -392,6 +392,38 @@ def hub_public_three_parquet_files_builder(three_parquet_files_paths: list[str])
     delete_hub_dataset_repo(repo_id=repo_id)
 
 
+@pytest.fixture(scope="session")
+def three_parquet_splits_paths(
+    tmp_path_factory: pytest.TempPathFactory, datasets: Mapping[str, Dataset]
+) -> Mapping[str, str]:
+    dataset = datasets["descriptive_statistics_string_text"]
+    path1 = str(tmp_path_factory.mktemp("data") / "train.parquet")
+    data1 = Dataset.from_dict(dataset[:30])
+    with open(path1, "wb") as f:
+        data1.to_parquet(f)
+
+    path2 = str(tmp_path_factory.mktemp("data") / "test.parquet")
+    data2 = Dataset.from_dict(dataset[30:60])
+    with open(path2, "wb") as f:
+        data2.to_parquet(f)
+
+    path3 = str(tmp_path_factory.mktemp("data") / "validation.parquet")
+    data3 = Dataset.from_dict(dataset[60:])
+    with open(path3, "wb") as f:
+        data3.to_parquet(f)
+
+    return {"train": path1, "test": path2, "validation": path3}
+
+
+@pytest.fixture(scope="session")
+def hub_public_three_parquet_splits_builder(three_parquet_splits_paths: Mapping[str, str]) -> Iterator[str]:
+    repo_id = create_hub_dataset_repo(
+        prefix="parquet_builder_three_splits", file_paths=three_parquet_splits_paths.values()
+    )
+    yield repo_id
+    delete_hub_dataset_repo(repo_id=repo_id)
+
+
 class HubDatasetTest(TypedDict):
     name: str
     config_names_response: Any

--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -418,7 +418,7 @@ def three_parquet_splits_paths(
 @pytest.fixture(scope="session")
 def hub_public_three_parquet_splits_builder(three_parquet_splits_paths: Mapping[str, str]) -> Iterator[str]:
     repo_id = create_hub_dataset_repo(
-        prefix="parquet_builder_three_splits", file_paths=three_parquet_splits_paths.values()
+        prefix="parquet_builder_three_splits", file_paths=list(three_parquet_splits_paths.values())
     )
     yield repo_id
     delete_hub_dataset_repo(repo_id=repo_id)


### PR DESCRIPTION
fixes #2581 

---

After merging and deploying, I'll refresh all the affected datasets.

It's not so much (<2k jobs)

```
db.cachedResponsesBlue.countDocuments({
    "kind": "config-parquet-and-info"
})
140609
db.cachedResponsesBlue.countDocuments({
    "kind": "config-parquet-and-info",
    "updated_at": { 
        $gte: new Date("2024-03-12T08:00:00.000Z"),
    }
})
1644
```