### PR TITLE
Fix cell truncation

### DIFF
--- a/libs/libcommon/src/libcommon/viewer_utils/truncate_rows.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/truncate_rows.py
@@ -144,7 +144,7 @@ def create_truncated_row_items(
     # 1. first get the first rows_min_number rows
     for row_idx, row in enumerate(rows[:rows_min_number]):
         row_item = to_row_item(row_idx=row_idx, row=row)
-        row_item["truncated_cells"] = truncated_columns
+        row_item["truncated_cells"] = list(truncated_columns)
         rows_bytes += get_json_size(row_item) + COMMA_SIZE
         row_items.append(row_item)
 


### PR DESCRIPTION
We were using the same `list` for all the cells. So if a cell has truncated columns then all the cells end up with the same value for `truncated_cells`

Close https://github.com/huggingface/datasets-server/issues/2586