### PR TITLE
Fix  ExternalServerError for None URLs in split-opt-in-out-scan

### DIFF
--- a/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
@@ -46,7 +46,7 @@ async def opt_in_out_task(
     try:
         spawning_response = await check_spawning(image_urls, session, semaphore, limiter, spawning_url)
     except Exception as err:
-        raise ExternalServerError(message=f"Error when trying to connect to {spawning_url}") from err
+        raise ExternalServerError(message=f"Error when trying to connect to {spawning_url}", cause=err) from err
     if "urls" not in spawning_response:
         raise ExternalServerError(message=f"Error when trying to connect to {spawning_url}: '{spawning_response}'")
     opt_in_urls_indices = [i for i in range(len(image_urls)) if spawning_response["urls"][i]["optIn"]]

--- a/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
@@ -45,8 +45,8 @@ async def opt_in_out_task(
 ) -> tuple[list[Any], list[Any]]:
     try:
         spawning_response = await check_spawning(image_urls, session, semaphore, limiter, spawning_url)
-    except Exception:
-        raise ExternalServerError(message=f"Error when trying to connect to {spawning_url}")
+    except Exception as err:
+        raise ExternalServerError(message=f"Error when trying to connect to {spawning_url}") from err
     if "urls" not in spawning_response:
         raise ExternalServerError(message=f"Error when trying to connect to {spawning_url}: '{spawning_response}'")
     opt_in_urls_indices = [i for i in range(len(image_urls)) if spawning_response["urls"][i]["optIn"]]
@@ -224,7 +224,7 @@ def compute_opt_in_out_urls_scan_response(
 
     # get the urls
     num_scanned_rows = len(rows)
-    urls = [row[urls_column] for row in rows for urls_column in image_url_columns]
+    urls = [row[urls_column] if row[urls_column] else "" for row in rows for urls_column in image_url_columns]
 
     # scan the urls
     opt_in_urls_indices, opt_out_urls_indices = run(

--- a/services/worker/tests/fixtures/datasets.py
+++ b/services/worker/tests/fixtures/datasets.py
@@ -141,6 +141,7 @@ def datasets() -> Mapping[str, Dataset]:
                         "http://testurl.test/test_image2.jpg",
                         "other",
                         "http://testurl.test/test_image3-optIn.png",
+                        None,
                     ]
                 },
                 dtype=pd.StringDtype(storage="python"),

--- a/services/worker/tests/job_runners/split/test_opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/tests/job_runners/split/test_opt_in_out_urls_scan_from_streaming.py
@@ -120,7 +120,7 @@ DEFAULT_EMPTY_RESPONSE = {
             IMAGE_URL_COLUMNS_RESPONSE_WITH_DATA,
             {
                 "has_urls_columns": True,
-                "num_scanned_rows": 4,
+                "num_scanned_rows": 5,
                 "opt_in_urls": [
                     {"url": "http://testurl.test/test_image3-optIn.png", "row_idx": 3, "column_name": "col"}
                 ],
@@ -130,7 +130,7 @@ DEFAULT_EMPTY_RESPONSE = {
                 "urls_columns": ["col"],
                 "num_opt_out_urls": 1,
                 "num_opt_in_urls": 1,
-                "num_urls": 4,
+                "num_urls": 5,
                 "full_scan": True,
             },
         ),
@@ -154,11 +154,11 @@ DEFAULT_EMPTY_RESPONSE = {
         ),
         (
             "spawning_opt_in_out",
-            4,  # dataset has same amount of rows
+            5,  # dataset has same amount of rows
             IMAGE_URL_COLUMNS_RESPONSE_WITH_DATA,
             {
                 "has_urls_columns": True,
-                "num_scanned_rows": 4,
+                "num_scanned_rows": 5,
                 "opt_in_urls": [
                     {"url": "http://testurl.test/test_image3-optIn.png", "row_idx": 3, "column_name": "col"}
                 ],
@@ -168,7 +168,7 @@ DEFAULT_EMPTY_RESPONSE = {
                 "urls_columns": ["col"],
                 "num_opt_out_urls": 1,
                 "num_opt_in_urls": 1,
-                "num_urls": 4,
+                "num_urls": 5,
                 "full_scan": True,
             },
         ),


### PR DESCRIPTION
Fix for https://github.com/huggingface/datasets-server/issues/2608
Many URLs are None and the job runner failed when doing the join operation at https://github.com/huggingface/datasets-server/blob/main/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py#L38