### PR TITLE
Add startupProbe to workers

### DIFF
--- a/chart/templates/worker/_container.tpl
+++ b/chart/templates/worker/_container.tpl
@@ -51,6 +51,12 @@
     httpGet:
       path: /healthcheck
       port: {{ .workerValues.uvicornPort }}
+  startupProbe:
+    failureThreshold: 30
+    periodSeconds: 5
+    httpGet:
+      path: /healthcheck
+      port: {{ .workerValues.uvicornPort }}
   ports:
   - containerPort: {{ .workerValues.uvicornPort }}
     name: http


### PR DESCRIPTION
the worker-light pods almost always fail the livenessProbe on start because they take some time to start