### PR TITLE
keep agent trace file paths untruncated

### DIFF
--- a/libs/libcommon/src/libcommon/viewer_utils/rows.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/rows.py
@@ -192,9 +192,8 @@ def create_first_rows_response(
             / len(transformed_rows)
             > URL_COLUMN_RATIO
         )
-        or ( # prompt column of agent traces
-            features == AGENT_TRACES_FEATURES
-            and col == "prompt"
+        or (  # metadata columns of agent traces
+            features == AGENT_TRACES_FEATURES and col in {"prompt", "file_path"}
         )
     ]
     row_items, truncated = create_truncated_row_items(


### PR DESCRIPTION
Keep `file_path` untruncated for agent trace `/first-rows` metadata, matching the existing `prompt` behavior.
