### PR TITLE
Use pandas for single files datasets

### DIFF
--- a/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
+++ b/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
@@ -112,22 +112,21 @@ def get_builder_configs_with_simplified_data_files(
         base_path=base_path,
         download_config=download_config,
     )
-    if not metadata_configs:  # inferred patterns are ugly, so let's simplify them
-        for config in builder_configs:
-            data_files = config.data_files.resolve(base_path=base_path, download_config=download_config)
-            config.data_files = DataFilesPatternsDict(
-                {
-                    str(split): (
-                        simplify_data_files_patterns(
-                            data_files_patterns=config.data_files[split],
-                            base_path=base_path,
-                            download_config=download_config,
-                            allowed_extensions=_MODULE_TO_EXTENSIONS[module_name],
-                        )
+    for config in builder_configs:
+        data_files = config.data_files.resolve(base_path=base_path, download_config=download_config)
+        config.data_files = DataFilesPatternsDict(
+            {
+                str(split): (
+                    simplify_data_files_patterns(
+                        data_files_patterns=config.data_files[split],
+                        base_path=base_path,
+                        download_config=download_config,
+                        allowed_extensions=_MODULE_TO_EXTENSIONS[module_name],
                     )
-                    for split in data_files
-                }
-            )
+                )
+                for split in data_files
+            }
+        )
     return builder_configs
 
 

--- a/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
+++ b/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
@@ -330,9 +330,21 @@ def test_compute_error(
             "cnn_dailymail",
             "parquet",
             {
-                "1.0.0": {"test": ["1.0.0/test-*"], "train": ["1.0.0/train-*"], "validation": ["1.0.0/validation-*"]},
-                "2.0.0": {"test": ["2.0.0/test-*"], "train": ["2.0.0/train-*"], "validation": ["2.0.0/validation-*"]},
-                "3.0.0": {"test": ["3.0.0/test-*"], "train": ["3.0.0/train-*"], "validation": ["3.0.0/validation-*"]},
+                "1.0.0": {
+                    "test": ["1.0.0/test-00000-of-00001.parquet"],
+                    "train": ["1.0.0/train-*.parquet"],
+                    "validation": ["1.0.0/validation-00000-of-00001.parquet"],
+                },
+                "2.0.0": {
+                    "test": ["2.0.0/test-00000-of-00001.parquet"],
+                    "train": ["2.0.0/train-*.parquet"],
+                    "validation": ["2.0.0/validation-00000-of-00001.parquet"],
+                },
+                "3.0.0": {
+                    "test": ["3.0.0/test-00000-of-00001.parquet"],
+                    "train": ["3.0.0/train-*.parquet"],
+                    "validation": ["3.0.0/validation-00000-of-00001.parquet"],
+                },
             },
         ),
         (


### PR DESCRIPTION
Pandas only supports paths without `*`.

I fixed an issue to get the full file name from single-file datasets YAML metadata containing the `data_files` with `*` 

close https://github.com/huggingface/datasets-server/issues/2614