### PR TITLE
Add formats tags

### DIFF
--- a/libs/libcommon/src/libcommon/processing_graph.py
+++ b/libs/libcommon/src/libcommon/processing_graph.py
@@ -687,7 +687,7 @@ specification: ProcessingGraphSpecification = {
     "dataset-compatible-libraries": {
         "input_type": "dataset",
         "triggered_by": "dataset-info",
-        "job_runner_version": 2,
+        "job_runner_version": 3,
         "difficulty": 20,
     },
 }

--- a/services/worker/src/worker/dtos.py
+++ b/services/worker/src/worker/dtos.py
@@ -221,6 +221,7 @@ class IsValidResponse(TypedDict):
 
 DatasetTag = Literal["croissant"]
 DatasetLibrary = Literal["mlcroissant", "webdataset", "datasets", "pandas", "dask"]
+DatasetFormat = Literal["json", "csv", "parquet", "imagefolder", "audiofolder", "webdataset", "text"]
 ProgrammingLanguage = Literal["python"]
 
 
@@ -240,6 +241,7 @@ class CompatibleLibrary(TypedDict):
 class DatasetCompatibleLibrariesResponse(TypedDict):
     tags: list[DatasetTag]
     libraries: list[CompatibleLibrary]
+    formats: list[DatasetFormat]
 
 
 class DatasetHubCacheResponse(TypedDict):
@@ -249,6 +251,7 @@ class DatasetHubCacheResponse(TypedDict):
     num_rows: int
     tags: list[DatasetTag]
     libraries: list[DatasetLibrary]
+    formats: list[DatasetFormat]
 
 
 class DatasetParquetResponse(TypedDict):

--- a/services/worker/src/worker/job_runners/dataset/hub_cache.py
+++ b/services/worker/src/worker/job_runners/dataset/hub_cache.py
@@ -6,7 +6,14 @@ import logging
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import CachedArtifactNotFoundError, get_previous_step_or_raise
 
-from worker.dtos import CompatibleLibrary, DatasetHubCacheResponse, DatasetLibrary, DatasetTag, JobResult
+from worker.dtos import (
+    CompatibleLibrary,
+    DatasetFormat,
+    DatasetHubCacheResponse,
+    DatasetLibrary,
+    DatasetTag,
+    JobResult,
+)
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 
 
@@ -65,6 +72,7 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
 
     tags: list[DatasetTag] = []
     libraries: list[DatasetLibrary] = []
+    formats: list[DatasetFormat] = []
     try:
         compatible_libraries_response = get_previous_step_or_raise(
             kind="dataset-compatible-libraries", dataset=dataset
@@ -72,6 +80,7 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
         tags = compatible_libraries_response["content"]["tags"]
         compatible_libraries: list[CompatibleLibrary] = compatible_libraries_response["content"]["libraries"]
         libraries = [compatible_library["library"] for compatible_library in compatible_libraries]
+        formats = compatible_libraries_response["content"].get("formats", [])
     except CachedArtifactNotFoundError:
         logging.info(f"Missing 'dataset-compatible-libraries' response for {dataset=}")
     except KeyError:
@@ -87,6 +96,7 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
             num_rows=num_rows,
             tags=tags,
             libraries=libraries,
+            formats=formats,
         ),
         progress,
     )

--- a/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
+++ b/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
@@ -51,7 +51,7 @@ UPSTREAM_RESPONSE_INFO_WEBDATASET: UpstreamResponse = UpstreamResponse(
     content={"dataset_info": {"default": {"config_name": "default", "builder_name": "webdataset"}}, "partial": False},
     progress=1.0,
 )
-UPSTREAM_RESPONSE_INFD_ERROR: UpstreamResponse = UpstreamResponse(
+UPSTREAM_RESPONSE_INFO_ERROR: UpstreamResponse = UpstreamResponse(
     kind="dataset-info",
     dataset=ERROR_DATASET,
     dataset_git_revision=REVISION_NAME,
@@ -62,6 +62,7 @@ UPSTREAM_RESPONSE_INFD_ERROR: UpstreamResponse = UpstreamResponse(
 EXPECTED_PARQUET = (
     {
         "tags": ["croissant"],
+        "formats": ["parquet"],
         "libraries": [
             {
                 "function": "Dataset",
@@ -122,6 +123,7 @@ EXPECTED_PARQUET = (
 EXPECTED_WEBDATASET = (
     {
         "tags": ["croissant"],
+        "formats": ["webdataset"],
         "libraries": [
             {
                 "function": "Dataset",
@@ -277,7 +279,7 @@ def test_compute(
         (
             ERROR_DATASET,
             [
-                UPSTREAM_RESPONSE_INFD_ERROR,
+                UPSTREAM_RESPONSE_INFO_ERROR,
             ],
             pytest.raises(CachedArtifactError),
         )

--- a/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
+++ b/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
@@ -65,24 +65,6 @@ EXPECTED_PARQUET = (
         "formats": ["parquet"],
         "libraries": [
             {
-                "function": "Dataset",
-                "language": "python",
-                "library": "mlcroissant",
-                "loading_codes": [
-                    {
-                        "config_name": "default",
-                        "arguments": {"record_set": "default", "partial": False},
-                        "code": (
-                            "from mlcroissant "
-                            "import Dataset\n"
-                            "\n"
-                            'ds = Dataset(jsonld="https://datasets-server.huggingface.co/croissant?dataset=parquet-dataset")\n'
-                            'records = ds.records("default")'
-                        ),
-                    }
-                ],
-            },
-            {
                 "function": "load_dataset",
                 "language": "python",
                 "library": "datasets",
@@ -116,15 +98,6 @@ EXPECTED_PARQUET = (
                     }
                 ],
             },
-        ],
-    },
-    1.0,
-)
-EXPECTED_WEBDATASET = (
-    {
-        "tags": ["croissant"],
-        "formats": ["webdataset"],
-        "libraries": [
             {
                 "function": "Dataset",
                 "language": "python",
@@ -134,14 +107,24 @@ EXPECTED_WEBDATASET = (
                         "config_name": "default",
                         "arguments": {"record_set": "default", "partial": False},
                         "code": (
-                            "from mlcroissant import Dataset\n"
+                            "from mlcroissant "
+                            "import Dataset\n"
                             "\n"
-                            'ds = Dataset(jsonld="https://datasets-server.huggingface.co/croissant?dataset=webdataset-dataset")\n'
+                            'ds = Dataset(jsonld="https://datasets-server.huggingface.co/croissant?dataset=parquet-dataset")\n'
                             'records = ds.records("default")'
                         ),
                     }
                 ],
             },
+        ],
+    },
+    1.0,
+)
+EXPECTED_WEBDATASET = (
+    {
+        "tags": ["croissant"],
+        "formats": ["webdataset"],
+        "libraries": [
             {
                 "function": "load_dataset",
                 "language": "python",
@@ -172,6 +155,23 @@ EXPECTED_WEBDATASET = (
                             "urls = f\"pipe: curl -s -L -H 'Authorization:Bearer {get_token()}' {'::'.join(urls)}\"\n"
                             "\n"
                             "ds = wds.WebDataset(urls).decode()"
+                        ),
+                    }
+                ],
+            },
+            {
+                "function": "Dataset",
+                "language": "python",
+                "library": "mlcroissant",
+                "loading_codes": [
+                    {
+                        "config_name": "default",
+                        "arguments": {"record_set": "default", "partial": False},
+                        "code": (
+                            "from mlcroissant import Dataset\n"
+                            "\n"
+                            'ds = Dataset(jsonld="https://datasets-server.huggingface.co/croissant?dataset=webdataset-dataset")\n'
+                            'records = ds.records("default")'
                         ),
                     }
                 ],

--- a/services/worker/tests/job_runners/dataset/test_hub_cache.py
+++ b/services/worker/tests/job_runners/dataset/test_hub_cache.py
@@ -63,7 +63,7 @@ UPSTREAM_RESPONSE_COMPATIBLE_LIBRARIES_OK: UpstreamResponse = UpstreamResponse(
     dataset=DATASET,
     dataset_git_revision=REVISION_NAME,
     http_status=HTTPStatus.OK,
-    content={"tags": ["tag"], "libraries": [{"library": "library"}]},
+    content={"tags": ["tag"], "libraries": [{"library": "library"}], "formats": ["format"]},
     progress=1.0,
 )
 UPSTREAM_RESPONSE_MODALITIES_OK: UpstreamResponse = UpstreamResponse(
@@ -83,6 +83,7 @@ EXPECTED_OK = (
         "tags": [],
         "libraries": [],
         "modalities": [],
+        "formats": [],
     },
     0.2,
 )
@@ -95,10 +96,11 @@ EXPECTED_NO_PROGRESS = (
         "tags": [],
         "libraries": [],
         "modalities": [],
+        "formats": [],
     },
     0.5,
 )
-EXPECTED_OK_WITH_LIBRARIES = (
+EXPECTED_OK_WITH_LIBRARIES_AND_FORMATS = (
     {
         "viewer": False,
         "preview": True,
@@ -107,6 +109,7 @@ EXPECTED_OK_WITH_LIBRARIES = (
         "tags": ["tag"],
         "libraries": ["library"],
         "modalities": [],
+        "formats": ["format"],
     },
     0.5,
 )
@@ -119,6 +122,7 @@ EXPECTED_OK_WITH_MODALITIES = (
         "tags": [],
         "libraries": [],
         "modalities": ["modality"],
+        "formats": [],
     },
     0.5,
 )
@@ -175,7 +179,7 @@ def get_job_runner(
                 UPSTREAM_RESPONSE_SIZE_NO_PROGRESS,
                 UPSTREAM_RESPONSE_COMPATIBLE_LIBRARIES_OK,
             ],
-            EXPECTED_OK_WITH_LIBRARIES,
+            EXPECTED_OK_WITH_LIBRARIES_AND_FORMATS,
         ),
         (
             [


### PR DESCRIPTION
Added `formats: list[str]` to "hub-cache". It is computed in "compatible-libraries" since compatibilities depend on the format.

Possibles values are
- csv
- json
- parquet
- text
- imagefolder
- audiofolder

Mentioned in https://github.com/huggingface/datasets-server/issues/2455

I chose to have it as a list for simplicity, but lmk if you think we should set it to `format: Optional[str]` instead

includes a minor change: updated the libraries order