### PR TITLE
try to fix env variable

### DIFF
--- a/chart/templates/_env/_envWorker.tpl
+++ b/chart/templates/_env/_envWorker.tpl
@@ -113,5 +113,5 @@
 - name: DESCRIPTIVE_STATISTICS_CACHE_DIRECTORY
   value: {{ .Values.descriptiveStatistics.cacheDirectory | quote }}
 - name: HF_HUB_ENABLE_HF_TRANSFER
-  value: 1
+  value: "1"
 {{- end -}}

--- a/chart/templates/services/search/_container.tpl
+++ b/chart/templates/services/search/_container.tpl
@@ -38,7 +38,7 @@
   - name: DUCKDB_INDEX_EXTENSIONS_DIRECTORY
     value: "/tmp/duckdb-extensions"
   - name: HF_HUB_ENABLE_HF_TRANSFER
-    value: 1
+    value: "1"
   volumeMounts:
   {{ include "volumeMountDuckDBIndexRW" . | nindent 2 }}
   securityContext:


### PR DESCRIPTION
While deploying the search component, it throws error:
cannot convert int64 to string