### PR TITLE
Harden sse-api hub-cache change stream (max await, task error logging, safe field access)

### DIFF
--- a/services/sse-api/src/sse_api/watcher.py
+++ b/services/sse-api/src/sse_api/watcher.py
@@ -200,9 +200,7 @@ class HubCacheWatcher:
                         if change["fullDocument"]["kind"] != HUB_CACHE_KIND:
                             continue
 
-                        updated_fields = (
-                            change.get("updateDescription") or {}
-                        ).get("updatedFields") or {}
+                        updated_fields = (change.get("updateDescription") or {}).get("updatedFields") or {}
                         if operation == "update" and not any(
                             field in updated_fields for field in ["content", "http_status"]
                         ):

--- a/services/sse-api/src/sse_api/watcher.py
+++ b/services/sse-api/src/sse_api/watcher.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 
 from motor.motor_asyncio import AsyncIOMotorClient
 from pymongo.errors import PyMongoError
+from pymongo.read_preferences import ReadPreference
 
 from sse_api.constants import HUB_CACHE_KIND
 
@@ -84,7 +85,10 @@ class HubCacheWatcher:
 
     def __init__(self, client: AsyncIOMotorClient, db_name: str, collection_name: str) -> None:
         self._client = client
-        self._collection = self._client[db_name][collection_name]
+        # Offload change stream + initial scan from primary (hot collection; write conflicts).
+        self._collection = self._client[db_name][collection_name].with_options(
+            read_preference=ReadPreference.SECONDARY_PREFERRED,
+        )
         self._publisher = HubCachePublisher(_watchers={})
 
     def run_initialization(self, suscriber: str) -> asyncio.Task[Any]:

--- a/services/sse-api/src/sse_api/watcher.py
+++ b/services/sse-api/src/sse_api/watcher.py
@@ -93,6 +93,15 @@ class HubCacheWatcher:
     def start_watching(self) -> None:
         self._watch_task = asyncio.create_task(self._watch_loop())
 
+        def _log_watch_task_result(task: asyncio.Task[None]) -> None:
+            if task.cancelled():
+                return
+            exc = task.exception()
+            if exc is not None:
+                logging.error("hub-cache watch task ended unexpectedly", exc_info=exc)
+
+        self._watch_task.add_done_callback(_log_watch_task_result)
+
     async def stop_watching(self) -> None:
         self._watch_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -170,6 +179,7 @@ class HubCacheWatcher:
                     resume_after=resume_token,
                     full_document="updateLookup",
                     full_document_before_change="whenAvailable",
+                    max_await_time_ms=30_000,
                 ) as stream:
                     async for change in stream:
                         resume_token = stream.resume_token
@@ -186,9 +196,11 @@ class HubCacheWatcher:
                         if change["fullDocument"]["kind"] != HUB_CACHE_KIND:
                             continue
 
+                        updated_fields = (
+                            change.get("updateDescription") or {}
+                        ).get("updatedFields") or {}
                         if operation == "update" and not any(
-                            field in change["updateDescription"]["updatedFields"]
-                            for field in ["content", "http_status"]
+                            field in updated_fields for field in ["content", "http_status"]
                         ):
                             # ^ no change, skip
                             continue


### PR DESCRIPTION
The hub-cache watcher can stop forwarding MongoDB change stream events while the SSE endpoint keeps emitting heartbeats, which matches production behaviour where a long-lived connection saw no data events until the pod restarted. 

This change sets max_await_time_ms on collection.watch() so getMore returns periodically instead of waiting indefinitely for the next change, which improves resilience and observability under slow or quiet streams. A done_callback on the watch task logs any unexpected task exit with a full traceback, so failures outside PyMongoError are visible in application logs instead of only as an unhandled task exception. 
Access to updateDescription.updatedFields is made defensive to avoid a KeyError on updates with an unexpected change document shape. Existing PyMongoError handling continues to log and back off before retrying the stream.

plus added SECONDARY_PREFERRED read preference 