### PR TITLE
Add retry when loading dataset builder

### DIFF
--- a/libs/libcommon/src/libcommon/constants.py
+++ b/libs/libcommon/src/libcommon/constants.py
@@ -40,6 +40,7 @@ ERROR_CODES_TO_RETRY = {
     "ConnectionError",
     "CreateCommitError",
     "ExternalServerError",
+    "HfHubError",
     "JobManagerCrashedError",
     "LockedDatasetTimeoutError",
     "PreviousStepStillProcessingError",

--- a/libs/libcommon/src/libcommon/exceptions.py
+++ b/libs/libcommon/src/libcommon/exceptions.py
@@ -98,6 +98,7 @@ CacheableErrorCode = Literal[
     "FeaturesError",
     "FeaturesResponseEmptyError",
     "FileSystemError",
+    "HfHubError",
     "InfoError",
     "JobManagerCrashedError",
     "JobManagerExceededMaximumDurationError",
@@ -307,6 +308,13 @@ class FileSystemError(CacheableError):
 
     def __init__(self, message: str, cause: Optional[BaseException] = None):
         super().__init__(message, HTTPStatus.INTERNAL_SERVER_ERROR, "FileSystemError", cause, False)
+
+
+class HfHubError(CacheableError):
+    """The HF Hub server is not responding or gave and error."""
+
+    def __init__(self, message: str, cause: Optional[BaseException] = None):
+        super().__init__(message, HTTPStatus.INTERNAL_SERVER_ERROR, "HfHubError", cause, False)
 
 
 class InfoError(CacheableError):

--- a/libs/libcommon/src/libcommon/exceptions.py
+++ b/libs/libcommon/src/libcommon/exceptions.py
@@ -311,7 +311,7 @@ class FileSystemError(CacheableError):
 
 
 class HfHubError(CacheableError):
-    """The HF Hub server is not responding or gave and error."""
+    """The HF Hub server is not responding or gave an error."""
 
     def __init__(self, message: str, cause: Optional[BaseException] = None):
         super().__init__(message, HTTPStatus.INTERNAL_SERVER_ERROR, "HfHubError", cause, False)

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -1227,7 +1227,10 @@ def compute_config_parquet_and_info_response(
     download_config = DownloadConfig(delete_extracted=True)
     try:
         logging.info(f"Loading {dataset=} {config=} builder. ")
-        builder = load_dataset_builder(
+        retry_load_dataset_builder = retry(on=[HfHubHTTPError], sleeps=HF_HUB_HTTP_ERROR_RETRY_SLEEPS)(
+            load_dataset_builder
+        )
+        builder = retry_load_dataset_builder(
             path=dataset,
             name=config,
             revision=source_revision,

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -63,6 +63,7 @@ from libcommon.exceptions import (
     ExternalFilesSizeRequestHTTPError,
     ExternalFilesSizeRequestTimeoutError,
     FileSystemError,
+    HfHubError,
     LockedDatasetTimeoutError,
     PreviousStepFormatError,
     UnsupportedExternalFilesError,
@@ -1250,6 +1251,8 @@ def compute_config_parquet_and_info_response(
         raise
     except FileNotFoundError as err:
         raise DatasetNotFoundError("The dataset, or the revision, does not exist on the Hub.") from err
+    except HfHubHTTPError as err:
+        raise HfHubError(f"Couldn't load dataset builder for {dataset=} {config=}.") from err
 
     partial = False
     if is_parquet_builder_with_hub_files(builder):


### PR DESCRIPTION
Related to https://github.com/huggingface/datasets-server/issues/1443 for `config-parquet-and-info`, we have 1065 entries with HfHubHTTPError UnexpectedError, we should retry because sometimes it is not a final error but just an issue with Hub's connectivity.
