### PR TITLE
 Try to improve fts for big datasets by stage table join

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -395,7 +395,7 @@ search:
       memory: "6500Mi"
     limits:
       cpu: 16
-      memory: "6500Mi"
+      memory: "9500Mi"
 
 sseApi:
   # Number of uvicorn workers for running the application

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -46,33 +46,63 @@ from starlette.responses import Response
 
 from search.duckdb_connection import duckdb_connect
 
-FTS_COMMAND_COUNT = (
+logger = logging.getLogger(__name__)
+
+DATASETS_WITH_FTS_BY_STAGE_TABLE = ["wikimedia/wikipedia", "asoria/search_test"]
+
+FTS_FULL_TABLE_COUNT_COMMAND = (
     "SELECT COUNT(*) FROM (SELECT __hf_index_id, fts_main_data.match_bm25(__hf_index_id, ?) AS __hf_fts_score FROM"
     " data) A WHERE __hf_fts_score IS NOT NULL;"
 )
-
-FTS_COMMAND = (
+FTS_FULL_TABLE_COMMAND = (
     "SELECT * EXCLUDE (__hf_fts_score) FROM (SELECT *, fts_main_data.match_bm25(__hf_index_id, ?) AS __hf_fts_score"
     " FROM data) A WHERE __hf_fts_score IS NOT NULL ORDER BY __hf_fts_score DESC OFFSET {offset} LIMIT {length};"
 )
 
 
-logger = logging.getLogger(__name__)
+def _search_full_table(
+    query: str, offset: int, length: int, index_file_location: str, extensions_directory: Optional[str] = None
+) -> tuple[int, pa.Table]:
+    with duckdb_connect(extensions_directory=extensions_directory, database=index_file_location) as con:
+        count_result = con.execute(query=FTS_FULL_TABLE_COUNT_COMMAND, parameters=[query]).fetchall()
+        num_rows_total = count_result[0][0]  # it will always return a non-empty list with one element in a tuple
+        logging.info(f"got {num_rows_total=} results for {query=} using full table scan {offset=} {length=}")
+        pa_table = con.execute(
+            query=FTS_FULL_TABLE_COMMAND.format(offset=offset, length=length),
+            parameters=[query],
+        ).arrow()
+    return num_rows_total, pa_table
+
+
+FTS_STAGE_TABLE_COMMAND = "SELECT * FROM (SELECT __hf_index_id, fts_main_data.match_bm25(__hf_index_id, ?) AS __hf_fts_score FROM data) A WHERE __hf_fts_score IS NOT NULL;"
+JOIN_STAGE_AND_DATA_COMMAND = (
+    "SELECT data.* FROM fts_stage_table JOIN data USING(__hf_index_id) ORDER BY fts_stage_table.__hf_fts_score DESC;"
+)
+
+
+def _search_stage_table(
+    query: str, offset: int, length: int, index_file_location: str, extensions_directory: Optional[str] = None
+) -> tuple[int, pa.Table]:
+    with duckdb_connect(extensions_directory=extensions_directory, database=index_file_location) as con:
+        fts_stage_table = con.execute(query=FTS_STAGE_TABLE_COMMAND, parameters=[query]).arrow()
+        num_rows_total = fts_stage_table.num_rows
+        logging.info(f"got {num_rows_total=} results for {query=} using stage table {offset=} {length=}")
+        fts_stage_table = fts_stage_table.sort_by([("__hf_fts_score", "descending")]).slice(offset, length)
+        pa_table = con.execute(query=JOIN_STAGE_AND_DATA_COMMAND).arrow()
+    return num_rows_total, pa_table
 
 
 def full_text_search(
-    index_file_location: str, query: str, offset: int, length: int, extensions_directory: Optional[str] = None
+    fts_by_stage_table: bool,
+    index_file_location: str,
+    query: str,
+    offset: int,
+    length: int,
+    extensions_directory: Optional[str] = None,
 ) -> tuple[int, pa.Table]:
-    with duckdb_connect(extensions_directory=extensions_directory, database=index_file_location) as con:
-        count_result = con.execute(query=FTS_COMMAND_COUNT, parameters=[query]).fetchall()
-        num_rows_total = count_result[0][0]  # it will always return a non-empty list with one element in a tuple
-        logging.debug(f"got {num_rows_total=} results for {query=}")
-        query_result = con.execute(
-            query=FTS_COMMAND.format(offset=offset, length=length),
-            parameters=[query],
-        )
-        pa_table = query_result.arrow()
-    return num_rows_total, pa_table
+    if fts_by_stage_table:
+        return _search_stage_table(query, offset, length, index_file_location, extensions_directory)
+    return _search_full_table(query, offset, length, index_file_location, extensions_directory)
 
 
 async def create_response(
@@ -202,8 +232,15 @@ def create_search_endpoint(
 
                 with StepProfiler(method="search_endpoint", step="perform FTS command"):
                     logging.debug(f"connect to index file {index_file_location}")
+                    fts_by_stage_table = dataset in DATASETS_WITH_FTS_BY_STAGE_TABLE
                     num_rows_total, pa_table = await anyio.to_thread.run_sync(
-                        full_text_search, index_file_location, query, offset, length, extensions_directory
+                        full_text_search,
+                        fts_by_stage_table,
+                        index_file_location,
+                        query,
+                        offset,
+                        length,
+                        extensions_directory,
                     )
 
                 with StepProfiler(method="search_endpoint", step="create response"):

--- a/services/search/tests/routes/test_search.py
+++ b/services/search/tests/routes/test_search.py
@@ -86,15 +86,22 @@ def test_full_text_search(
     con.sql("PRAGMA create_fts_index('data', '__hf_index_id', '*', overwrite=1);")
     con.close()
 
-    # assert search results
-    (num_rows_total, pa_table) = full_text_search(index_file_location, query, offset, length)
-    assert num_rows_total is not None
-    assert pa_table is not None
-    assert num_rows_total == expected_num_rows_total
-
     fields = [pa.field("__hf_index_id", pa.int64()), pa.field("text", pa.string())]
     filtered_df = pd.DataFrame(expected_result)
     expected_table = pa.Table.from_pandas(filtered_df, schema=pa.schema(fields), preserve_index=False)
+
+    # assert search results normal mode (full table scan)
+    (num_rows_total, pa_table) = full_text_search(False, index_file_location, query, offset, length)
+    assert num_rows_total is not None
+    assert pa_table is not None
+    assert num_rows_total == expected_num_rows_total
+    assert pa_table == expected_table
+
+    # assert search results with FTS by stage table
+    (num_rows_total, pa_table) = full_text_search(True, index_file_location, query, offset, length)
+    assert num_rows_total is not None
+    assert pa_table is not None
+    assert num_rows_total == expected_num_rows_total
     assert pa_table == expected_table
 
     # ensure that database has not been modified


### PR DESCRIPTION
Following PR https://github.com/huggingface/datasets-server/pull/2633 and comment https://github.com/huggingface/datasets-server/pull/2633#issuecomment-2021117342 I would like to first try with a JOIN approach:

1. Get the rows that match the query criteria (score NOT NULL)
2.  JOIN with the `data` table to get the other columns 
 
This approach should be better than the current process, but it might still not work for big datasets since the "data" table does not have a PRIMARY KEY yet. See https://github.com/huggingface/datasets-server/blob/main/services/worker/src/worker/job_runners/split/duckdb_index.py#L58 we only define the sequence, but it is still a heap table (without indexes to improve the duckdb query plan). 
If this approach sounds good, it will be necessary to change `split-duckdb-index` to add a PRIMARY KEY at table creation, but it will affect the file size. For `wikimedia/wikipedia`, I tried adding the index, and it increased from 9GB to 13 GB. We have to put in a balance between space/performance. Otherwise, growing memory of search pods would also help.
 