### PR TITLE
adapt JWT verification to new field

### DIFF
--- a/libs/libapi/src/libapi/jwt_token.py
+++ b/libs/libapi/src/libapi/jwt_token.py
@@ -308,5 +308,6 @@ def validate_jwt(
     permissions = decoded.get("permissions")
     if not isinstance(permissions, dict):
         raise JWTMissingRequiredClaim("The 'permissions' claim in the JWT payload must be a dict.")
-    if all(permissions.get(permission) is not True for permission in READ_PERMISSIONS):
+    if not any(permissions.get(permission) is True for permission in READ_PERMISSIONS):
+        # ^ any True permission among READ_PERMISSIONS is enough to read the dataset
         raise JWTInvalidClaimRead("No permission in JWT payload is True. Not allowed to read the dataset.")

--- a/libs/libapi/tests/test_authentication.py
+++ b/libs/libapi/tests/test_authentication.py
@@ -177,7 +177,9 @@ def create_request(headers: Mapping[str, str]) -> Request:
 
 def get_jwt(dataset: str) -> str:
     return jwt.encode(
-        {"sub": f"/datasets/{dataset}", "read": read_ok, "exp": exp_ok}, private_key, algorithm=algorithm_rs256
+        {"sub": f"/datasets/{dataset}", "permissions": {"repo.content.read": read_ok}, "exp": exp_ok},
+        private_key,
+        algorithm=algorithm_rs256,
     )
 
 

--- a/libs/libapi/tests/test_jwt_token.py
+++ b/libs/libapi/tests/test_jwt_token.py
@@ -331,7 +331,7 @@ def test_validate_jwt_read(read: str, expectation: Any) -> None:
             does_not_raise(),
         ),
         (
-            {"repo.write": True, "repo.content.read": False},  # <- we allow it, even if this seems contradictory
+            {"repo.write": True, "repo.content.read": False},  # a False permission does not block the True ones
             does_not_raise(),
         ),
     ],


### PR DESCRIPTION
The JWT now contains `permissions: {"repo.content.read": true}` instead
of the (soon deprecated) ``read: true`.

fixes https://github.com/huggingface/datasets-server/issues/2620.