### PR TITLE
Fix hub cache libraries

### DIFF
--- a/libs/libcommon/src/libcommon/processing_graph.py
+++ b/libs/libcommon/src/libcommon/processing_graph.py
@@ -681,7 +681,7 @@ specification: ProcessingGraphSpecification = {
             "dataset-size",
             "dataset-compatible-libraries",
         ],
-        "job_runner_version": 1,
+        "job_runner_version": 2,
         "difficulty": 20,
     },
     "dataset-compatible-libraries": {

--- a/services/worker/src/worker/job_runners/dataset/hub_cache.py
+++ b/services/worker/src/worker/job_runners/dataset/hub_cache.py
@@ -6,7 +6,7 @@ import logging
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import CachedArtifactNotFoundError, get_previous_step_or_raise
 
-from worker.dtos import DatasetHubCacheResponse, DatasetLibrary, DatasetTag, JobResult
+from worker.dtos import CompatibleLibrary, DatasetHubCacheResponse, DatasetLibrary, DatasetTag, JobResult
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 
 
@@ -70,7 +70,8 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
             kind="dataset-compatible-libraries", dataset=dataset
         )
         tags = compatible_libraries_response["content"]["tags"]
-        libraries = compatible_libraries_response["content"]["libraries"]
+        compatible_libraries: list[CompatibleLibrary] = compatible_libraries_response["content"]["libraries"]
+        libraries = [compatible_library["library"] for compatible_library in compatible_libraries]
     except CachedArtifactNotFoundError:
         logging.info(f"Missing 'dataset-compatible-libraries' response for {dataset=}")
     except KeyError:

--- a/services/worker/tests/job_runners/dataset/test_hub_cache.py
+++ b/services/worker/tests/job_runners/dataset/test_hub_cache.py
@@ -63,7 +63,7 @@ UPSTREAM_RESPONSE_LOADING_TAGS_OK: UpstreamResponse = UpstreamResponse(
     dataset=DATASET,
     dataset_git_revision=REVISION_NAME,
     http_status=HTTPStatus.OK,
-    content={"tags": ["tag"], "libraries": ["library"]},
+    content={"tags": ["tag"], "libraries": [{"library": "library"}]},
     progress=1.0,
 )
 EXPECTED_OK = (


### PR DESCRIPTION
Follows the changes in https://github.com/huggingface/datasets-server/pull/2454

The `dataset-hub-cache` should have `libraries` as a list of strings, not a list of CompatibleLibrary objects