### PR TITLE
fix: correct typo 'occured' to 'occurred'

### DIFF
--- a/libs/libapi/src/libapi/rows_utils.py
+++ b/libs/libapi/src/libapi/rows_utils.py
@@ -48,7 +48,7 @@ def _transform_row(
                 PIL.UnidentifiedImageError: " It seems the image can't be loaded with PIL.Image and could be corrupted."
             }
             suggestion_msg = suggestion_messages.get(type(err), " Please report the issue.")
-            location_msg = "" if row_idx == 0 else f" This occured on row {offset + row_idx}."
+            location_msg = "" if row_idx == 0 else f" This occurred on row {offset + row_idx}."
             raise TransformRowsProcessingError(
                 "Server error while post-processing the rows." + location_msg + suggestion_msg, cause=err
             ) from err

--- a/libs/libcommon/src/libcommon/viewer_utils/rows.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/rows.py
@@ -54,7 +54,7 @@ def transform_rows(
                 PIL.UnidentifiedImageError: " It seems the image can't be loaded with PIL.Image and could be corrupted."
             }
             suggestion_msg = suggestion_messages.get(type(err), " Please report the issue.")
-            location_msg = "" if row_idx == 0 else f" This occured on row {row_idx}."
+            location_msg = "" if row_idx == 0 else f" This occurred on row {row_idx}."
             raise RowsPostProcessingError(
                 "Server error while post-processing the rows." + location_msg + suggestion_msg, cause=err
             ) from err


### PR DESCRIPTION
Fixed typo in error messages in rows.py and rows_utils.py where 'occured' should be 'occurred'.