### PR TITLE
change values for autoscaling

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -431,7 +431,7 @@ workers:
     autoscaling:
       enabled: true
       minReplicas: 4
-      maxReplicas: 50
+      maxReplicas: 40
       targets:
         - targetQueueName: "worker_size_jobs_count"
           targetQueueLength: 50
@@ -459,10 +459,10 @@ workers:
     autoscaling:
       enabled: true
       minReplicas: 10
-      maxReplicas: 100
+      maxReplicas: 80
       targets:
         - targetQueueName: "worker_size_jobs_count"
-          targetQueueLength: 50
+          targetQueueLength: 150
           targetWorkerSize: "medium"
     resources:
       requests:
@@ -490,7 +490,7 @@ workers:
       maxReplicas: 50
       targets:
         - targetQueueName: "worker_size_jobs_count"
-          targetQueueLength: 50
+          targetQueueLength: 150
           targetWorkerSize: "light"
     resources:
       requests:


### PR DESCRIPTION
- increase threshold for medium and light workers, because it's pretty common to have a burst of 50 jobs
- reduce the max number of mium and heavy workers because it's not possible currently, with 50 nodes, to get 100 medium workers and 50 heavy workers at the same time