### PR TITLE
Init shortcut job

### DIFF
--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -918,7 +918,7 @@
           }
         }
       },
-      "PreviousJob": {
+      "Job": {
         "type": "object",
         "required": ["dataset", "config", "split", "kind"],
         "properties": {
@@ -934,10 +934,10 @@
           "split": { "anyOf": [{ "type": "string" }, { "type": "null" }] }
         }
       },
-      "PreviousJobs": {
+      "Jobs": {
         "type": "array",
         "items": {
-          "$ref": "#/components/schemas/PreviousJob"
+          "$ref": "#/components/schemas/Job"
         }
       },
       "ParquetResponse": {
@@ -954,10 +954,10 @@
             "type": "object"
           },
           "pending": {
-            "$ref": "#/components/schemas/PreviousJobs"
+            "$ref": "#/components/schemas/Jobs"
           },
           "failed": {
-            "$ref": "#/components/schemas/PreviousJobs"
+            "$ref": "#/components/schemas/Jobs"
           },
           "partial": {
             "$ref": "#/components/schemas/Partial"
@@ -998,10 +998,10 @@
             "description": "A dump of the DatasetInfo object from the datasets library. See https://huggingface.co/docs/datasets/en/package_reference/main_classes#datasets.DatasetInfo. We don't describe the contents of these metadata for now."
           },
           "pending": {
-            "$ref": "#/components/schemas/PreviousJobs"
+            "$ref": "#/components/schemas/Jobs"
           },
           "failed": {
-            "$ref": "#/components/schemas/PreviousJobs"
+            "$ref": "#/components/schemas/Jobs"
           },
           "partial": {
             "$ref": "#/components/schemas/Partial"
@@ -1145,10 +1145,10 @@
             }
           },
           "pending": {
-            "$ref": "#/components/schemas/PreviousJobs"
+            "$ref": "#/components/schemas/Jobs"
           },
           "failed": {
-            "$ref": "#/components/schemas/PreviousJobs"
+            "$ref": "#/components/schemas/Jobs"
           },
           "partial": {
             "$ref": "#/components/schemas/Partial"

--- a/e2e/tests/test_31_admin_metrics.py
+++ b/e2e/tests/test_31_admin_metrics.py
@@ -24,7 +24,7 @@ def test_metrics() -> None:
 
     # the queue metrics are computed each time a job is created and processed
     # they should exist at least for some of jobs types
-    for queue in ["dataset-config-names", "split-first-rows", "dataset-parquet"]:
+    for queue in ["dataset-init", "split-first-rows", "dataset-parquet"]:
         # eg. 'queue_jobs_total{pid="10",queue="split-first-rows",status="started"}'
         assert has_metric(
             name="queue_jobs_total",

--- a/libs/libcommon/src/libcommon/dtos.py
+++ b/libs/libcommon/src/libcommon/dtos.py
@@ -133,3 +133,10 @@ class SplitFirstRowsResponse(FullSplitItem):
     features: list[FeatureItem]
     rows: list[RowItem]
     truncated: bool
+
+
+class CachedJob(TypedDict):
+    dataset: str
+    config: Optional[str]
+    split: Optional[str]
+    kind: str

--- a/libs/libcommon/src/libcommon/orchestrator.py
+++ b/libs/libcommon/src/libcommon/orchestrator.py
@@ -23,7 +23,13 @@ from libcommon.constants import (
     YAML_FIELDS_TO_CHECK,
 )
 from libcommon.dtos import CachedJob, JobInfo, JobResult, Priority
-from libcommon.processing_graph import ProcessingGraph, ProcessingStep, ProcessingStepDoesNotExist, processing_graph
+from libcommon.processing_graph import (
+    InputType,
+    ProcessingGraph,
+    ProcessingStep,
+    ProcessingStepDoesNotExist,
+    processing_graph,
+)
 from libcommon.prometheus import StepProfiler
 from libcommon.queue.jobs import Queue
 from libcommon.simple_cache import (
@@ -468,11 +474,28 @@ class AfterJobPlan(Plan):
         config = self.job_info["params"]["config"]
         split = self.job_info["params"]["split"]
         job_type = self.job_info["type"]
+        next_processing_steps: list[tuple[CachedJob, ProcessingStep]] = []
         try:
             processing_step = self.processing_graph.get_processing_step_by_job_type(job_type)
-            next_processing_steps = self.processing_graph.get_children(processing_step.name)
+            for next_processing_step in self.processing_graph.get_children(processing_step.name):
+                next_processing_steps.append(
+                    (
+                        {"dataset": self.dataset, "config": config, "split": split, "kind": job_type},
+                        next_processing_step,
+                    )
+                )
         except ProcessingStepDoesNotExist as e:
             raise ValueError(f"Processing step with job type: {job_type} does not exist") from e
+
+        if self.shortcut_jobs_by_key:
+            for shortcut_job in self.shortcut_jobs_by_key.values():
+                job_type = shortcut_job["kind"]
+                try:
+                    processing_step = self.processing_graph.get_processing_step_by_job_type(job_type)
+                    for next_processing_step in self.processing_graph.get_children(processing_step.name):
+                        next_processing_steps.append((shortcut_job, next_processing_step))
+                except ProcessingStepDoesNotExist as e:
+                    raise ValueError(f"Processing step with job type: {job_type} does not exist") from e
 
         if len(next_processing_steps) == 0:
             # no next processing step, nothing to do
@@ -488,28 +511,31 @@ class AfterJobPlan(Plan):
         # note that it can contain a lot of unrelated jobs, we will clean after
         self.pending_jobs_df = Queue().get_pending_jobs_df(
             dataset=self.dataset,
-            job_types=[next_processing_step.job_type for next_processing_step in next_processing_steps],
+            job_types=[next_processing_step[1].job_type for next_processing_step in next_processing_steps],
         )
 
-        self.job_infos_to_create: list[JobInfo] = []
+        self.job_infos_to_create: dict[str, JobInfo] = {}
         config_names: Optional[list[str]] = None
         split_names: Optional[list[str]] = None
 
         # filter to only get the jobs that are not already in the queue or done using a shortcut
-        for next_processing_step in next_processing_steps:
-            if processing_step.input_type == next_processing_step.input_type:
+        for cached_job, next_processing_step in next_processing_steps:
+            cached_job_input_type: InputType = (
+                "split" if cached_job["split"] else ("config" if cached_job["config"] else "dataset")
+            )
+            if cached_job_input_type == next_processing_step.input_type:
                 # same level, one job is expected
                 # D -> D, C -> C, S -> S
-                self.update(next_processing_step, config, split)
-            elif processing_step.input_type in ["config", "split"] and next_processing_step.input_type == "dataset":
+                self.update(next_processing_step, cached_job["config"], cached_job["split"])
+            elif cached_job_input_type in ["config", "split"] and next_processing_step.input_type == "dataset":
                 # going to upper level (fan-in), one job is expected
                 # S -> D, C -> D
                 self.update(next_processing_step, None, None)
-            elif processing_step.input_type == "split" and next_processing_step.input_type == "config":
+            elif cached_job_input_type == "split" and next_processing_step.input_type == "config":
                 # going to upper level (fan-in), one job is expected
                 # S -> C
-                self.update(next_processing_step, config, None)
-            elif processing_step.input_type == "dataset" and next_processing_step.input_type == "config":
+                self.update(next_processing_step, cached_job["config"], None)
+            elif cached_job_input_type == "dataset" and next_processing_step.input_type == "config":
                 # going to lower level (fan-out), one job is expected per config, we need the list of configs
                 # D -> C
                 if config_names is None:
@@ -522,7 +548,7 @@ class AfterJobPlan(Plan):
                     )  # Note that we use the cached content even the revision is different (ie. maybe obsolete)
                 for config_name in config_names:
                     self.update(next_processing_step, config_name, None)
-            elif processing_step.input_type == "config" and next_processing_step.input_type == "split":
+            elif cached_job_input_type == "config" and next_processing_step.input_type == "split":
                 # going to lower level (fan-out), one job is expected per split, we need the list of splits
                 # C -> S
                 if split_names is None:
@@ -534,20 +560,19 @@ class AfterJobPlan(Plan):
                         name_field="split",
                     )  # Note that we use the cached content even the revision is different (ie. maybe obsolete)
                 for split_name in split_names:
-                    self.update(next_processing_step, config, split_name)
+                    self.update(next_processing_step, cached_job["config"], split_name)
             else:
                 raise NotImplementedError(
-                    f"Unsupported input types: {processing_step.input_type} -> {next_processing_step.input_type}"
+                    f"Unsupported input types: {cached_job_input_type} -> {next_processing_step.input_type}"
                 )
                 # we don't support fan-out dataset-level to split-level (no need for now)
-
         # Better keep this order: delete, then create
         # Note that all the waiting jobs for other revisions will be deleted
         # The started jobs are ignored, for now.
         if not self.pending_jobs_df.empty:
             self.add_task(DeleteWaitingJobsTask(jobs_df=self.pending_jobs_df))
         if self.job_infos_to_create:
-            self.add_task(CreateJobsTask(job_infos=self.job_infos_to_create))
+            self.add_task(CreateJobsTask(job_infos=list(self.job_infos_to_create.values())))
 
     def update(
         self,
@@ -556,12 +581,10 @@ class AfterJobPlan(Plan):
         split: Optional[str],
     ) -> None:
         # ignore if job was done using a shortcut
-        if (
-            get_shortcut_job_key(
-                {"kind": next_processing_step.job_type, "dataset": self.dataset, "config": config, "split": split}
-            )
-            in self.shortcut_jobs_by_key
-        ):
+        job_key = get_shortcut_job_key(
+            {"kind": next_processing_step.job_type, "dataset": self.dataset, "config": config, "split": split}
+        )
+        if job_key in self.shortcut_jobs_by_key or job_key in self.job_infos_to_create:
             return
         # ignore unrelated jobs
         config_mask = (
@@ -593,21 +616,19 @@ class AfterJobPlan(Plan):
                 difficulty += next_processing_step.bonus_difficulty_if_dataset_is_big
             # increase difficulty according to number of failed runs
             difficulty = min(DEFAULT_DIFFICULTY_MAX, difficulty)
-            self.job_infos_to_create.append(
-                {
-                    "job_id": "not used",  # TODO: remove this field
-                    "type": next_processing_step.job_type,
-                    "params": {
-                        "dataset": self.dataset,
-                        "config": config,
-                        "split": split,
-                        "revision": self.revision,
-                    },
-                    "priority": self.priority,
-                    "difficulty": difficulty,
-                    "started_at": None,
-                }
-            )
+            self.job_infos_to_create[job_key] = {
+                "job_id": "not used",  # TODO: remove this field
+                "type": next_processing_step.job_type,
+                "params": {
+                    "dataset": self.dataset,
+                    "config": config,
+                    "split": split,
+                    "revision": self.revision,
+                },
+                "priority": self.priority,
+                "difficulty": difficulty,
+                "started_at": None,
+            }
 
 
 @dataclass

--- a/libs/libcommon/src/libcommon/orchestrator.py
+++ b/libs/libcommon/src/libcommon/orchestrator.py
@@ -22,7 +22,7 @@ from libcommon.constants import (
     DIFFICULTY_BONUS_BY_FAILED_RUNS,
     YAML_FIELDS_TO_CHECK,
 )
-from libcommon.dtos import JobInfo, JobResult, Priority
+from libcommon.dtos import CachedJob, JobInfo, JobResult, Priority
 from libcommon.processing_graph import ProcessingGraph, ProcessingStep, ProcessingStepDoesNotExist, processing_graph
 from libcommon.prometheus import StepProfiler
 from libcommon.queue.jobs import Queue
@@ -445,12 +445,13 @@ class AfterJobPlan(Plan):
 
     Args:
         job_info (`JobInfo`): The job info.
+        shortcuts_jobs (`dict[str, CachedJob]`): The list of shortcut job results obtained running job_info
         processing_graph (`ProcessingGraph`): The processing graph.
     """
 
     job_info: JobInfo
+    shortcut_jobs_by_key: dict[str, CachedJob]
     processing_graph: ProcessingGraph
-    failed_runs: int
 
     dataset: str = field(init=False)
     config: Optional[str] = field(init=False)
@@ -494,7 +495,7 @@ class AfterJobPlan(Plan):
         config_names: Optional[list[str]] = None
         split_names: Optional[list[str]] = None
 
-        # filter to only get the jobs that are not already in the queue
+        # filter to only get the jobs that are not already in the queue or done using a shortcut
         for next_processing_step in next_processing_steps:
             if processing_step.input_type == next_processing_step.input_type:
                 # same level, one job is expected
@@ -554,6 +555,14 @@ class AfterJobPlan(Plan):
         config: Optional[str],
         split: Optional[str],
     ) -> None:
+        # ignore if job was done using a shortcut
+        if (
+            get_shortcut_job_key(
+                {"kind": next_processing_step.job_type, "dataset": self.dataset, "config": config, "split": split}
+            )
+            in self.shortcut_jobs_by_key
+        ):
+            return
         # ignore unrelated jobs
         config_mask = (
             self.pending_jobs_df["config"].isnull() if config is None else self.pending_jobs_df["config"] == config
@@ -1236,15 +1245,16 @@ def get_failed_runs(job_info: JobInfo) -> int:
             split=params["split"],
         )
         return (
-            previous_response["failed_runs"]
-            if previous_response["dataset_git_revision"] == params["revision"]
-            else 0
+            previous_response["failed_runs"] if previous_response["dataset_git_revision"] == params["revision"] else 0
         )
     except CachedArtifactNotFoundError:
         return 0
 
 
 def save_job_result(job_result: JobResult, failed_runs: int) -> None:
+    if not job_result["output"]:
+        logging.debug("the job raised an exception, don't update the cache")
+        return
     job_info = job_result["job_info"]
     # update the cache
     output = job_result["output"]
@@ -1276,7 +1286,7 @@ def save_job_result(job_result: JobResult, failed_runs: int) -> None:
 
 def finish_job(
     job_info: JobInfo,
-    failed_runs: int,
+    shortcut_jobs_by_key: dict[str, CachedJob],
     processing_graph: ProcessingGraph = processing_graph,
 ) -> TasksStatistics:
     """
@@ -1286,6 +1296,7 @@ def finish_job(
 
     Args:
         job_result (`JobResult`): The result of the job.
+        shortcuts_jobs (`dict[str, CachedJob]`): The list of shortcut job results obtained running job_info
         processing_graph (`ProcessingGraph`, *optional*): The processing graph.
         failed_runs (`int`): The number of times this job has failed previously.
 
@@ -1306,7 +1317,11 @@ def finish_job(
         # ^ change the priority of children jobs if the priority was updated during the job
     logging.debug("the job has been finished.")
     # trigger the next steps
-    plan = AfterJobPlan(job_info=job_info, processing_graph=processing_graph, failed_runs=failed_runs)
+    plan = AfterJobPlan(
+        job_info=job_info,
+        shortcut_jobs_by_key=shortcut_jobs_by_key.copy(),
+        processing_graph=processing_graph,
+    )
     statistics = plan.run()
     logging.debug("jobs have been created for the next steps.")
     return statistics
@@ -1373,3 +1388,7 @@ def get_revision(dataset: str) -> Optional[str]:
     if pending_jobs.get("revision") and isinstance(revision := pending_jobs["revision"][0], str):
         return revision
     return None
+
+
+def get_shortcut_job_key(job: CachedJob) -> str:
+    return f"{job['kind']}({job['dataset']}, {job['config']}, {job['split']})"

--- a/libs/libcommon/src/libcommon/orchestrator.py
+++ b/libs/libcommon/src/libcommon/orchestrator.py
@@ -1221,35 +1221,31 @@ def backfill(
     return plan.run()
 
 
-def finish_job(
-    job_result: JobResult,
-    processing_graph: ProcessingGraph = processing_graph,
-) -> TasksStatistics:
-    """
-    Finish a job.
+def get_failed_runs(job_info: JobInfo) -> int:
+    try:
+        processing_step = processing_graph.get_processing_step_by_job_type(job_info["type"])
+    except ProcessingStepDoesNotExist as e:
+        raise ValueError(f"Processing step for job type {job_info['type']} does not exist") from e
 
-    It will finish the job, store the result in the cache, and trigger the next steps.
+    params = job_info["params"]
+    try:
+        previous_response = get_response_metadata(
+            kind=processing_step.cache_kind,
+            dataset=params["dataset"],
+            config=params["config"],
+            split=params["split"],
+        )
+        return (
+            previous_response["failed_runs"]
+            if previous_response["dataset_git_revision"] == params["revision"]
+            else 0
+        )
+    except CachedArtifactNotFoundError:
+        return 0
 
-    Args:
-        job_result (`JobResult`): The result of the job.
-        processing_graph (`ProcessingGraph`, *optional*): The processing graph.
 
-    Raises:
-        [`ValueError`]: If the job is not found, or if the processing step is not found.
-
-    Returns:
-        `TasksStatistics`: The statistics of the finish_job.
-    """
-    # check if the job is still in started status
+def save_job_result(job_result: JobResult, failed_runs: int) -> None:
     job_info = job_result["job_info"]
-    if not Queue().is_job_started(job_id=job_info["job_id"]):
-        logging.debug("the job was deleted, don't update the cache")
-        return TasksStatistics()
-    # if the job could not provide an output, finish it and return
-    if not job_result["output"]:
-        Queue().finish_job(job_id=job_info["job_id"])
-        logging.debug("the job raised an exception, don't update the cache")
-        return TasksStatistics()
     # update the cache
     output = job_result["output"]
     params = job_info["params"]
@@ -1258,21 +1254,8 @@ def finish_job(
     except ProcessingStepDoesNotExist as e:
         raise ValueError(f"Processing step for job type {job_info['type']} does not exist") from e
 
-    try:
-        previous_response = get_response_metadata(
-            kind=processing_step.cache_kind,
-            dataset=params["dataset"],
-            config=params["config"],
-            split=params["split"],
-        )
-        failed_runs = (
-            previous_response["failed_runs"] + 1
-            if output["http_status"] != HTTPStatus.OK
-            and previous_response["dataset_git_revision"] == params["revision"]
-            else 0
-        )
-    except CachedArtifactNotFoundError:
-        failed_runs = 0
+    if output["http_status"] != HTTPStatus.OK:
+        failed_runs += 1
 
     upsert_response_params(
         # inputs
@@ -1289,6 +1272,33 @@ def finish_job(
         duration=job_result["duration"],
     )
     logging.debug("the job output has been written to the cache.")
+
+
+def finish_job(
+    job_info: JobInfo,
+    failed_runs: int,
+    processing_graph: ProcessingGraph = processing_graph,
+) -> TasksStatistics:
+    """
+    Finish a job.
+
+    It will finish the job, store the result in the cache, and trigger the next steps.
+
+    Args:
+        job_result (`JobResult`): The result of the job.
+        processing_graph (`ProcessingGraph`, *optional*): The processing graph.
+        failed_runs (`int`): The number of times this job has failed previously.
+
+    Raises:
+        [`ValueError`]: If the job is not found, or if the processing step is not found.
+
+    Returns:
+        `TasksStatistics`: The statistics of the finish_job.
+    """
+    # check if the job is still in started status
+    if not Queue().is_job_started(job_id=job_info["job_id"]):
+        logging.debug("the job was deleted, don't update the cache")
+        return TasksStatistics()
     # finish the job
     job_priority = Queue().finish_job(job_id=job_info["job_id"])
     if job_priority:

--- a/libs/libcommon/src/libcommon/processing_graph.py
+++ b/libs/libcommon/src/libcommon/processing_graph.py
@@ -488,10 +488,16 @@ class Artifact:
 # - every config-level step should be triggered by at least one dataset-level or config-level step
 # to be sure the steps are processed even if a dataset has no configs, or if a config has no splits.
 specification: ProcessingGraphSpecification = {
+    "dataset-init": {
+        "input_type": "dataset",
+        "job_runner_version": 1,
+        "difficulty": 50,
+    },
     "dataset-config-names": {
         "input_type": "dataset",
         "job_runner_version": 1,
         "difficulty": 50,
+        "triggered_by": "dataset-init",
     },
     "split-first-rows": {
         "input_type": "split",
@@ -695,11 +701,12 @@ specification: ProcessingGraphSpecification = {
     },
     "dataset-filetypes": {
         "input_type": "dataset",
-        # no "triggered_by" <- this is a root step
+        "triggered_by": "dataset-init",
         "job_runner_version": 1,
         "difficulty": 50,
     },
 }
+
 
 # global variable
 processing_graph = ProcessingGraph(specification=specification)

--- a/libs/libcommon/src/libcommon/utils.py
+++ b/libs/libcommon/src/libcommon/utils.py
@@ -294,7 +294,7 @@ def download_file_from_hub(
     resume_download: bool = False,
 ) -> str:
     logging.debug(f"Using {constants.HF_HUB_ENABLE_HF_TRANSFER} for hf_transfer")
-    retry_on = [RuntimeError] if constants.HF_HUB_ENABLE_HF_TRANSFER else [ReadTimeout]
+    retry_on: list[type[Exception]] = [RuntimeError] if constants.HF_HUB_ENABLE_HF_TRANSFER else [ReadTimeout]
     retry_download_hub_file = retry(on=retry_on, sleeps=HF_HUB_HTTP_ERROR_RETRY_SLEEPS)(hf_hub_download)
     return retry_download_hub_file(
         repo_type=repo_type,

--- a/libs/libcommon/src/libcommon/viewer_utils/rows.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/rows.py
@@ -192,9 +192,8 @@ def create_first_rows_response(
             / len(transformed_rows)
             > URL_COLUMN_RATIO
         )
-        or ( # prompt column of agent traces
-            features == AGENT_TRACES_FEATURES
-            and col == "prompt"
+        or (  # prompt column of agent traces
+            features == AGENT_TRACES_FEATURES and col == "prompt"
         )
     ]
     row_items, truncated = create_truncated_row_items(

--- a/libs/libcommon/tests/test_backfill_on_real_graph.py
+++ b/libs/libcommon/tests/test_backfill_on_real_graph.py
@@ -52,6 +52,7 @@ def test_plan_job_creation_and_termination() -> None:
                 "dataset-config-names,dataset,revision",
                 "dataset-hub-cache,dataset,revision",
                 "dataset-info,dataset,revision",
+                "dataset-init,dataset,revision",
                 "dataset-is-valid,dataset,revision",
                 "dataset-compatible-libraries,dataset,revision",
                 "dataset-modalities,dataset,revision",
@@ -70,7 +71,7 @@ def test_plan_job_creation_and_termination() -> None:
         # The queue is empty, so no step is in process.
         queue_status={"in_process": []},
         # The root dataset-level steps, as well as the "fan-in" steps, are ready to be backfilled.
-        tasks=["CreateJobs,13"],
+        tasks=["CreateJobs,14"],
     )
 
     dataset_backfill_plan.run()
@@ -90,6 +91,7 @@ def test_plan_job_creation_and_termination() -> None:
                 "dataset-config-names,dataset,revision",
                 "dataset-hub-cache,dataset,revision",
                 "dataset-info,dataset,revision",
+                "dataset-init,dataset,revision",
                 "dataset-is-valid,dataset,revision",
                 "dataset-compatible-libraries,dataset,revision",
                 "dataset-modalities,dataset,revision",
@@ -111,6 +113,7 @@ def test_plan_job_creation_and_termination() -> None:
                 "dataset-config-names,dataset,revision",
                 "dataset-hub-cache,dataset,revision",
                 "dataset-info,dataset,revision",
+                "dataset-init,dataset,revision",
                 "dataset-is-valid,dataset,revision",
                 "dataset-opt-in-out-urls-count,dataset,revision",
                 "dataset-parquet,dataset,revision",
@@ -174,6 +177,7 @@ def test_plan_job_creation_and_termination() -> None:
                 "config-is-valid,dataset,revision,config2",
                 "dataset-hub-cache,dataset,revision",
                 "dataset-info,dataset,revision",
+                "dataset-init,dataset,revision",
                 "dataset-is-valid,dataset,revision",
                 "dataset-compatible-libraries,dataset,revision",
                 "dataset-modalities,dataset,revision",
@@ -194,6 +198,7 @@ def test_plan_job_creation_and_termination() -> None:
             "in_process": [
                 "dataset-hub-cache,dataset,revision",
                 "dataset-info,dataset,revision",
+                "dataset-init,dataset,revision",
                 "dataset-is-valid,dataset,revision",
                 "dataset-opt-in-out-urls-count,dataset,revision",
                 "dataset-parquet,dataset,revision",

--- a/libs/libcommon/tests/test_operations.py
+++ b/libs/libcommon/tests/test_operations.py
@@ -15,6 +15,7 @@ from huggingface_hub.utils import HfHubHTTPError
 from requests import Response
 
 from libcommon.constants import CONFIG_SPLIT_NAMES_KIND, DATASET_CONFIG_NAMES_KIND, TAG_NFAA_SYNONYMS
+from libcommon.dtos import JobResult
 from libcommon.exceptions import (
     DatasetInBlockListError,
     NotSupportedDisabledRepositoryError,
@@ -29,7 +30,7 @@ from libcommon.operations import (
     get_latest_dataset_revision_if_supported_or_raise,
     update_dataset,
 )
-from libcommon.orchestrator import finish_job
+from libcommon.orchestrator import finish_job, save_job_result
 from libcommon.processing_graph import specification
 from libcommon.queue.jobs import Queue
 from libcommon.resources import CacheMongoResource, QueueMongoResource
@@ -412,21 +413,22 @@ def test_2274_only_first_steps(
 
         # process the first two jobs
         for _ in range(2):
-            finish_job(
-                job_result={
-                    "job_info": queue.start_job(),
-                    "job_runner_version": JOB_RUNNER_VERSION,
-                    "is_success": True,
-                    "output": {
-                        "content": {},
-                        "http_status": HTTPStatus.OK,
-                        "error_code": None,
-                        "details": None,
-                        "progress": 1.0,
-                    },
-                    "duration": 1,
-                }
-            )
+            job_info = queue.start_job()
+            job_result: JobResult = {
+                "job_info": job_info,
+                "job_runner_version": JOB_RUNNER_VERSION,
+                "is_success": True,
+                "output": {
+                    "content": {},
+                    "http_status": HTTPStatus.OK,
+                    "error_code": None,
+                    "details": None,
+                    "progress": 1.0,
+                },
+                "duration": 1,
+            }
+            save_job_result(job_result, failed_runs=0)
+            finish_job(job_info, shortcut_jobs_by_key={})
 
         assert len(queue.get_pending_jobs_df(dataset=dataset)) == 7
         assert len(get_cache_entries_df(dataset=dataset)) == 2

--- a/libs/libcommon/tests/test_operations.py
+++ b/libs/libcommon/tests/test_operations.py
@@ -395,7 +395,7 @@ def test_2274_only_first_steps(
     cache_mongo_resource: CacheMongoResource,
 ) -> None:
     JOB_RUNNER_VERSION = 1
-    FIRST_CACHE_KINDS = ["dataset-config-names", "dataset-filetypes"]
+    FIRST_CACHE_KINDS = ["dataset-init"]
 
     # see https://github.com/huggingface/dataset-viewer/issues/2274
     with tmp_dataset(namespace=NORMAL_USER, token=NORMAL_USER_TOKEN, private=False) as dataset:
@@ -407,12 +407,12 @@ def test_2274_only_first_steps(
         pending_jobs_df = queue.get_pending_jobs_df(dataset=dataset)
         cache_entries_df = get_cache_entries_df(dataset=dataset)
 
-        assert len(pending_jobs_df) == 2
+        assert len(pending_jobs_df) == len(FIRST_CACHE_KINDS)
         assert pending_jobs_df.iloc[0]["type"] in FIRST_CACHE_KINDS
         assert cache_entries_df.empty
 
         # process the first two jobs
-        for _ in range(2):
+        for _ in range(len(FIRST_CACHE_KINDS)):
             job_info = queue.start_job()
             job_result: JobResult = {
                 "job_info": job_info,
@@ -430,27 +430,27 @@ def test_2274_only_first_steps(
             save_job_result(job_result, failed_runs=0)
             finish_job(job_info, shortcut_jobs_by_key={})
 
-        assert len(queue.get_pending_jobs_df(dataset=dataset)) == 7
-        assert len(get_cache_entries_df(dataset=dataset)) == 2
+        assert len(queue.get_pending_jobs_df(dataset=dataset)) == 2
+        assert len(get_cache_entries_df(dataset=dataset)) == len(FIRST_CACHE_KINDS)
 
         # let's delete all the jobs, to get in the same state as the bug
         queue.delete_dataset_waiting_jobs(dataset=dataset)
 
         assert queue.get_pending_jobs_df(dataset=dataset).empty
-        assert len(get_cache_entries_df(dataset=dataset)) == 2
+        assert len(get_cache_entries_df(dataset=dataset)) == len(FIRST_CACHE_KINDS)
 
         # try to reproduce the bug in #2375 by update at this point: no
         update_dataset(dataset=dataset, hf_endpoint=CI_HUB_ENDPOINT, hf_token=CI_APP_TOKEN)
 
         assert queue.get_pending_jobs_df(dataset=dataset).empty
-        assert len(get_cache_entries_df(dataset=dataset)) == 2
+        assert len(get_cache_entries_df(dataset=dataset)) == len(FIRST_CACHE_KINDS)
 
         # THE BUG IS REPRODUCED: the jobs should have been recreated at that point.
 
         backfill_dataset(dataset=dataset, hf_endpoint=CI_HUB_ENDPOINT, hf_token=CI_APP_TOKEN)
 
         assert not queue.get_pending_jobs_df(dataset=dataset).empty
-        assert len(get_cache_entries_df(dataset=dataset)) == 2
+        assert len(get_cache_entries_df(dataset=dataset)) == len(FIRST_CACHE_KINDS)
 
 
 @pytest.mark.parametrize(

--- a/libs/libcommon/tests/test_orchestrator.py
+++ b/libs/libcommon/tests/test_orchestrator.py
@@ -9,8 +9,10 @@ from libcommon.dtos import JobOutput, JobResult, Priority, Status
 from libcommon.orchestrator import (
     AfterJobPlan,
     finish_job,
+    get_failed_runs,
     has_pending_ancestor_jobs,
     remove_dataset,
+    save_job_result,
     set_revision,
 )
 from libcommon.processing_graph import Artifact, ProcessingGraph
@@ -92,7 +94,7 @@ def test_after_job_plan(
     after_job_plan = AfterJobPlan(
         processing_graph=processing_graph,
         job_info=job_info,
-        failed_runs=0,
+        shortcut_jobs_by_key={},
     )
     if len(artifacts_to_create):
         assert after_job_plan.as_response() == [f"CreateJobs,{len(artifacts_to_create)}"]
@@ -124,7 +126,7 @@ def test_after_job_plan_delete() -> None:
     after_job_plan = AfterJobPlan(
         processing_graph=PROCESSING_GRAPH_PARALLEL,
         job_info=job_info,
-        failed_runs=0,
+        shortcut_jobs_by_key={},
     )
     assert after_job_plan.as_response() == ["CreateJobs,1", "DeleteWaitingJobs,1"]
 
@@ -180,16 +182,8 @@ def test_finish_job(
         ),
         duration=1,
     )
-    finish_job(job_result=job_result, processing_graph=processing_graph)
 
-    assert JobDocument.objects(dataset=DATASET_NAME).count() == len(artifacts_to_create)
-
-    done_job = JobDocument.objects(dataset=DATASET_NAME, status=Status.STARTED)
-    assert done_job.count() == 0
-
-    waiting_jobs = JobDocument.objects(dataset=DATASET_NAME, status=Status.WAITING)
-    assert waiting_jobs.count() == len(artifacts_to_create)
-    assert {job.type for job in waiting_jobs} == {Artifact.parse_id(artifact)[4] for artifact in artifacts_to_create}
+    save_job_result(job_result, failed_runs=0)
 
     assert CachedResponseDocument.objects(dataset=DATASET_NAME).count() == 1
     cached_response = CachedResponseDocument.objects(dataset=DATASET_NAME).first()
@@ -201,6 +195,17 @@ def test_finish_job(
     assert cached_response.progress == 1.0
     assert cached_response.job_runner_version == JOB_RUNNER_VERSION
     assert cached_response.dataset_git_revision == REVISION_NAME
+
+    finish_job(job_info=job_result["job_info"], shortcut_jobs_by_key={}, processing_graph=processing_graph)
+
+    assert JobDocument.objects(dataset=DATASET_NAME).count() == len(artifacts_to_create)
+
+    done_job = JobDocument.objects(dataset=DATASET_NAME, status=Status.STARTED)
+    assert done_job.count() == 0
+
+    waiting_jobs = JobDocument.objects(dataset=DATASET_NAME, status=Status.WAITING)
+    assert waiting_jobs.count() == len(artifacts_to_create)
+    assert {job.type for job in waiting_jobs} == {Artifact.parse_id(artifact)[4] for artifact in artifacts_to_create}
 
 
 @pytest.mark.parametrize(
@@ -223,23 +228,10 @@ def test_finish_job_priority_update(
         difficulty=DIFFICULTY,
     )
     job_info = Queue().start_job()
-    job_result = JobResult(
-        job_info=job_info,
-        job_runner_version=JOB_RUNNER_VERSION,
-        is_success=True,
-        output=JobOutput(
-            content=CONFIG_NAMES_CONTENT,
-            http_status=HTTPStatus.OK,
-            error_code=None,
-            details=None,
-            progress=1.0,
-        ),
-        duration=1,
-    )
     # update the priority of the started job before it finishes
     JobDocument(dataset=DATASET_NAME, pk=job_info["job_id"]).update(priority=Priority.HIGH)
     # then finish
-    finish_job(job_result=job_result, processing_graph=processing_graph)
+    finish_job(job_info=job_info, shortcut_jobs_by_key={}, processing_graph=processing_graph)
 
     assert JobDocument.objects(dataset=DATASET_NAME).count() == len(artifacts_to_create)
 
@@ -428,7 +420,9 @@ def run_job(revision: str, http_status: HTTPStatus) -> None:
         ),
         duration=1,
     )
-    finish_job(job_result=job_result, processing_graph=PROCESSING_GRAPH_GENEALOGY)
+    failed_runs = get_failed_runs(job_info)
+    save_job_result(job_result, failed_runs=failed_runs)
+    finish_job(job_info=job_info, shortcut_jobs_by_key={}, processing_graph=PROCESSING_GRAPH_GENEALOGY)
     # clear generated jobs when finishing jobs
     Queue().delete_dataset_waiting_jobs(DATASET_NAME)
 

--- a/libs/libcommon/tests/test_orchestrator.py
+++ b/libs/libcommon/tests/test_orchestrator.py
@@ -449,8 +449,8 @@ def test_upsert_response_failed_runs() -> None:
 
     # overwrite cache record with failed result and new revision
     run_job(second_revision, HTTPStatus.INTERNAL_SERVER_ERROR)
-    assert_failed_runs(0)
+    assert_failed_runs(1)
 
     # overwrite cache record with success result and new revision
     run_job(second_revision, HTTPStatus.OK)
-    assert_failed_runs(0)
+    assert_failed_runs(1)

--- a/libs/libcommon/tests/test_orchestrator.py
+++ b/libs/libcommon/tests/test_orchestrator.py
@@ -228,9 +228,23 @@ def test_finish_job_priority_update(
         difficulty=DIFFICULTY,
     )
     job_info = Queue().start_job()
+    job_result = JobResult(
+        job_info=job_info,
+        job_runner_version=JOB_RUNNER_VERSION,
+        is_success=True,
+        output=JobOutput(
+            content=CONFIG_NAMES_CONTENT,
+            http_status=HTTPStatus.OK,
+            error_code=None,
+            details=None,
+            progress=1.0,
+        ),
+        duration=1,
+    )
     # update the priority of the started job before it finishes
     JobDocument(dataset=DATASET_NAME, pk=job_info["job_id"]).update(priority=Priority.HIGH)
     # then finish
+    save_job_result(job_result, failed_runs=0)
     finish_job(job_info=job_info, shortcut_jobs_by_key={}, processing_graph=processing_graph)
 
     assert JobDocument.objects(dataset=DATASET_NAME).count() == len(artifacts_to_create)

--- a/libs/libcommon/tests/test_processing_graph.py
+++ b/libs/libcommon/tests/test_processing_graph.py
@@ -62,8 +62,12 @@ def test_graph() -> None:
                 "dataset-size",
                 "dataset-is-valid",
             ],
-            [],
-            [],
+            [
+                "dataset-init",
+            ],
+            [
+                "dataset-init",
+            ],
         ),
         (
             "config-parquet-and-info",
@@ -73,7 +77,10 @@ def test_graph() -> None:
                 "config-size",
             ],
             ["dataset-config-names"],
-            ["dataset-config-names"],
+            [
+                "dataset-config-names",
+                "dataset-init",
+            ],
         ),
         (
             "config-split-names",
@@ -84,7 +91,7 @@ def test_graph() -> None:
                 "config-is-valid",
             ],
             ["dataset-config-names", "config-info"],
-            ["dataset-config-names", "config-parquet-and-info", "config-info"],
+            ["dataset-config-names", "dataset-init", "config-parquet-and-info", "config-info"],
         ),
         (
             "dataset-split-names",
@@ -97,6 +104,7 @@ def test_graph() -> None:
             ],
             [
                 "dataset-config-names",
+                "dataset-init",
                 "config-parquet-and-info",
                 "config-info",
                 "config-split-names",
@@ -109,6 +117,7 @@ def test_graph() -> None:
             [
                 "config-parquet",
                 "dataset-config-names",
+                "dataset-init",
                 "config-split-names",
                 "config-parquet-and-info",
                 "config-parquet-metadata",
@@ -119,49 +128,49 @@ def test_graph() -> None:
             "config-parquet",
             ["config-parquet-metadata", "dataset-parquet"],
             ["config-parquet-and-info"],
-            ["dataset-config-names", "config-parquet-and-info"],
+            ["dataset-config-names", "dataset-init", "config-parquet-and-info"],
         ),
         (
             "config-parquet-metadata",
             ["split-first-rows", "split-is-valid", "split-descriptive-statistics", "split-presidio-scan"],
             ["config-parquet"],
-            ["dataset-config-names", "config-parquet-and-info", "config-parquet"],
+            ["dataset-config-names", "dataset-init", "config-parquet-and-info", "config-parquet"],
         ),
         (
             "dataset-parquet",
             [],
             ["dataset-config-names", "config-parquet"],
-            ["dataset-config-names", "config-parquet-and-info", "config-parquet"],
+            ["dataset-config-names", "dataset-init", "config-parquet-and-info", "config-parquet"],
         ),
         (
             "config-info",
             ["dataset-info", "config-split-names"],
             ["config-parquet-and-info"],
-            ["dataset-config-names", "config-parquet-and-info"],
+            ["dataset-config-names", "dataset-init", "config-parquet-and-info"],
         ),
         (
             "dataset-info",
             ["dataset-compatible-libraries", "dataset-modalities", "dataset-croissant-crumbs"],
             ["dataset-config-names", "config-info"],
-            ["dataset-config-names", "config-parquet-and-info", "config-info"],
+            ["dataset-config-names", "dataset-init", "config-parquet-and-info", "config-info"],
         ),
         (
             "config-size",
             ["split-is-valid", "dataset-size"],
             ["config-parquet-and-info"],
-            ["dataset-config-names", "config-parquet-and-info"],
+            ["dataset-config-names", "dataset-init", "config-parquet-and-info"],
         ),
         (
             "dataset-size",
             ["dataset-hub-cache"],
             ["dataset-config-names", "config-size"],
-            ["dataset-config-names", "config-parquet-and-info", "config-size"],
+            ["dataset-config-names", "dataset-init", "config-parquet-and-info", "config-size"],
         ),
         (
             "dataset-compatible-libraries",
             ["dataset-hub-cache"],
             ["dataset-info"],
-            ["dataset-config-names", "config-parquet-and-info", "config-info", "dataset-info"],
+            ["dataset-config-names", "dataset-init", "config-parquet-and-info", "config-info", "dataset-info"],
         ),
         (
             "dataset-modalities",
@@ -176,6 +185,7 @@ def test_graph() -> None:
                 "dataset-config-names",
                 "dataset-filetypes",
                 "dataset-info",
+                "dataset-init",
                 "split-first-rows",
                 "split-image-url-columns",
             ],
@@ -189,6 +199,7 @@ def test_graph() -> None:
             ],
             [
                 "dataset-config-names",
+                "dataset-init",
                 "config-parquet-and-info",
                 "config-info",
                 "config-parquet",
@@ -207,6 +218,7 @@ def test_graph() -> None:
             ["split-first-rows"],
             [
                 "dataset-config-names",
+                "dataset-init",
                 "config-split-names",
                 "config-info",
                 "config-parquet-and-info",
@@ -221,6 +233,7 @@ def test_graph() -> None:
             ["split-image-url-columns"],
             [
                 "dataset-config-names",
+                "dataset-init",
                 "config-split-names",
                 "config-info",
                 "config-parquet-and-info",
@@ -236,6 +249,7 @@ def test_graph() -> None:
             ["split-opt-in-out-urls-scan"],
             [
                 "dataset-config-names",
+                "dataset-init",
                 "config-split-names",
                 "split-first-rows",
                 "config-info",
@@ -252,6 +266,7 @@ def test_graph() -> None:
             ["split-opt-in-out-urls-count", "config-split-names"],
             [
                 "dataset-config-names",
+                "dataset-init",
                 "config-split-names",
                 "split-first-rows",
                 "config-info",
@@ -269,6 +284,7 @@ def test_graph() -> None:
             ["config-opt-in-out-urls-count", "dataset-config-names"],
             [
                 "dataset-config-names",
+                "dataset-init",
                 "config-split-names",
                 "split-first-rows",
                 "config-info",
@@ -290,6 +306,7 @@ def test_graph() -> None:
                 "config-parquet-and-info",
                 "config-parquet-metadata",
                 "dataset-config-names",
+                "dataset-init",
             ],
         ),
         (
@@ -303,6 +320,7 @@ def test_graph() -> None:
                 "config-parquet-metadata",
                 "config-split-names",
                 "dataset-config-names",
+                "dataset-init",
                 "dataset-split-names",
                 "split-presidio-scan",
             ],
@@ -316,6 +334,7 @@ def test_graph() -> None:
                 "config-parquet",
                 "config-parquet-and-info",
                 "dataset-config-names",
+                "dataset-init",
             ],
         ),
         (
@@ -333,6 +352,7 @@ def test_graph() -> None:
                 "dataset-config-names",
                 "dataset-filetypes",
                 "dataset-info",
+                "dataset-init",
                 "dataset-is-valid",
                 "dataset-compatible-libraries",
                 "dataset-modalities",
@@ -355,6 +375,7 @@ def test_graph() -> None:
                 "config-info",
                 "config-size",
                 "dataset-config-names",
+                "dataset-init",
                 "split-first-rows",
                 "split-descriptive-statistics",
             ],
@@ -371,6 +392,7 @@ def test_graph() -> None:
                 "config-info",
                 "config-size",
                 "dataset-config-names",
+                "dataset-init",
                 "split-first-rows",
                 "split-descriptive-statistics",
                 "split-is-valid",
@@ -380,13 +402,17 @@ def test_graph() -> None:
             "dataset-croissant-crumbs",
             [],
             ["dataset-info"],
-            ["dataset-config-names", "config-parquet-and-info", "config-info", "dataset-info"],
+            ["dataset-config-names", "dataset-init", "config-parquet-and-info", "config-info", "dataset-info"],
         ),
         (
             "dataset-filetypes",
             ["dataset-modalities"],
-            [],
-            [],
+            [
+                "dataset-init",
+            ],
+            [
+                "dataset-init",
+            ],
         ),
     ],
 )
@@ -397,5 +423,5 @@ def test_default_graph_steps(
 
 
 def test_default_graph_first_steps() -> None:
-    roots = ["dataset-config-names", "dataset-filetypes"]
+    roots = ["dataset-init"]
     assert_lists_are_equal(processing_graph.get_first_processing_steps(), roots)

--- a/services/worker/src/worker/config.py
+++ b/services/worker/src/worker/config.py
@@ -274,11 +274,13 @@ class NumbaConfig:
 
 
 CONFIG_NAMES_MAX_NUMBER = 4_000
+CONFIG_NAMES_MAX_NUMBER_FOR_INIT = 10
 
 
 @dataclass(frozen=True)
 class ConfigNamesConfig:
     max_number: int = CONFIG_NAMES_MAX_NUMBER
+    max_number_for_init: int = CONFIG_NAMES_MAX_NUMBER_FOR_INIT
 
     @classmethod
     def from_env(cls) -> "ConfigNamesConfig":
@@ -286,6 +288,7 @@ class ConfigNamesConfig:
         with env.prefixed("CONFIG_NAMES_"):
             return cls(
                 max_number=env.int(name="MAX_NUMBER", default=CONFIG_NAMES_MAX_NUMBER),
+                max_number_for_init=env.int(name="MAX_NUMBER_FOR_INIT", default=CONFIG_NAMES_MAX_NUMBER_FOR_INIT),
             )
 
 

--- a/services/worker/src/worker/dtos.py
+++ b/services/worker/src/worker/dtos.py
@@ -43,11 +43,18 @@ class DatasetSplitNamesResponse(TypedDict):
     failed: list[FailedConfigItem]
 
 
-class PreviousJob(TypedDict):
+class Job(TypedDict):
     dataset: str
     config: Optional[str]
     split: Optional[Union[str, None]]
     kind: str
+
+
+@dataclass
+class ShortcutJobResult(JobResult):
+    job: Job
+    content: Mapping[str, Any]
+    progress: float = field(init=False, default=1.0)
 
 
 class OptUrl(TypedDict):
@@ -241,8 +248,8 @@ class DatasetConfigNamesResponse(TypedDict):
 
 class DatasetInfoResponse(TypedDict):
     dataset_info: dict[str, Any]
-    pending: list[PreviousJob]
-    failed: list[PreviousJob]
+    pending: list[Job]
+    failed: list[Job]
     partial: bool
 
 
@@ -322,8 +329,8 @@ class DatasetFiletypesResponse(TypedDict):
 
 class DatasetParquetResponse(TypedDict):
     parquet_files: list[SplitHubFile]
-    pending: list[PreviousJob]
-    failed: list[PreviousJob]
+    pending: list[Job]
+    failed: list[Job]
     partial: bool
 
 
@@ -344,6 +351,11 @@ class DatasetSizeContent(TypedDict):
 
 class DatasetSizeResponse(TypedDict):
     size: DatasetSizeContent
-    pending: list[PreviousJob]
-    failed: list[PreviousJob]
+    pending: list[Job]
+    failed: list[Job]
     partial: bool
+
+
+class DatasetInitResponse(TypedDict):
+    successes: list[Job]
+    failed: list[Job]

--- a/services/worker/src/worker/dtos.py
+++ b/services/worker/src/worker/dtos.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Literal, Optional, TypedDict, Union
 
-from libcommon.dtos import FullConfigItem, FullSplitItem, SplitHubFile, SplitItem
+from libcommon.dtos import CachedJob, FullConfigItem, FullSplitItem, SplitHubFile, SplitItem
 
 
 class JobRunnerInfo(TypedDict):
@@ -43,16 +43,9 @@ class DatasetSplitNamesResponse(TypedDict):
     failed: list[FailedConfigItem]
 
 
-class Job(TypedDict):
-    dataset: str
-    config: Optional[str]
-    split: Optional[Union[str, None]]
-    kind: str
-
-
 @dataclass
 class ShortcutJobResult(JobResult):
-    job: Job
+    job: CachedJob
     content: Mapping[str, Any]
     progress: float = field(init=False, default=1.0)
 
@@ -248,8 +241,8 @@ class DatasetConfigNamesResponse(TypedDict):
 
 class DatasetInfoResponse(TypedDict):
     dataset_info: dict[str, Any]
-    pending: list[Job]
-    failed: list[Job]
+    pending: list[CachedJob]
+    failed: list[CachedJob]
     partial: bool
 
 
@@ -329,8 +322,8 @@ class DatasetFiletypesResponse(TypedDict):
 
 class DatasetParquetResponse(TypedDict):
     parquet_files: list[SplitHubFile]
-    pending: list[Job]
-    failed: list[Job]
+    pending: list[CachedJob]
+    failed: list[CachedJob]
     partial: bool
 
 
@@ -351,11 +344,11 @@ class DatasetSizeContent(TypedDict):
 
 class DatasetSizeResponse(TypedDict):
     size: DatasetSizeContent
-    pending: list[Job]
-    failed: list[Job]
+    pending: list[CachedJob]
+    failed: list[CachedJob]
     partial: bool
 
 
 class DatasetInitResponse(TypedDict):
-    successes: list[Job]
-    failed: list[Job]
+    successes: list[CachedJob]
+    failed: list[CachedJob]

--- a/services/worker/src/worker/job_manager.py
+++ b/services/worker/src/worker/job_manager.py
@@ -8,7 +8,7 @@ from typing import Optional
 from uuid import uuid4
 
 from libcommon.config import CommonConfig
-from libcommon.dtos import JobInfo, JobParams, JobResult, Priority
+from libcommon.dtos import CachedJob, JobInfo, JobParams, JobResult, Priority
 from libcommon.exceptions import (
     CustomError,
     DatasetNotFoundError,
@@ -18,7 +18,7 @@ from libcommon.exceptions import (
     TooBigContentError,
     UnexpectedError,
 )
-from libcommon.orchestrator import finish_job, get_failed_runs, save_job_result
+from libcommon.orchestrator import finish_job, get_failed_runs, get_shortcut_job_key, save_job_result
 from libcommon.processing_graph import ProcessingStepDoesNotExist, processing_graph
 from libcommon.simple_cache import (
     CachedArtifactError,
@@ -68,6 +68,7 @@ class JobManager:
         self.worker_config = app_config.worker
         self.job_runner = job_runner
         self.job_runner_version = processing_graph.get_processing_step_by_job_type(self.job_type).job_runner_version
+        self.shortcut_jobs_by_key: dict[str, CachedJob] = {}
         self._failed_runs: Optional[int] = None
         self.setup()
 
@@ -126,7 +127,7 @@ class JobManager:
         save_job_result(job_result=job_result, failed_runs=self.failed_runs)
 
     def finish(self) -> None:
-        finish_job(job_info=self.job_info, failed_runs=self.failed_runs)
+        finish_job(job_info=self.job_info, shortcut_jobs_by_key=self.shortcut_jobs_by_key)
 
     def process(
         self,
@@ -146,6 +147,8 @@ class JobManager:
                             f" ({self.worker_config.content_max_bytes})."
                         )
                     if isinstance(job_result, ShortcutJobResult):
+                        # use a dict in case it updates the same job multiple times
+                        self.shortcut_jobs_by_key[get_shortcut_job_key(job_result.job)] = job_result.job
                         job_info = JobInfo(
                             job_id=self.job_id + "-shortcut-" + str(uuid4()),
                             type=job_result.job["kind"],
@@ -161,7 +164,7 @@ class JobManager:
                         )
                         try:
                             processing_step = processing_graph.get_processing_step_by_job_type(job_result.job["kind"])
-                            processing_step.job_runner_version
+                            job_runner_version = processing_step.job_runner_version
                         except ProcessingStepDoesNotExist as e:
                             raise ValueError(f"Processing step for job type {job_info['type']} does not exist") from e
                     else:

--- a/services/worker/src/worker/job_manager.py
+++ b/services/worker/src/worker/job_manager.py
@@ -2,8 +2,10 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 from http import HTTPStatus
 from typing import Optional
+from uuid import uuid4
 
 from libcommon.config import CommonConfig
 from libcommon.dtos import JobInfo, JobParams, JobResult, Priority
@@ -16,8 +18,8 @@ from libcommon.exceptions import (
     TooBigContentError,
     UnexpectedError,
 )
-from libcommon.orchestrator import finish_job
-from libcommon.processing_graph import processing_graph
+from libcommon.orchestrator import finish_job, get_failed_runs, save_job_result
+from libcommon.processing_graph import ProcessingStepDoesNotExist, processing_graph
 from libcommon.simple_cache import (
     CachedArtifactError,
     CachedArtifactNotFoundError,
@@ -25,6 +27,7 @@ from libcommon.simple_cache import (
 from libcommon.utils import get_duration_or_none, orjson_dumps
 
 from worker.config import AppConfig, WorkerConfig
+from worker.dtos import ShortcutJobResult
 from worker.job_runner import JobRunner
 
 
@@ -65,6 +68,7 @@ class JobManager:
         self.worker_config = app_config.worker
         self.job_runner = job_runner
         self.job_runner_version = processing_graph.get_processing_step_by_job_type(self.job_type).job_runner_version
+        self._failed_runs: Optional[int] = None
         self.setup()
 
     def setup(self) -> None:
@@ -73,6 +77,12 @@ class JobManager:
             raise ValueError(
                 f"The submitted job type is {self.job_type}, but the job manager only processes {job_type}"
             )
+
+    @property
+    def failed_runs(self) -> int:
+        if self._failed_runs is None:
+            self._failed_runs = get_failed_runs(self.job_info)
+        return self._failed_runs
 
     def __str__(self) -> str:
         return f"JobManager(job_id={self.job_id} dataset={self.job_params['dataset']} job_info={self.job_info}"
@@ -95,42 +105,81 @@ class JobManager:
     def critical(self, msg: str) -> None:
         self.log(level=logging.CRITICAL, msg=msg)
 
-    def run_job(self) -> JobResult:
+    def run_job(self) -> Iterator[JobResult]:
+        job_result: Optional[JobResult] = None
         try:
             self.job_runner.validate()
-            job_result: JobResult = self.process()
+            for job_result in self.process():
+                yield job_result
         except Exception:
-            job_result = {
-                "job_info": self.job_info,
-                "job_runner_version": self.job_runner_version,
-                "is_success": False,
-                "output": None,
-                "duration": get_duration_or_none(self.job_info["started_at"]),
-            }
-        result_str = "SUCCESS" if job_result["is_success"] else "ERROR"
-        self.debug(f"job output with {result_str} - {self}")
-        return job_result
+            if job_result is None:
+                yield {
+                    "job_info": self.job_info,
+                    "job_runner_version": self.job_runner_version,
+                    "is_success": False,
+                    "output": None,
+                    "duration": get_duration_or_none(self.job_info["started_at"]),
+                }
+                self.debug(f"job output with ERROR - {self}")
 
-    def finish(self, job_result: JobResult) -> None:
-        finish_job(job_result=job_result)
+    def save_job_result(self, job_result: JobResult) -> None:
+        save_job_result(job_result=job_result, failed_runs=self.failed_runs)
+
+    def finish(self) -> None:
+        finish_job(job_info=self.job_info, failed_runs=self.failed_runs)
 
     def process(
         self,
-    ) -> JobResult:
+    ) -> Iterator[JobResult]:
         self.info(f"compute {self}")
         started_at = self.job_info["started_at"]
         try:
             try:
                 self.job_runner.pre_compute()
-                job_result = self.job_runner.compute()
-                content = job_result.content
+                for job_result in self.job_runner.compute():
+                    content = job_result.content
 
-                # Validate content size
-                if len(orjson_dumps(content)) > self.worker_config.content_max_bytes:
-                    raise TooBigContentError(
-                        "The computed response content exceeds the supported size in bytes"
-                        f" ({self.worker_config.content_max_bytes})."
-                    )
+                    # Validate content size
+                    if len(orjson_dumps(content)) > self.worker_config.content_max_bytes:
+                        raise TooBigContentError(
+                            "The computed response content exceeds the supported size in bytes"
+                            f" ({self.worker_config.content_max_bytes})."
+                        )
+                    if isinstance(job_result, ShortcutJobResult):
+                        job_info = JobInfo(
+                            job_id=self.job_id + "-shortcut-" + str(uuid4()),
+                            type=job_result.job["kind"],
+                            params={
+                                "dataset": job_result.job["dataset"],
+                                "revision": self.job_info["params"]["revision"],
+                                "config": job_result.job["config"],
+                                "split": job_result.job["split"],
+                            },
+                            priority=self.job_info["priority"],
+                            difficulty=self.job_info["difficulty"],
+                            started_at=self.job_info["started_at"],
+                        )
+                        try:
+                            processing_step = processing_graph.get_processing_step_by_job_type(job_result.job["kind"])
+                            processing_step.job_runner_version
+                        except ProcessingStepDoesNotExist as e:
+                            raise ValueError(f"Processing step for job type {job_info['type']} does not exist") from e
+                    else:
+                        job_info = self.job_info
+                        job_runner_version = self.job_runner_version
+                    yield {
+                        "job_info": job_info,
+                        "job_runner_version": job_runner_version,
+                        "is_success": True,
+                        "output": {
+                            "content": content,
+                            "http_status": HTTPStatus.OK,
+                            "error_code": None,
+                            "details": None,
+                            "progress": job_result.progress,
+                        },
+                        "duration": get_duration_or_none(started_at),
+                    }
             except CachedArtifactNotFoundError as err:
                 raise PreviousStepStillProcessingError(
                     message="The previous steps are still being processed", cause=err
@@ -142,23 +191,10 @@ class JobManager:
                 f"dataset={self.job_params['dataset']} revision={self.job_params['revision']} job_info={self.job_info}"
                 " is valid"
             )
-            return {
-                "job_info": self.job_info,
-                "job_runner_version": self.job_runner_version,
-                "is_success": True,
-                "output": {
-                    "content": content,
-                    "http_status": HTTPStatus.OK,
-                    "error_code": None,
-                    "details": None,
-                    "progress": job_result.progress,
-                },
-                "duration": get_duration_or_none(started_at),
-            }
         except DatasetNotFoundError:
             # To avoid filling the cache, we don't save this error. Otherwise, DoS is possible.
             self.debug(f"the dataset={self.job_params['dataset']} could not be found, don't update the cache")
-            return {
+            yield {
                 "job_info": self.job_info,
                 "job_runner_version": self.job_runner_version,
                 "is_success": False,
@@ -171,7 +207,7 @@ class JobManager:
             # We add an entry to details: "copied_from_artifact", with its identification details, to have a chance
             # to debug if needed.
             self.debug(f"response for job_info={self.job_info} had an error from a previous step")
-            return {
+            yield {
                 "job_info": self.job_info,
                 "job_runner_version": self.job_runner_version,
                 "is_success": False,
@@ -187,7 +223,7 @@ class JobManager:
         except Exception as err:
             e = err if isinstance(err, CustomError) else UnexpectedError(str(err), err)
             self.debug(f"response for job_info={self.job_info} had an error")
-            return {
+            yield {
                 "job_info": self.job_info,
                 "job_runner_version": self.job_runner_version,
                 "is_success": False,
@@ -208,7 +244,7 @@ class JobManager:
             " had an error (crashed)"
         )
         error = JobManagerCrashedError(message=message, cause=cause)
-        self.finish(
+        self.save_job_result(
             job_result={
                 "job_info": self.job_info,
                 "job_runner_version": self.job_runner_version,
@@ -223,6 +259,7 @@ class JobManager:
                 "duration": get_duration_or_none(self.job_info["started_at"]),
             }
         )
+        self.finish()
 
     def set_exceeded_maximum_duration(self, message: str, cause: Optional[BaseException] = None) -> None:
         self.info(
@@ -231,7 +268,7 @@ class JobManager:
             " had an error (exceeded maximum duration)"
         )
         error = JobManagerExceededMaximumDurationError(message=message, cause=cause)
-        self.finish(
+        self.save_job_result(
             job_result={
                 "job_info": self.job_info,
                 "job_runner_version": self.job_runner_version,
@@ -246,3 +283,4 @@ class JobManager:
                 "duration": get_duration_or_none(self.job_info["started_at"]),
             }
         )
+        self.finish()

--- a/services/worker/src/worker/job_manager.py
+++ b/services/worker/src/worker/job_manager.py
@@ -165,8 +165,8 @@ class JobManager:
                         try:
                             processing_step = processing_graph.get_processing_step_by_job_type(job_result.job["kind"])
                             job_runner_version = processing_step.job_runner_version
-                        except ProcessingStepDoesNotExist as e:
-                            raise ValueError(f"Processing step for job type {job_info['type']} does not exist") from e
+                        except ProcessingStepDoesNotExist as shortcut_e:
+                            raise ValueError(f"Processing step for job type {job_info['type']} does not exist") from shortcut_e
                     else:
                         job_info = self.job_info
                         job_runner_version = self.job_runner_version

--- a/services/worker/src/worker/job_manager.py
+++ b/services/worker/src/worker/job_manager.py
@@ -166,7 +166,9 @@ class JobManager:
                             processing_step = processing_graph.get_processing_step_by_job_type(job_result.job["kind"])
                             job_runner_version = processing_step.job_runner_version
                         except ProcessingStepDoesNotExist as shortcut_e:
-                            raise ValueError(f"Processing step for job type {job_info['type']} does not exist") from shortcut_e
+                            raise ValueError(
+                                f"Processing step for job type {job_info['type']} does not exist"
+                            ) from shortcut_e
                     else:
                         job_info = self.job_info
                         job_runner_version = self.job_runner_version

--- a/services/worker/src/worker/job_runner.py
+++ b/services/worker/src/worker/job_runner.py
@@ -2,6 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 
 from libcommon.dtos import JobInfo
 
@@ -27,7 +28,7 @@ class JobRunner(ABC):
         pass
 
     @abstractmethod
-    def compute(self) -> JobResult:
+    def compute(self) -> Iterator[JobResult]:
         pass
 
     def post_compute(self) -> None:

--- a/services/worker/src/worker/job_runner_factory.py
+++ b/services/worker/src/worker/job_runner_factory.py
@@ -27,6 +27,7 @@ from worker.job_runners.dataset.croissant_crumbs import DatasetCroissantCrumbsJo
 from worker.job_runners.dataset.filetypes import DatasetFiletypesJobRunner
 from worker.job_runners.dataset.hub_cache import DatasetHubCacheJobRunner
 from worker.job_runners.dataset.info import DatasetInfoJobRunner
+from worker.job_runners.dataset.init import DatasetInitJobRunner
 from worker.job_runners.dataset.is_valid import DatasetIsValidJobRunner
 from worker.job_runners.dataset.modalities import DatasetModalitiesJobRunner
 from worker.job_runners.dataset.opt_in_out_urls_count import (
@@ -78,6 +79,12 @@ class JobRunnerFactory(BaseJobRunnerFactory):
 
     def _create_job_runner(self, job_info: JobInfo) -> JobRunner:
         job_type = job_info["type"]
+        if job_type == DatasetInitJobRunner.get_job_type():
+            return DatasetInitJobRunner(
+                job_info=job_info,
+                app_config=self.app_config,
+                hf_datasets_cache=self.hf_datasets_cache,
+            )
         if job_type == DatasetConfigNamesJobRunner.get_job_type():
             return DatasetConfigNamesJobRunner(
                 job_info=job_info,

--- a/services/worker/src/worker/job_runners/config/info.py
+++ b/services/worker/src/worker/job_runners/config/info.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterator
 
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import get_previous_step_or_raise
@@ -53,5 +54,5 @@ class ConfigInfoJobRunner(ConfigJobRunner):
     def get_job_type() -> str:
         return "config-info"
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult(compute_config_info_response(dataset=self.dataset, config=self.config))
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult(compute_config_info_response(dataset=self.dataset, config=self.config))

--- a/services/worker/src/worker/job_runners/config/is_valid.py
+++ b/services/worker/src/worker/job_runners/config/is_valid.py
@@ -2,6 +2,7 @@
 # Copyright 2023 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 from http import HTTPStatus
 
 from libcommon.exceptions import PreviousStepFormatError
@@ -90,6 +91,6 @@ class ConfigIsValidJobRunner(ConfigJobRunner):
     def get_job_type() -> str:
         return "config-is-valid"
 
-    def compute(self) -> JobResult:
+    def compute(self) -> Iterator[JobResult]:
         response_content, progress = compute_is_valid_response(dataset=self.dataset, config=self.config)
-        return JobResult(response_content, progress=progress)
+        yield JobResult(response_content, progress=progress)

--- a/services/worker/src/worker/job_runners/config/opt_in_out_urls_count.py
+++ b/services/worker/src/worker/job_runners/config/opt_in_out_urls_count.py
@@ -2,6 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 from http import HTTPStatus
 
 from libcommon.exceptions import PreviousStepFormatError
@@ -75,6 +76,6 @@ class ConfigOptInOutUrlsCountJobRunner(ConfigJobRunner):
     def get_job_type() -> str:
         return "config-opt-in-out-urls-count"
 
-    def compute(self) -> JobResult:
+    def compute(self) -> Iterator[JobResult]:
         response_content, progress = compute_opt_in_out_urls_count_response(dataset=self.dataset, config=self.config)
-        return JobResult(response_content, progress=progress)
+        yield JobResult(response_content, progress=progress)

--- a/services/worker/src/worker/job_runners/config/parquet.py
+++ b/services/worker/src/worker/job_runners/config/parquet.py
@@ -2,6 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import get_previous_step_or_raise
@@ -57,5 +58,5 @@ class ConfigParquetJobRunner(ConfigJobRunner):
     def get_job_type() -> str:
         return "config-parquet"
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult(compute_parquet_response(dataset=self.dataset, config=self.config))
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult(compute_parquet_response(dataset=self.dataset, config=self.config))

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -1131,7 +1131,7 @@ def commit_parquet_conversion(
         commit_message (`str`):
             The summary (first line) of the commit that will be created.
         target_revision (`str`, *optional*):
-            The git revision to commit from. Defaults to the head of the `"main"` branch.
+            The git revision to commit to. Defaults to the head of the `"refs/convert/parquet"` branch.
 
     Raises:
         [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError):
@@ -1151,7 +1151,7 @@ def commit_parquet_conversion(
     )
     operations: list[CommitOperation] = list(delete_operations + parquet_operations)
     logging.info(f"{len(operations)} git operations to do for {dataset=} {config=}.")
-    create_commits(
+    commits = create_commits(
         committer_hf_api,
         repo_id=dataset,
         revision=target_revision,
@@ -1159,27 +1159,28 @@ def commit_parquet_conversion(
         commit_message=commit_message,
         parent_commit=target_dataset_info.sha,
     )
-    # squash the history to save space
-    retry_super_squash_history = retry(on=[HfHubHTTPError], sleeps=HF_HUB_HTTP_ERROR_RETRY_SLEEPS)(
-        committer_hf_api.super_squash_history
-    )
-    try:
-        retry_super_squash_history(
-            repo_id=dataset,
-            repo_type=DATASET_TYPE,
-            commit_message=commit_message,
-            branch=target_revision,
+    if commits and commits[-1].oid != target_dataset_info.sha:
+        # squash the history to save space
+        retry_super_squash_history = retry(on=[HfHubHTTPError], sleeps=HF_HUB_HTTP_ERROR_RETRY_SLEEPS)(
+            committer_hf_api.super_squash_history
         )
-    except RuntimeError as e:
-        if e.__cause__ and isinstance(e.__cause__, HfHubHTTPError):
-            raise CreateCommitError(
-                message=(
-                    f"Could not squash the history of the commits (after {len(HF_HUB_HTTP_ERROR_RETRY_SLEEPS)}"
-                    f" attempts)."
-                ),
-                cause=e.__cause__,
-            ) from e.__cause__
-        raise e
+        try:
+            retry_super_squash_history(
+                repo_id=dataset,
+                repo_type=DATASET_TYPE,
+                commit_message=commit_message,
+                branch=target_revision,
+            )
+        except RuntimeError as e:
+            if e.__cause__ and isinstance(e.__cause__, HfHubHTTPError):
+                raise CreateCommitError(
+                    message=(
+                        f"Could not squash the history of the commits (after {len(HF_HUB_HTTP_ERROR_RETRY_SLEEPS)}"
+                        f" attempts)."
+                    ),
+                    cause=e.__cause__,
+                ) from e.__cause__
+            raise e
 
 
 def backward_compat_features(

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -5,7 +5,7 @@ import functools
 import logging
 import os
 import re
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Iterator
 from contextlib import ExitStack
 from itertools import groupby
 from pathlib import Path
@@ -1441,8 +1441,8 @@ class ConfigParquetAndInfoJobRunner(ConfigJobRunnerWithDatasetsCache):
         self.parquet_and_info_config = app_config.parquet_and_info
         self.committer_config = app_config.committer
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult(
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult(
             compute_config_parquet_and_info_response(
                 job_id=self.job_info["job_id"],
                 dataset=self.dataset,

--- a/services/worker/src/worker/job_runners/config/parquet_metadata.py
+++ b/services/worker/src/worker/job_runners/config/parquet_metadata.py
@@ -2,6 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 from typing import Optional
 
 from libcommon.constants import DATASET_SEPARATOR, PARQUET_REVISION
@@ -221,8 +222,8 @@ class ConfigParquetMetadataJobRunner(ConfigJobRunner):
         self.data_store = data_store
         self.parquet_metadata_directory = parquet_metadata_directory
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult(
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult(
             compute_parquet_metadata_response(
                 dataset=self.dataset,
                 config=self.config,

--- a/services/worker/src/worker/job_runners/config/size.py
+++ b/services/worker/src/worker/job_runners/config/size.py
@@ -2,6 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import get_previous_step_or_raise
@@ -110,5 +111,5 @@ class ConfigSizeJobRunner(ConfigJobRunner):
     def get_job_type() -> str:
         return "config-size"
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult(compute_config_size_response(dataset=self.dataset, config=self.config))
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult(compute_config_size_response(dataset=self.dataset, config=self.config))

--- a/services/worker/src/worker/job_runners/config/split_names.py
+++ b/services/worker/src/worker/job_runners/config/split_names.py
@@ -2,6 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 from typing import Optional
 
 from datasets import get_dataset_split_names
@@ -140,9 +141,9 @@ class ConfigSplitNamesJobRunner(ConfigJobRunnerWithDatasetsCache):
     def get_job_type() -> str:
         return "config-split-names"
 
-    def compute(self) -> CompleteJobResult:
+    def compute(self) -> Iterator[CompleteJobResult]:
         try:
-            return CompleteJobResult(
+            yield CompleteJobResult(
                 compute_split_names_from_info_response(
                     dataset=self.dataset, config=self.config, max_number=self.app_config.split_names.max_number
                 )
@@ -153,7 +154,7 @@ class ConfigSplitNamesJobRunner(ConfigJobRunnerWithDatasetsCache):
                 f"Trying to compute it using streaming."
             )
             pass
-        return CompleteJobResult(
+        yield CompleteJobResult(
             compute_split_names_from_streaming_response(
                 dataset=self.dataset,
                 config=self.config,

--- a/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
+++ b/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
@@ -3,6 +3,7 @@
 
 import logging
 import re
+from collections.abc import Iterator
 from http import HTTPStatus
 from itertools import islice
 from typing import Any, Callable, Optional
@@ -932,8 +933,7 @@ class DatasetCompatibleLibrariesJobRunner(DatasetJobRunnerWithDatasetsCache):
     def get_job_type() -> str:
         return "dataset-compatible-libraries"
 
-    def compute(self) -> CompleteJobResult:
-        response_content = compute_compatible_libraries_response(
-            dataset=self.dataset, hf_token=self.app_config.common.hf_token
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult(
+            compute_compatible_libraries_response(dataset=self.dataset, hf_token=self.app_config.common.hf_token)
         )
-        return CompleteJobResult(response_content)

--- a/services/worker/src/worker/job_runners/dataset/croissant_crumbs.py
+++ b/services/worker/src/worker/job_runners/dataset/croissant_crumbs.py
@@ -3,7 +3,7 @@
 
 import logging
 import re
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from itertools import islice
 from typing import Any
 
@@ -230,6 +230,5 @@ class DatasetCroissantCrumbsJobRunner(DatasetJobRunner):
     def get_job_type() -> str:
         return "dataset-croissant-crumbs"
 
-    def compute(self) -> CompleteJobResult:
-        response_content = compute_croissant_crumbs_response(dataset=self.dataset)
-        return CompleteJobResult(response_content)
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult(compute_croissant_crumbs_response(dataset=self.dataset))

--- a/services/worker/src/worker/job_runners/dataset/filetypes.py
+++ b/services/worker/src/worker/job_runners/dataset/filetypes.py
@@ -3,6 +3,7 @@
 
 import logging
 from collections import Counter
+from collections.abc import Iterator
 from typing import Optional
 
 from datasets import DownloadConfig, StreamingDownloadManager
@@ -116,8 +117,8 @@ class DatasetFiletypesJobRunner(DatasetJobRunnerWithDatasetsCache):
     def get_job_type() -> str:
         return "dataset-filetypes"
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult(
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult(
             compute_filetypes_response(
                 dataset=self.dataset,
                 hf_endpoint=self.app_config.common.hf_endpoint,

--- a/services/worker/src/worker/job_runners/dataset/hub_cache.py
+++ b/services/worker/src/worker/job_runners/dataset/hub_cache.py
@@ -2,6 +2,7 @@
 # Copyright 2023 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 from typing import Optional
 
 from libcommon.exceptions import PreviousStepFormatError
@@ -139,6 +140,6 @@ class DatasetHubCacheJobRunner(DatasetJobRunner):
     def get_job_type() -> str:
         return "dataset-hub-cache"
 
-    def compute(self) -> JobResult:
+    def compute(self) -> Iterator[JobResult]:
         response_content, progress = compute_hub_cache_response(dataset=self.dataset)
-        return JobResult(response_content, progress=progress)
+        yield JobResult(response_content, progress=progress)

--- a/services/worker/src/worker/job_runners/dataset/info.py
+++ b/services/worker/src/worker/job_runners/dataset/info.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from http import HTTPStatus
 from typing import Any
 
+from libcommon.dtos import CachedJob
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import (
     CachedArtifactNotFoundError,
@@ -13,7 +14,7 @@ from libcommon.simple_cache import (
     get_response,
 )
 
-from worker.dtos import DatasetInfoResponse, Job, JobResult
+from worker.dtos import DatasetInfoResponse, JobResult
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 
 
@@ -57,7 +58,7 @@ def compute_dataset_info_response(dataset: str) -> tuple[DatasetInfoResponse, fl
             except CachedArtifactNotFoundError:
                 logging.debug(f"No response found in previous step for {dataset=} {config=}: 'config-info'.")
                 pending.append(
-                    Job(
+                    CachedJob(
                         kind="config-info",
                         dataset=dataset,
                         config=config,
@@ -68,7 +69,7 @@ def compute_dataset_info_response(dataset: str) -> tuple[DatasetInfoResponse, fl
             if config_response["http_status"] != HTTPStatus.OK:
                 logging.debug(f"Previous step gave an error: {config_response['http_status']}")
                 failed.append(
-                    Job(
+                    CachedJob(
                         kind="config-info",
                         dataset=dataset,
                         config=config,

--- a/services/worker/src/worker/job_runners/dataset/info.py
+++ b/services/worker/src/worker/job_runners/dataset/info.py
@@ -2,6 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 from http import HTTPStatus
 from typing import Any
 
@@ -12,7 +13,7 @@ from libcommon.simple_cache import (
     get_response,
 )
 
-from worker.dtos import DatasetInfoResponse, JobResult, PreviousJob
+from worker.dtos import DatasetInfoResponse, Job, JobResult
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 
 
@@ -56,7 +57,7 @@ def compute_dataset_info_response(dataset: str) -> tuple[DatasetInfoResponse, fl
             except CachedArtifactNotFoundError:
                 logging.debug(f"No response found in previous step for {dataset=} {config=}: 'config-info'.")
                 pending.append(
-                    PreviousJob(
+                    Job(
                         kind="config-info",
                         dataset=dataset,
                         config=config,
@@ -67,7 +68,7 @@ def compute_dataset_info_response(dataset: str) -> tuple[DatasetInfoResponse, fl
             if config_response["http_status"] != HTTPStatus.OK:
                 logging.debug(f"Previous step gave an error: {config_response['http_status']}")
                 failed.append(
-                    PreviousJob(
+                    Job(
                         kind="config-info",
                         dataset=dataset,
                         config=config,
@@ -91,6 +92,6 @@ class DatasetInfoJobRunner(DatasetJobRunner):
     def get_job_type() -> str:
         return "dataset-info"
 
-    def compute(self) -> JobResult:
+    def compute(self) -> Iterator[JobResult]:
         response_content, progress = compute_dataset_info_response(dataset=self.dataset)
-        return JobResult(response_content, progress=progress)
+        yield JobResult(response_content, progress=progress)

--- a/services/worker/src/worker/job_runners/dataset/init.py
+++ b/services/worker/src/worker/job_runners/dataset/init.py
@@ -5,15 +5,12 @@ import logging
 from collections.abc import Iterator
 from typing import Optional
 
-from datasets import (
-    get_dataset_config_names,
-    get_dataset_default_config_name,
-)
 from datasets.data_files import EmptyDatasetError as _EmptyDatasetError
 from datasets.exceptions import (
     DataFilesNotFoundError as _DataFilesNotFoundError,
 )
 from datasets.exceptions import DatasetNotFoundError
+from datasets.load import dataset_module_factory, get_dataset_builder_class
 from huggingface_hub.utils import HfHubHTTPError
 from libcommon.exceptions import (
     ConfigNamesError,
@@ -25,17 +22,18 @@ from libcommon.exceptions import (
     RetryableConfigNamesError,
 )
 
-from worker.dtos import CompleteJobResult, ConfigNameItem, DatasetConfigNamesResponse
+from worker.dtos import ConfigNameItem, DatasetConfigNamesResponse, DatasetInitResponse, Job, JobResult, ShortcutJobResult
+from worker.job_runners.dataset.config_names import DatasetConfigNamesJobRunner
 from worker.job_runners.dataset.dataset_job_runner import (
     DatasetJobRunnerWithDatasetsCache,
 )
 
 
-def compute_config_names_response(
+def compute_init_responses(
     dataset: str,
-    max_number: int,
+    max_num_configs: int,
     hf_token: Optional[str] = None,
-) -> DatasetConfigNamesResponse:
+) -> Iterator[JobResult]:
     """
     Get the response of 'dataset-config-names' for one specific dataset on huggingface.co.
     Dataset can be gated if you pass an acceptable token.
@@ -60,26 +58,10 @@ def compute_config_names_response(
     Returns:
         `DatasetConfigNamesResponse`: An object with the list of config names.
     """
-    logging.info(f"compute 'dataset-config-names' for {dataset=}")
-    # get the list of splits in streaming mode
+    logging.info(f"compute 'dataset-init' for {dataset=}")
+    dataset_init_response: DatasetInitResponse = {"successes": [], "failed": []}
     try:
-        default_config_name: Optional[str] = None
-        config_names = get_dataset_config_names(
-            path=dataset,
-            token=hf_token,
-        )
-        if len(config_names) > 1:
-            default_config_name = get_dataset_default_config_name(
-                path=dataset,
-                token=hf_token,
-            )
-        config_name_items: list[ConfigNameItem] = [
-            {"dataset": dataset, "config": str(config)}
-            for config in sorted(
-                config_names,
-                key=lambda config_name: (config_name != default_config_name, config_name),  # default config first
-            )
-        ]
+        dataset_module = dataset_module_factory(dataset, token=hf_token)
     except _EmptyDatasetError as err:
         raise EmptyDatasetError("The dataset is empty.", cause=err) from err
     except _DataFilesNotFoundError as err:
@@ -95,25 +77,51 @@ def compute_config_names_response(
     except Exception as err:
         raise ConfigNamesError("Cannot get the config names for the dataset.", cause=err) from err
 
+    default_config_name: Optional[str] = None
+    builder_cls = get_dataset_builder_class(dataset_module)
+    config_names = list(builder_cls.builder_configs.keys())
+    if "config_name" in dataset_module.builder_kwargs and isinstance(
+        dataset_module.builder_kwargs["config_name"], str
+    ):
+        default_config_name = dataset_module.builder_kwargs["config_name"]
+    elif builder_cls.DEFAULT_CONFIG_NAME:
+        default_config_name = builder_cls.DEFAULT_CONFIG_NAME
+    elif config_names:
+        default_config_name = config_names[0] if len(config_names) == 1 else None
+    else:
+        default_config_name = "default"
+
+    config_name_items: list[ConfigNameItem] = [
+        {"dataset": dataset, "config": str(config)}
+        for config in sorted(
+            config_names,
+            key=lambda config_name: (config_name != default_config_name, config_name),  # default config first
+        )
+    ]
+
     number_of_configs = len(config_name_items)
-    if number_of_configs > max_number:
+    if number_of_configs > max_num_configs:
         raise DatasetWithTooManyConfigsError(
-            f"The maximum number of configs allowed is {max_number}, dataset has {number_of_configs} configs."
+            f"The maximum number of configs allowed is {max_num_configs}, dataset has {number_of_configs} configs."
         )
 
-    return DatasetConfigNamesResponse(config_names=config_name_items)
+    job: Job = {"dataset": dataset, "kind": DatasetConfigNamesJobRunner.get_job_type(), "config": None, "split": None}
+    dataset_init_response["successes"].append(job)
+    yield ShortcutJobResult(
+        content=DatasetConfigNamesResponse(config_names=config_name_items),
+        job=job,
+    )
+    yield JobResult(dataset_init_response, progress=1.0)
 
 
-class DatasetConfigNamesJobRunner(DatasetJobRunnerWithDatasetsCache):
+class DatasetInitJobRunner(DatasetJobRunnerWithDatasetsCache):
     @staticmethod
     def get_job_type() -> str:
-        return "dataset-config-names"
+        return "dataset-init"
 
-    def compute(self) -> Iterator[CompleteJobResult]:
-        yield CompleteJobResult(
-            compute_config_names_response(
-                dataset=self.dataset,
-                hf_token=self.app_config.common.hf_token,
-                max_number=self.app_config.config_names.max_number,
-            )
+    def compute(self) -> Iterator[JobResult]:
+        yield from compute_init_responses(
+            dataset=self.dataset,
+            hf_token=self.app_config.common.hf_token,
+            max_num_configs=self.app_config.config_names.max_number_for_init,
         )

--- a/services/worker/src/worker/job_runners/dataset/init.py
+++ b/services/worker/src/worker/job_runners/dataset/init.py
@@ -12,6 +12,7 @@ from datasets.exceptions import (
 from datasets.exceptions import DatasetNotFoundError
 from datasets.load import dataset_module_factory, get_dataset_builder_class
 from huggingface_hub.utils import HfHubHTTPError
+from libcommon.dtos import CachedJob
 from libcommon.exceptions import (
     ConfigNamesError,
     DataFilesNotFoundError,
@@ -22,7 +23,13 @@ from libcommon.exceptions import (
     RetryableConfigNamesError,
 )
 
-from worker.dtos import ConfigNameItem, DatasetConfigNamesResponse, DatasetInitResponse, Job, JobResult, ShortcutJobResult
+from worker.dtos import (
+    ConfigNameItem,
+    DatasetConfigNamesResponse,
+    DatasetInitResponse,
+    JobResult,
+    ShortcutJobResult,
+)
 from worker.job_runners.dataset.config_names import DatasetConfigNamesJobRunner
 from worker.job_runners.dataset.dataset_job_runner import (
     DatasetJobRunnerWithDatasetsCache,
@@ -105,7 +112,12 @@ def compute_init_responses(
             f"The maximum number of configs allowed is {max_num_configs}, dataset has {number_of_configs} configs."
         )
 
-    job: Job = {"dataset": dataset, "kind": DatasetConfigNamesJobRunner.get_job_type(), "config": None, "split": None}
+    job: CachedJob = {
+        "dataset": dataset,
+        "kind": DatasetConfigNamesJobRunner.get_job_type(),
+        "config": None,
+        "split": None,
+    }
     dataset_init_response["successes"].append(job)
     yield ShortcutJobResult(
         content=DatasetConfigNamesResponse(config_names=config_name_items),

--- a/services/worker/src/worker/job_runners/dataset/is_valid.py
+++ b/services/worker/src/worker/job_runners/dataset/is_valid.py
@@ -2,6 +2,7 @@
 # Copyright 2023 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 from http import HTTPStatus
 
 from libcommon.exceptions import PreviousStepFormatError
@@ -85,6 +86,6 @@ class DatasetIsValidJobRunner(DatasetJobRunner):
     def get_job_type() -> str:
         return "dataset-is-valid"
 
-    def compute(self) -> JobResult:
+    def compute(self) -> Iterator[JobResult]:
         response_content, progress = compute_is_valid_response(dataset=self.dataset)
-        return JobResult(response_content, progress=progress)
+        yield JobResult(response_content, progress=progress)

--- a/services/worker/src/worker/job_runners/dataset/modalities.py
+++ b/services/worker/src/worker/job_runners/dataset/modalities.py
@@ -2,6 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 from http import HTTPStatus
 
 from datasets import Audio, Features, Image, LargeList, List, Pdf, Translation, TranslationVariableLanguages, Value
@@ -383,6 +384,5 @@ class DatasetModalitiesJobRunner(DatasetJobRunner):
     def get_job_type() -> str:
         return "dataset-modalities"
 
-    def compute(self) -> CompleteJobResult:
-        response_content = compute_modalities_response(dataset=self.dataset)
-        return CompleteJobResult(response_content)
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult(compute_modalities_response(dataset=self.dataset))

--- a/services/worker/src/worker/job_runners/dataset/opt_in_out_urls_count.py
+++ b/services/worker/src/worker/job_runners/dataset/opt_in_out_urls_count.py
@@ -2,6 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 from http import HTTPStatus
 
 from libcommon.exceptions import PreviousStepFormatError
@@ -83,6 +84,6 @@ class DatasetOptInOutUrlsCountJobRunner(DatasetJobRunner):
     def get_job_type() -> str:
         return "dataset-opt-in-out-urls-count"
 
-    def compute(self) -> JobResult:
+    def compute(self) -> Iterator[JobResult]:
         response_content, progress = compute_opt_in_out_urls_count_response(dataset=self.dataset)
-        return JobResult(response_content, progress=progress)
+        yield JobResult(response_content, progress=progress)

--- a/services/worker/src/worker/job_runners/dataset/parquet.py
+++ b/services/worker/src/worker/job_runners/dataset/parquet.py
@@ -2,6 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 from http import HTTPStatus
 
 from libcommon.dtos import SplitHubFile
@@ -15,8 +16,8 @@ from libcommon.simple_cache import (
 from worker.dtos import (
     ConfigParquetResponse,
     DatasetParquetResponse,
+    Job,
     JobResult,
-    PreviousJob,
 )
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 
@@ -59,7 +60,7 @@ def compute_parquet_response(dataset: str) -> tuple[DatasetParquetResponse, floa
             except CachedArtifactNotFoundError:
                 logging.debug("No response found in previous step for this dataset: 'config-parquet' endpoint.")
                 pending.append(
-                    PreviousJob(
+                    Job(
                         {
                             "kind": "config-parquet",
                             "dataset": dataset,
@@ -72,7 +73,7 @@ def compute_parquet_response(dataset: str) -> tuple[DatasetParquetResponse, floa
             if response["http_status"] != HTTPStatus.OK:
                 logging.debug(f"Previous step gave an error: {response['http_status']}.")
                 failed.append(
-                    PreviousJob(
+                    Job(
                         {
                             "kind": "config-parquet",
                             "dataset": dataset,
@@ -105,6 +106,6 @@ class DatasetParquetJobRunner(DatasetJobRunner):
     def get_job_type() -> str:
         return "dataset-parquet"
 
-    def compute(self) -> JobResult:
+    def compute(self) -> Iterator[JobResult]:
         response_content, progress = compute_parquet_response(dataset=self.dataset)
-        return JobResult(response_content, progress=progress)
+        yield JobResult(response_content, progress=progress)

--- a/services/worker/src/worker/job_runners/dataset/parquet.py
+++ b/services/worker/src/worker/job_runners/dataset/parquet.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Iterator
 from http import HTTPStatus
 
-from libcommon.dtos import SplitHubFile
+from libcommon.dtos import CachedJob, SplitHubFile
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import (
     CachedArtifactNotFoundError,
@@ -16,7 +16,6 @@ from libcommon.simple_cache import (
 from worker.dtos import (
     ConfigParquetResponse,
     DatasetParquetResponse,
-    Job,
     JobResult,
 )
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
@@ -60,7 +59,7 @@ def compute_parquet_response(dataset: str) -> tuple[DatasetParquetResponse, floa
             except CachedArtifactNotFoundError:
                 logging.debug("No response found in previous step for this dataset: 'config-parquet' endpoint.")
                 pending.append(
-                    Job(
+                    CachedJob(
                         {
                             "kind": "config-parquet",
                             "dataset": dataset,
@@ -73,7 +72,7 @@ def compute_parquet_response(dataset: str) -> tuple[DatasetParquetResponse, floa
             if response["http_status"] != HTTPStatus.OK:
                 logging.debug(f"Previous step gave an error: {response['http_status']}.")
                 failed.append(
-                    Job(
+                    CachedJob(
                         {
                             "kind": "config-parquet",
                             "dataset": dataset,

--- a/services/worker/src/worker/job_runners/dataset/presidio_entities_count.py
+++ b/services/worker/src/worker/job_runners/dataset/presidio_entities_count.py
@@ -2,6 +2,7 @@
 # Copyright 2024 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 from http import HTTPStatus
 
 from libcommon.exceptions import PreviousStepFormatError
@@ -95,6 +96,6 @@ class DatasetPresidioEntitiesCountJobRunner(DatasetJobRunner):
     def get_job_type() -> str:
         return "dataset-presidio-entities-count"
 
-    def compute(self) -> JobResult:
+    def compute(self) -> Iterator[JobResult]:
         response_content, progress = compute_presidio_entities_count_response(dataset=self.dataset)
-        return JobResult(response_content, progress=progress)
+        yield JobResult(response_content, progress=progress)

--- a/services/worker/src/worker/job_runners/dataset/size.py
+++ b/services/worker/src/worker/job_runners/dataset/size.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from http import HTTPStatus
 from typing import Optional
 
+from libcommon.dtos import CachedJob
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import (
     CachedArtifactNotFoundError,
@@ -18,7 +19,6 @@ from worker.dtos import (
     ConfigSizeResponse,
     DatasetSize,
     DatasetSizeResponse,
-    Job,
     JobResult,
     SplitSize,
 )
@@ -64,7 +64,7 @@ def compute_sizes_response(dataset: str) -> tuple[DatasetSizeResponse, float]:
             except CachedArtifactNotFoundError:
                 logging.debug("No response found in previous step for this dataset: 'config-size' endpoint.")
                 pending.append(
-                    Job(
+                    CachedJob(
                         {
                             "kind": "config-size",
                             "dataset": dataset,
@@ -77,7 +77,7 @@ def compute_sizes_response(dataset: str) -> tuple[DatasetSizeResponse, float]:
             if response["http_status"] != HTTPStatus.OK:
                 logging.debug(f"Previous step gave an error: {response['http_status']}.")
                 failed.append(
-                    Job(
+                    CachedJob(
                         {
                             "kind": "config-size",
                             "dataset": dataset,

--- a/services/worker/src/worker/job_runners/dataset/size.py
+++ b/services/worker/src/worker/job_runners/dataset/size.py
@@ -2,6 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 from http import HTTPStatus
 from typing import Optional
 
@@ -17,8 +18,8 @@ from worker.dtos import (
     ConfigSizeResponse,
     DatasetSize,
     DatasetSizeResponse,
+    Job,
     JobResult,
-    PreviousJob,
     SplitSize,
 )
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
@@ -63,7 +64,7 @@ def compute_sizes_response(dataset: str) -> tuple[DatasetSizeResponse, float]:
             except CachedArtifactNotFoundError:
                 logging.debug("No response found in previous step for this dataset: 'config-size' endpoint.")
                 pending.append(
-                    PreviousJob(
+                    Job(
                         {
                             "kind": "config-size",
                             "dataset": dataset,
@@ -76,7 +77,7 @@ def compute_sizes_response(dataset: str) -> tuple[DatasetSizeResponse, float]:
             if response["http_status"] != HTTPStatus.OK:
                 logging.debug(f"Previous step gave an error: {response['http_status']}.")
                 failed.append(
-                    PreviousJob(
+                    Job(
                         {
                             "kind": "config-size",
                             "dataset": dataset,
@@ -138,6 +139,6 @@ class DatasetSizeJobRunner(DatasetJobRunner):
     def get_job_type() -> str:
         return "dataset-size"
 
-    def compute(self) -> JobResult:
+    def compute(self) -> Iterator[JobResult]:
         response_content, progress = compute_sizes_response(dataset=self.dataset)
-        return JobResult(response_content, progress=progress)
+        yield JobResult(response_content, progress=progress)

--- a/services/worker/src/worker/job_runners/dataset/split_names.py
+++ b/services/worker/src/worker/job_runners/dataset/split_names.py
@@ -2,6 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 from http import HTTPStatus
 
 from libcommon.constants import CONFIG_SPLIT_NAMES_KIND
@@ -104,6 +105,6 @@ class DatasetSplitNamesJobRunner(DatasetJobRunner):
     def get_job_type() -> str:
         return "dataset-split-names"
 
-    def compute(self) -> JobResult:
+    def compute(self) -> Iterator[JobResult]:
         response_content, progress = compute_dataset_split_names_response(dataset=self.dataset)
-        return JobResult(response_content, progress=progress)
+        yield JobResult(response_content, progress=progress)

--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -2,6 +2,7 @@
 # Copyright 2023 The HuggingFace Authors.
 import logging
 from collections import Counter
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Optional, TypedDict, Union
 
@@ -333,10 +334,10 @@ class SplitDescriptiveStatisticsJobRunner(SplitJobRunnerWithCache):
     def get_job_type() -> str:
         return "split-descriptive-statistics"
 
-    def compute(self) -> CompleteJobResult:
+    def compute(self) -> Iterator[CompleteJobResult]:
         if self.cache_subdirectory is None:
             raise CacheDirectoryNotInitializedError("Cache directory has not been initialized.")
-        return CompleteJobResult(
+        yield CompleteJobResult(
             compute_descriptive_statistics_response(
                 dataset=self.dataset,
                 config=self.config,

--- a/services/worker/src/worker/job_runners/split/first_rows.py
+++ b/services/worker/src/worker/job_runners/split/first_rows.py
@@ -4,6 +4,7 @@
 
 import functools
 import logging
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Optional
 
@@ -314,9 +315,9 @@ class SplitFirstRowsJobRunner(SplitJobRunnerWithDatasetsCache):
         self.parquet_metadata_directory = parquet_metadata_directory
         self.storage_client = storage_client
 
-    def compute(self) -> CompleteJobResult:
+    def compute(self) -> Iterator[CompleteJobResult]:
         try:
-            return CompleteJobResult(
+            yield CompleteJobResult(
                 compute_first_rows_from_parquet_response(
                     dataset=self.dataset,
                     revision=self.dataset_git_revision,
@@ -345,7 +346,7 @@ class SplitFirstRowsJobRunner(SplitJobRunnerWithDatasetsCache):
                 f"Trying to compute it using streaming."
             )
             pass
-        return CompleteJobResult(
+        yield CompleteJobResult(
             compute_first_rows_from_streaming_response(
                 dataset=self.dataset,
                 revision=self.dataset_git_revision,

--- a/services/worker/src/worker/job_runners/split/first_rows.py
+++ b/services/worker/src/worker/job_runners/split/first_rows.py
@@ -345,7 +345,9 @@ class SplitFirstRowsJobRunner(SplitJobRunnerWithDatasetsCache):
                 f"Cannot compute 'split-first-rows' from parquet for {self.dataset=} {self.config=}. "
                 f"Trying to compute it using streaming."
             )
-            pass
+        else:
+            # If the parquet path succeeded, return early to avoid trying the streaming path
+            return
         yield CompleteJobResult(
             compute_first_rows_from_streaming_response(
                 dataset=self.dataset,

--- a/services/worker/src/worker/job_runners/split/image_url_columns.py
+++ b/services/worker/src/worker/job_runners/split/image_url_columns.py
@@ -2,6 +2,7 @@
 # Copyright 2023 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 
 from libcommon.dtos import SplitFirstRowsResponse
 from libcommon.exceptions import PreviousStepFormatError
@@ -103,8 +104,8 @@ class SplitImageUrlColumnsJobRunner(SplitJobRunner):
     def get_job_type() -> str:
         return "split-image-url-columns"
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult(
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult(
             compute_image_url_columns(
                 dataset=self.dataset,
                 config=self.config,

--- a/services/worker/src/worker/job_runners/split/is_valid.py
+++ b/services/worker/src/worker/job_runners/split/is_valid.py
@@ -2,6 +2,7 @@
 # Copyright 2023 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 
 from datasets import Features
 from libcommon.constants import (
@@ -18,7 +19,7 @@ from libcommon.simple_cache import (
 )
 
 from worker.config import AppConfig
-from worker.dtos import CompleteJobResult, IsValidResponse, JobResult
+from worker.dtos import CompleteJobResult, IsValidResponse
 from worker.job_runners.split.split_job_runner import SplitJobRunner
 
 
@@ -96,5 +97,5 @@ class SplitIsValidJobRunner(SplitJobRunner):
             app_config=app_config,
         )
 
-    def compute(self) -> JobResult:
-        return CompleteJobResult(compute_is_valid_response(dataset=self.dataset, config=self.config, split=self.split))
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult(compute_is_valid_response(dataset=self.dataset, config=self.config, split=self.split))

--- a/services/worker/src/worker/job_runners/split/opt_in_out_urls_count.py
+++ b/services/worker/src/worker/job_runners/split/opt_in_out_urls_count.py
@@ -2,6 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
+from collections.abc import Iterator
 
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import get_previous_step_or_raise
@@ -43,8 +44,8 @@ class SplitOptInOutUrlsCountJobRunner(SplitJobRunner):
     def get_job_type() -> str:
         return "split-opt-in-out-urls-count"
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult(
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult(
             compute_opt_in_out_urls_count_response(
                 dataset=self.dataset,
                 config=self.config,

--- a/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
@@ -3,6 +3,7 @@
 
 import logging
 from asyncio import Semaphore, create_task, run, wait
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Optional
 
@@ -277,8 +278,8 @@ class SplitOptInOutUrlsScanJobRunner(SplitJobRunnerWithDatasetsCache):
         )
         self.urls_scan_config = app_config.urls_scan
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult(
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult(
             compute_opt_in_out_urls_scan_response(
                 dataset=self.dataset,
                 config=self.config,

--- a/services/worker/src/worker/job_runners/split/presidio_scan.py
+++ b/services/worker/src/worker/job_runners/split/presidio_scan.py
@@ -4,7 +4,7 @@
 import logging
 import re
 from collections import Counter
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from itertools import count
 from pathlib import Path
 from typing import Any, Optional
@@ -444,8 +444,8 @@ class SplitPresidioEntitiesScanJobRunner(SplitJobRunnerWithDatasetsCache):
         )
         self.presidio_entities_scan_config = app_config.presidio_scan
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult(
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult(
             compute_presidio_entities_scan_response(
                 dataset=self.dataset,
                 config=self.config,

--- a/services/worker/src/worker/loop.py
+++ b/services/worker/src/worker/loop.py
@@ -132,10 +132,12 @@ class Loop:
         with LongStepProfiler("loop", "run_job"):
             job_runner = self.job_runner_factory.create_job_runner(job_info)
             job_manager = JobManager(job_info=job_info, app_config=self.app_config, job_runner=job_runner)
-            job_result = job_manager.run_job()
+            job_results = job_manager.run_job()
+            for job_result in job_results:
+                job_manager.save_job_result(job_result)
 
         with StepProfiler("loop", "finish_job"):
-            job_manager.finish(job_result=job_result)
+            job_manager.finish()
             self.set_worker_state(current_job_info=None)
             return True
 

--- a/services/worker/tests/fixtures/files.py
+++ b/services/worker/tests/fixtures/files.py
@@ -116,7 +116,7 @@ def extra_fields_readme(tmp_path_factory: pytest.TempPathFactory) -> str:
 def n_configs_paths(tmp_path_factory: pytest.TempPathFactory) -> list[str]:
     directory = tmp_path_factory.mktemp("data")
     readme = directory / "README.md"
-    N = 15
+    N = 4
     lines = [
         "---",
         "configs:",

--- a/services/worker/tests/job_runners/config/test_config_job_runner.py
+++ b/services/worker/tests/job_runners/config/test_config_job_runner.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The HuggingFace Authors.
 
+from collections.abc import Iterator
 from http import HTTPStatus
 from typing import Optional
 
@@ -27,8 +28,8 @@ class DummyConfigJobRunner(ConfigJobRunner):
     def get_job_type() -> str:
         return "/dummy"
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult({"key": "value"})
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult({"key": "value"})
 
 
 def test_failed_creation(app_config: AppConfig) -> None:

--- a/services/worker/tests/job_runners/config/test_info.py
+++ b/services/worker/tests/job_runners/config/test_info.py
@@ -206,10 +206,10 @@ def test_compute(
     job_runner.pre_compute()
     if should_raise:
         with pytest.raises(Exception) as e:
-            job_runner.compute()
+            list(job_runner.compute())
         assert e.typename == expected_error_code
     else:
-        assert job_runner.compute().content == expected_content
+        assert list(job_runner.compute())[0].content == expected_content
     job_runner.post_compute()
 
 
@@ -218,5 +218,5 @@ def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> No
     job_runner = get_job_runner(dataset, config, app_config)
     job_runner.pre_compute()
     with pytest.raises(CachedArtifactNotFoundError):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/config/test_is_valid.py
+++ b/services/worker/tests/job_runners/config/test_is_valid.py
@@ -236,7 +236,7 @@ def test_compute(
         upsert_response(**upstream_response)
     job_runner = get_job_runner(dataset, config, app_config)
     job_runner.pre_compute()
-    compute_result = job_runner.compute()
+    compute_result = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert compute_result.content == expected[0]
     assert compute_result.progress == expected[1]
@@ -260,5 +260,5 @@ def test_compute_raises(
     job_runner = get_job_runner(dataset, config, app_config)
     job_runner.pre_compute()
     with pytest.raises(Exception):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/config/test_opt_in_out_urls_count.py
+++ b/services/worker/tests/job_runners/config/test_opt_in_out_urls_count.py
@@ -254,10 +254,10 @@ def test_compute(
     job_runner.pre_compute()
     if should_raise:
         with pytest.raises(Exception) as e:
-            job_runner.compute()
+            list(job_runner.compute())
         assert e.typename == expected_error_code
     else:
-        assert job_runner.compute().content == expected_content
+        assert list(job_runner.compute())[0].content == expected_content
     job_runner.post_compute()
 
 
@@ -266,5 +266,5 @@ def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> No
     job_runner = get_job_runner(dataset, config, app_config)
     job_runner.pre_compute()
     with pytest.raises(CachedArtifactNotFoundError):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/config/test_parquet.py
+++ b/services/worker/tests/job_runners/config/test_parquet.py
@@ -272,10 +272,10 @@ def test_compute(
     job_runner.pre_compute()
     if should_raise:
         with pytest.raises(Exception) as e:
-            job_runner.compute()
+            list(job_runner.compute())
         assert e.typename == expected_error_code
     else:
-        assert job_runner.compute().content == expected_content
+        assert list(job_runner.compute())[0].content == expected_content
     job_runner.post_compute()
 
 
@@ -284,5 +284,5 @@ def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> No
     job_runner = get_job_runner(dataset, config, app_config)
     job_runner.pre_compute()
     with pytest.raises(CachedArtifactNotFoundError):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -340,7 +340,7 @@ def test_previous_step_error(
     )
     job_runner.pre_compute()
     with pytest.raises(Exception) as exc_info:
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()
     assert exc_info.typename == exception_name
 

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -543,17 +543,24 @@ def test_concurrency(
     configs = [str(config_name["config"]) for config_name in job_result["output"]["content"]["config_names"]]
 
     # launch the job runners
-    NUM_JOB_RUNNERS = 10
+    NUM_JOB_RUNNERS = 4
     with Pool(NUM_JOB_RUNNERS, initializer=set_hub_ci_env) as pool:
-        pool.map(
-            launch_job_runner,
-            [
-                JobRunnerArgs(
-                    dataset=repo_id, revision=revision, config=config, app_config=app_config, tmp_path=tmp_path
-                )
-                for config in configs
-            ],
-        )
+        async_results = [
+            pool.apply_async(
+                launch_job_runner,
+                (
+                    JobRunnerArgs(
+                        dataset=repo_id, revision=revision, config=config, app_config=app_config, tmp_path=tmp_path
+                    ),
+                ),
+            )
+            for config in configs
+        ]
+        for i, async_result in enumerate(async_results):
+            try:
+                async_result.get(timeout=300)  # 5 minutes per worker
+            except Exception as e:
+                raise RuntimeError(f"Worker {i} (config={configs[i]}) failed: {e}") from e
 
 
 @pytest.mark.parametrize(

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -460,27 +460,41 @@ class JobRunnerArgs(TypedDict):
 
 
 def launch_job_runner(job_runner_args: JobRunnerArgs) -> CompleteJobResult:
+    from libcommon.resources import CacheMongoResource
+
     config = job_runner_args["config"]
     dataset = job_runner_args["dataset"]
     revision = job_runner_args["revision"]
     app_config = job_runner_args["app_config"]
     tmp_path = job_runner_args["tmp_path"]
-    job_runner = ConfigParquetAndInfoJobRunner(
-        job_info=JobInfo(
-            job_id=f"job_{config}",
-            type="config-parquet-and-info",
-            params=JobParams(dataset=dataset, revision=revision, config=config, split=None),
-            priority=Priority.NORMAL,
-            difficulty=50,
-            started_at=None,
-        ),
-        app_config=app_config,
-        hf_datasets_cache=tmp_path,
-    )
-    job_runner.pre_compute()
-    result = list(job_runner.compute())[0]
-    job_runner.post_compute()
-    return result
+    with CacheMongoResource(database=app_config.cache.mongo_database, host=app_config.cache.mongo_url):
+        job_runner = ConfigParquetAndInfoJobRunner(
+            job_info=JobInfo(
+                job_id=f"job_{config}",
+                type="config-parquet-and-info",
+                params=JobParams(dataset=dataset, revision=revision, config=config, split=None),
+                priority=Priority.NORMAL,
+                difficulty=50,
+                started_at=None,
+            ),
+            app_config=app_config,
+            hf_datasets_cache=tmp_path,
+        )
+        job_runner.pre_compute()
+        result = list(job_runner.compute())[0]
+        job_runner.post_compute()
+        return result
+
+
+def set_hub_ci_env() -> None:
+    import os
+
+    import datasets.config
+    import huggingface_hub.constants
+
+    os.environ["HF_ENDPOINT"] = CI_HUB_ENDPOINT
+    datasets.config.HF_ENDPOINT = CI_HUB_ENDPOINT
+    huggingface_hub.constants.ENDPOINT = CI_HUB_ENDPOINT
 
 
 def test_concurrency(
@@ -522,6 +536,7 @@ def test_concurrency(
         job_runner=get_dataset_config_names_job_runner(repo_id, app_config),
     )
     job_result = list(job_manager.run_job())[0]
+    job_manager.save_job_result(job_result)
     job_manager.finish()
     if not job_result["output"]:
         raise ValueError("Could not get config names")
@@ -529,7 +544,7 @@ def test_concurrency(
 
     # launch the job runners
     NUM_JOB_RUNNERS = 10
-    with Pool(NUM_JOB_RUNNERS) as pool:
+    with Pool(NUM_JOB_RUNNERS, initializer=set_hub_ci_env) as pool:
         pool.map(
             launch_job_runner,
             [

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -145,7 +145,7 @@ def test_compute(
     config = hub_responses_public["config_names_response"]["config_names"][0]["config"]
     job_runner = get_job_runner(dataset, config, app_config)
     job_runner.pre_compute()
-    response = job_runner.compute()
+    response = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert response
     content = response.content
@@ -211,7 +211,7 @@ def test_supported_if_big_parquet(
     config = hub_responses_big["config_names_response"]["config_names"][0]["config"]
     job_runner = get_job_runner(dataset, config, app_config)
     job_runner.pre_compute()
-    response = job_runner.compute()
+    response = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert response
     content = response.content
@@ -236,7 +236,7 @@ def test_partially_converted_if_big_non_parquet(
     # to be able to stop the generation mid-way.
     job_runner.pre_compute()
     with patch.object(CsvConfig, "pd_read_csv_kwargs", {"chunksize": 10}):
-        response = job_runner.compute()
+        response = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert response
     content = response.content
@@ -258,7 +258,7 @@ def test_supported_if_gated(
     config = hub_responses_gated["config_names_response"]["config_names"][0]["config"]
     job_runner = get_job_runner(dataset, config, app_config)
     job_runner.pre_compute()
-    response = job_runner.compute()
+    response = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert response
     assert response.content
@@ -290,7 +290,7 @@ def test_compute_splits_response_simple_csv_ok(
     expected_parquet_and_info_response = hub_datasets[name]["parquet_and_info_response"]
     job_runner = get_job_runner(dataset, config, app_config)
     job_runner.pre_compute()
-    result = job_runner.compute().content
+    result = list(job_runner.compute())[0].content
     job_runner.post_compute()
     assert_content_is_equal(result, expected_parquet_and_info_response)
 
@@ -478,7 +478,7 @@ def launch_job_runner(job_runner_args: JobRunnerArgs) -> CompleteJobResult:
         hf_datasets_cache=tmp_path,
     )
     job_runner.pre_compute()
-    result = job_runner.compute()
+    result = list(job_runner.compute())[0]
     job_runner.post_compute()
     return result
 
@@ -521,8 +521,8 @@ def test_concurrency(
         app_config=app_config,
         job_runner=get_dataset_config_names_job_runner(repo_id, app_config),
     )
-    job_result = job_manager.run_job()
-    job_manager.finish(job_result=job_result)
+    job_result = list(job_manager.run_job())[0]
+    job_manager.finish()
     if not job_result["output"]:
         raise ValueError("Could not get config names")
     configs = [str(config_name["config"]) for config_name in job_result["output"]["content"]["config_names"]]

--- a/services/worker/tests/job_runners/config/test_parquet_metadata.py
+++ b/services/worker/tests/job_runners/config/test_parquet_metadata.py
@@ -297,10 +297,10 @@ def test_compute_libviewer(
 
     if should_raise:
         with pytest.raises(Exception) as e:
-            job_runner.compute()
+            list(job_runner.compute())
         assert e.type.__name__ == expected_error_code
     else:
-        content = job_runner.compute().content
+        content = list(job_runner.compute())[0].content
         assert content == expected_content
 
         assert content["parquet_files_metadata"]

--- a/services/worker/tests/job_runners/config/test_size.py
+++ b/services/worker/tests/job_runners/config/test_size.py
@@ -374,10 +374,10 @@ def test_compute(
     job_runner.pre_compute()
     if should_raise:
         with pytest.raises(Exception) as e:
-            job_runner.compute()
+            list(job_runner.compute())
         assert e.typename == expected_error_code
     else:
-        assert job_runner.compute().content == expected_content
+        assert list(job_runner.compute())[0].content == expected_content
     job_runner.post_compute()
 
 
@@ -386,5 +386,5 @@ def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> No
     job_runner = get_job_runner(dataset, config, app_config)
     job_runner.pre_compute()
     with pytest.raises(CachedArtifactNotFoundError):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/config/test_split_names.py
+++ b/services/worker/tests/job_runners/config/test_split_names.py
@@ -210,12 +210,12 @@ def test_compute_split_names_from_streaming_response(
 
     job_runner.pre_compute()
     if error_code is None:
-        result = job_runner.compute().content
+        result = list(job_runner.compute())[0].content
         assert result == expected_configs_response
         return
 
     with pytest.raises(CustomError) as exc_info:
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()
 
     assert exc_info.value.code == error_code
@@ -235,7 +235,7 @@ def test_compute(app_config: AppConfig, get_job_runner: GetJobRunner, hub_public
     config, _ = get_default_config_split()
     job_runner = get_job_runner(dataset, config, app_config)
     job_runner.pre_compute()
-    response = job_runner.compute()
+    response = list(job_runner.compute())[0]
     job_runner.post_compute()
     content = response.content
     assert len(content["splits"]) == 1

--- a/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
+++ b/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
@@ -477,7 +477,7 @@ def test_compute(
         upsert_response(**upstream_response)
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
-    compute_result = job_runner.compute()
+    compute_result = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert compute_result.content == expected[0]
     assert compute_result.progress == expected[1]
@@ -508,7 +508,7 @@ def test_compute_error(
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
     with expectation:
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()
 
 

--- a/services/worker/tests/job_runners/dataset/test_config_names.py
+++ b/services/worker/tests/job_runners/dataset/test_config_names.py
@@ -56,7 +56,7 @@ def test_compute(app_config: AppConfig, hub_public_csv: str, get_job_runner: Get
     dataset = hub_public_csv
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
-    response = job_runner.compute()
+    response = list(job_runner.compute())[0]
     job_runner.post_compute()
     content = response.content
     assert len(content["config_names"]) == 1
@@ -85,7 +85,7 @@ def test_compute_too_many_configs(
         with patch("worker.job_runners.dataset.config_names.get_dataset_default_config_name", return_value=None):
             if error_code:
                 with pytest.raises(CustomError) as exc_info:
-                    job_runner.compute()
+                    list(job_runner.compute())
                 assert exc_info.value.code == error_code
             else:
                 assert job_runner.compute() is not None
@@ -140,12 +140,12 @@ def test_compute_splits_response(
     )
     job_runner.pre_compute()
     if error_code is None:
-        result = job_runner.compute().content
+        result = list(job_runner.compute())[0].content
         assert result == expected_configs_response
         return
 
     with pytest.raises(CustomError) as exc_info:
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()
     assert exc_info.value.code == error_code
     assert exc_info.value.cause_exception == cause

--- a/services/worker/tests/job_runners/dataset/test_dataset_job_runner.py
+++ b/services/worker/tests/job_runners/dataset/test_dataset_job_runner.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The HuggingFace Authors.
+from collections.abc import Iterator
 
 import pytest
 from libcommon.dtos import Priority
@@ -15,8 +16,8 @@ class DummyDatasetJobRunner(DatasetJobRunner):
     def get_job_type() -> str:
         return "/dummy"
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult({"key": "value"})
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult({"key": "value"})
 
 
 def test_failed_creation(app_config: AppConfig) -> None:

--- a/services/worker/tests/job_runners/dataset/test_filetypes.py
+++ b/services/worker/tests/job_runners/dataset/test_filetypes.py
@@ -168,7 +168,7 @@ def test_compute(
 ) -> None:
     job_runner = get_job_runner(dataset, app_config_prod)
     job_runner.pre_compute()
-    response = job_runner.compute()
+    response = list(job_runner.compute())[0]
     job_runner.post_compute()
     content = response.content
     assert content["filetypes"] == filetypes

--- a/services/worker/tests/job_runners/dataset/test_hub_cache.py
+++ b/services/worker/tests/job_runners/dataset/test_hub_cache.py
@@ -334,7 +334,7 @@ def test_compute(
         upsert_response(**upstream_response)
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
-    compute_result = job_runner.compute()
+    compute_result = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert compute_result.content == expected[0]
     assert compute_result.progress == expected[1]

--- a/services/worker/tests/job_runners/dataset/test_info.py
+++ b/services/worker/tests/job_runners/dataset/test_info.py
@@ -6,7 +6,7 @@ from http import HTTPStatus
 from typing import Any
 
 import pytest
-from libcommon.dtos import Priority
+from libcommon.dtos import CachedJob, Priority
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.simple_cache import (
@@ -16,7 +16,6 @@ from libcommon.simple_cache import (
 )
 
 from worker.config import AppConfig
-from worker.dtos import Job
 from worker.job_runners.dataset.info import DatasetInfoJobRunner
 
 from ..config.test_info import CONFIG_INFO_1, CONFIG_INFO_2, DATASET_INFO_OK
@@ -80,7 +79,7 @@ EXPECTED_PARTIAL_PENDING = (
             "config_1": CONFIG_INFO_1,
         },
         "pending": [
-            Job(
+            CachedJob(
                 kind="config-info",
                 dataset="dataset_ok",
                 config="config_2",
@@ -100,7 +99,7 @@ EXPECTED_PARTIAL_FAILED = (
         },
         "pending": [],
         "failed": [
-            Job(
+            CachedJob(
                 kind="config-info",
                 dataset="dataset_ok",
                 config="config_2",
@@ -233,7 +232,7 @@ def test_compute(
             job_runner.compute()
         assert e.typename == expected_error_code
     else:
-        compute_result = job_runner.compute()
+        compute_result = list(job_runner.compute())[0]
         assert compute_result.content == expected[0]
         assert compute_result.progress == expected[1]
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/dataset/test_info.py
+++ b/services/worker/tests/job_runners/dataset/test_info.py
@@ -229,7 +229,7 @@ def test_compute(
     job_runner.pre_compute()
     if should_raise:
         with pytest.raises(Exception) as e:
-            job_runner.compute()
+            list(job_runner.compute())
         assert e.typename == expected_error_code
     else:
         compute_result = list(job_runner.compute())[0]
@@ -243,5 +243,5 @@ def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> No
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
     with pytest.raises(CachedArtifactNotFoundError):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/dataset/test_info.py
+++ b/services/worker/tests/job_runners/dataset/test_info.py
@@ -16,7 +16,7 @@ from libcommon.simple_cache import (
 )
 
 from worker.config import AppConfig
-from worker.dtos import PreviousJob
+from worker.dtos import Job
 from worker.job_runners.dataset.info import DatasetInfoJobRunner
 
 from ..config.test_info import CONFIG_INFO_1, CONFIG_INFO_2, DATASET_INFO_OK
@@ -80,7 +80,7 @@ EXPECTED_PARTIAL_PENDING = (
             "config_1": CONFIG_INFO_1,
         },
         "pending": [
-            PreviousJob(
+            Job(
                 kind="config-info",
                 dataset="dataset_ok",
                 config="config_2",
@@ -100,7 +100,7 @@ EXPECTED_PARTIAL_FAILED = (
         },
         "pending": [],
         "failed": [
-            PreviousJob(
+            Job(
                 kind="config-info",
                 dataset="dataset_ok",
                 config="config_2",

--- a/services/worker/tests/job_runners/dataset/test_is_valid.py
+++ b/services/worker/tests/job_runners/dataset/test_is_valid.py
@@ -227,7 +227,7 @@ def test_compute(
         upsert_response(**upstream_response)
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
-    compute_result = job_runner.compute()
+    compute_result = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert compute_result.content == expected[0]
     assert compute_result.progress == expected[1]
@@ -251,5 +251,5 @@ def test_compute_raises(
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
     with pytest.raises(Exception):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/dataset/test_modalities.py
+++ b/services/worker/tests/job_runners/dataset/test_modalities.py
@@ -396,7 +396,7 @@ def test_compute(
         upsert_response(**upstream_response)
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
-    compute_result = job_runner.compute()
+    compute_result = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert compute_result.content == expected[0]
     assert compute_result.progress == expected[1]
@@ -426,5 +426,5 @@ def test_compute_error(
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
     with expectation:
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/dataset/test_opt_in_out_urls_count.py
+++ b/services/worker/tests/job_runners/dataset/test_opt_in_out_urls_count.py
@@ -208,10 +208,10 @@ def test_compute(
     job_runner.pre_compute()
     if should_raise:
         with pytest.raises(Exception) as e:
-            job_runner.compute()
+            list(job_runner.compute())
         assert e.typename == expected_error_code
     else:
-        assert job_runner.compute().content == expected_content
+        assert list(job_runner.compute())[0].content == expected_content
     job_runner.post_compute()
 
 
@@ -220,5 +220,5 @@ def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> No
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
     with pytest.raises(CachedArtifactNotFoundError):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/dataset/test_parquet.py
+++ b/services/worker/tests/job_runners/dataset/test_parquet.py
@@ -187,10 +187,10 @@ def test_compute(
     job_runner.pre_compute()
     if should_raise:
         with pytest.raises(Exception) as e:
-            job_runner.compute()
+            list(job_runner.compute())
         assert e.typename == expected_error_code
     else:
-        assert job_runner.compute().content == expected_content
+        assert list(job_runner.compute())[0].content == expected_content
     job_runner.post_compute()
 
 
@@ -199,5 +199,5 @@ def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> No
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
     with pytest.raises(CachedArtifactNotFoundError):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/dataset/test_presidio_entities_count.py
+++ b/services/worker/tests/job_runners/dataset/test_presidio_entities_count.py
@@ -351,10 +351,10 @@ def test_compute(
     job_runner.pre_compute()
     if should_raise:
         with pytest.raises(Exception) as e:
-            job_runner.compute()
+            list(job_runner.compute())
         assert e.typename == expected_error_code
     else:
-        assert job_runner.compute().content == expected_content
+        assert list(job_runner.compute())[0].content == expected_content
     job_runner.post_compute()
 
 
@@ -363,5 +363,5 @@ def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> No
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
     with pytest.raises(CachedArtifactNotFoundError):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/dataset/test_size.py
+++ b/services/worker/tests/job_runners/dataset/test_size.py
@@ -672,10 +672,10 @@ def test_compute(
     job_runner.pre_compute()
     if should_raise:
         with pytest.raises(Exception) as e:
-            job_runner.compute()
+            list(job_runner.compute())
         assert e.typename == expected_error_code
     else:
-        assert job_runner.compute().content == expected_content
+        assert list(job_runner.compute())[0].content == expected_content
     job_runner.post_compute()
 
 
@@ -684,5 +684,5 @@ def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> No
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
     with pytest.raises(CachedArtifactNotFoundError):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/dataset/test_split_names.py
+++ b/services/worker/tests/job_runners/dataset/test_split_names.py
@@ -164,7 +164,7 @@ def test_compute_progress(
         )
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
-    response = job_runner.compute()
+    response = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert response.content == expected_content
     assert response.progress == progress
@@ -199,7 +199,7 @@ def test_compute_error(app_config: AppConfig, get_job_runner: GetJobRunner) -> N
     )
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
-    response = job_runner.compute()
+    response = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert response.content == {
         "splits": [],
@@ -237,7 +237,7 @@ def test_compute_format_error(app_config: AppConfig, get_job_runner: GetJobRunne
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
     with pytest.raises(PreviousStepFormatError):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()
 
 
@@ -246,5 +246,5 @@ def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> No
     job_runner = get_job_runner(dataset, app_config)
     job_runner.pre_compute()
     with pytest.raises(CachedArtifactNotFoundError):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/split/test_descriptive_statistics.py
+++ b/services/worker/tests/job_runners/split/test_descriptive_statistics.py
@@ -454,7 +454,7 @@ def test_compute(
     job_runner.pre_compute()
     if expected_error_code:
         with pytest.raises(Exception) as e:
-            job_runner.compute()
+            list(job_runner.compute())
         assert e.typename == expected_error_code
     else:
         response = list(job_runner.compute())[0]

--- a/services/worker/tests/job_runners/split/test_descriptive_statistics.py
+++ b/services/worker/tests/job_runners/split/test_descriptive_statistics.py
@@ -402,7 +402,7 @@ def test_compute(
     # computing and pushing real parquet files because we need them for stats computation
     parquet_and_info_job_runner = get_parquet_and_info_job_runner(dataset, config, app_config)
     parquet_and_info_job_runner.pre_compute()
-    parquet_and_info_response = parquet_and_info_job_runner.compute()
+    parquet_and_info_response = list(parquet_and_info_job_runner.compute())[0]
     parquet_and_info_job_runner.post_compute()
     config_parquet_and_info = parquet_and_info_response.content
 
@@ -419,7 +419,7 @@ def test_compute(
 
     parquet_job_runner = get_parquet_job_runner(dataset, config, app_config)
     parquet_job_runner.pre_compute()
-    parquet_response = parquet_job_runner.compute()
+    parquet_response = list(parquet_job_runner.compute())[0]
     parquet_job_runner.post_compute()
     config_parquet = parquet_response.content
 
@@ -436,7 +436,7 @@ def test_compute(
 
     parquet_metadata_job_runner = get_parquet_metadata_job_runner(dataset, config, app_config)
     parquet_metadata_job_runner.pre_compute()
-    parquet_metadata_response = parquet_metadata_job_runner.compute()
+    parquet_metadata_response = list(parquet_metadata_job_runner.compute())[0]
     parquet_metadata_job_runner.post_compute()
     config_parquet_metadata = parquet_metadata_response.content
 
@@ -457,7 +457,7 @@ def test_compute(
             job_runner.compute()
         assert e.typename == expected_error_code
     else:
-        response = job_runner.compute()
+        response = list(job_runner.compute())[0]
         assert sorted(response.content.keys()) == ["num_examples", "partial", "statistics"]
         assert response.content["num_examples"] == expected_response["num_examples"]  # type: ignore
 

--- a/services/worker/tests/job_runners/split/test_first_rows.py
+++ b/services/worker/tests/job_runners/split/test_first_rows.py
@@ -188,10 +188,10 @@ def test_compute_from_parquet_libviewer(
         job_runner.pre_compute()
         if error_code:
             with pytest.raises(CustomError) as error_info:
-                job_runner.compute()
+                list(job_runner.compute())
             assert error_info.value.code == error_code
         else:
-            response = job_runner.compute().content
+            response = list(job_runner.compute())[0].content
             assert get_json_size(response) <= rows_max_bytes
             assert response
             assert response["rows"]
@@ -285,12 +285,12 @@ def test_number_rows(
     job_runner.pre_compute()
     if exception_name is None:
         job_runner.validate()
-        result = job_runner.compute().content
+        result = list(job_runner.compute())[0].content
         assert result == expected_first_rows_response
     else:
         with pytest.raises(Exception) as exc_info:
             job_runner.validate()
-            job_runner.compute()
+            list(job_runner.compute())
         assert exc_info.typename == exception_name
     job_runner.post_compute()
 
@@ -302,7 +302,7 @@ def test_compute(app_config: AppConfig, get_job_runner: GetJobRunner, hub_public
     config, split = get_default_config_split()
     job_runner = get_job_runner(dataset, config, split, app_config)
     job_runner.pre_compute()
-    response = job_runner.compute()
+    response = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert response
     content = response.content
@@ -334,7 +334,7 @@ def test_long_column_name(
     with patch("worker.utils.MAX_COLUMN_NAME_LENGTH", max_column_name_length):
         if raises:
             with pytest.raises(TooLongColumnNameError):
-                job_runner.compute()
+                list(job_runner.compute())
         else:
-            job_runner.compute()
+            list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/split/test_image_url_columns.py
+++ b/services/worker/tests/job_runners/split/test_image_url_columns.py
@@ -206,7 +206,7 @@ def test_compute(
         http_status=HTTPStatus.OK,
     )
     job_runner.pre_compute()
-    response = job_runner.compute()
+    response = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert response
     assert response.content == expected_content
@@ -254,6 +254,6 @@ def test_compute_failed(
         )
     job_runner.pre_compute()
     with pytest.raises(Exception) as exc_info:
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()
     assert exc_info.typename == exception_name

--- a/services/worker/tests/job_runners/split/test_is_valid.py
+++ b/services/worker/tests/job_runners/split/test_is_valid.py
@@ -254,7 +254,7 @@ def test_compute(
         upsert_response(**upstream_response)
     job_runner = get_job_runner(dataset, config, split, app_config)
     job_runner.pre_compute()
-    compute_result = job_runner.compute()
+    compute_result = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert compute_result.content == expected[0]
     assert compute_result.progress == expected[1]
@@ -264,7 +264,7 @@ def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> No
     dataset, config, split = "doesnotexist", "doesnotexist", "doesnotexist"
     job_runner = get_job_runner(dataset, config, split, app_config)
     job_runner.pre_compute()
-    compute_result = job_runner.compute()
+    compute_result = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert compute_result.content == {
         "viewer": False,

--- a/services/worker/tests/job_runners/split/test_opt_in_out_urls_count.py
+++ b/services/worker/tests/job_runners/split/test_opt_in_out_urls_count.py
@@ -157,10 +157,10 @@ def test_compute(
     job_runner.pre_compute()
     if should_raise:
         with pytest.raises(Exception) as e:
-            job_runner.compute()
+            list(job_runner.compute())
         assert e.typename == expected_error_code
     else:
-        assert job_runner.compute().content == expected_content
+        assert list(job_runner.compute())[0].content == expected_content
     job_runner.post_compute()
 
 
@@ -169,5 +169,5 @@ def test_doesnotexist(app_config: AppConfig, get_job_runner: GetJobRunner) -> No
     job_runner = get_job_runner(dataset, config, split, app_config)
     job_runner.pre_compute()
     with pytest.raises(CachedArtifactNotFoundError):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()

--- a/services/worker/tests/job_runners/split/test_opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/tests/job_runners/split/test_opt_in_out_urls_scan_from_streaming.py
@@ -207,7 +207,7 @@ def test_compute(
     )
     job_runner.pre_compute()
     with patch("worker.job_runners.split.opt_in_out_urls_scan_from_streaming.check_spawning", mock_check_spawning):
-        response = job_runner.compute()
+        response = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert response
     assert response.content == expected_content
@@ -274,7 +274,7 @@ def test_compute_failed(
         )
     job_runner.pre_compute()
     with pytest.raises(Exception) as exc_info:
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()
     assert exc_info.typename == exception_name
 
@@ -305,7 +305,7 @@ def test_compute_error_from_spawning(
     )
     job_runner.pre_compute()
     with pytest.raises(ExternalServerError):
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()
 
 

--- a/services/worker/tests/job_runners/split/test_presidio_scan.py
+++ b/services/worker/tests/job_runners/split/test_presidio_scan.py
@@ -421,7 +421,7 @@ def test_compute(
         http_status=HTTPStatus.OK,
     )
     job_runner.pre_compute()
-    response = job_runner.compute()
+    response = list(job_runner.compute())[0]
     job_runner.post_compute()
     assert response
     assert response.content == expected_content
@@ -470,6 +470,6 @@ def test_compute_failed(
         )
     job_runner.pre_compute()
     with pytest.raises(Exception) as exc_info:
-        job_runner.compute()
+        list(job_runner.compute())
     job_runner.post_compute()
     assert exc_info.typename == exception_name

--- a/services/worker/tests/job_runners/split/test_split_job_runner.py
+++ b/services/worker/tests/job_runners/split/test_split_job_runner.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The HuggingFace Authors.
 
+from collections.abc import Iterator
 from http import HTTPStatus
 from typing import Optional
 
@@ -27,8 +28,8 @@ class DummySplitJobRunner(SplitJobRunner):
     def get_job_type() -> str:
         return "/dummy"
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult({"key": "value"})
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult({"key": "value"})
 
 
 @pytest.mark.parametrize("config,split", [(None, None), (None, "split"), ("config", None)])

--- a/services/worker/tests/job_runners/test__job_runner_with_cache.py
+++ b/services/worker/tests/job_runners/test__job_runner_with_cache.py
@@ -2,7 +2,7 @@
 # Copyright 2023 The HuggingFace Authors.
 
 import random
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Optional
 
@@ -23,8 +23,8 @@ class DummyJobRunner(JobRunnerWithCache):
     def get_job_type() -> str:
         return "dummy-job-runner"
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult({"col1": "a" * 200})
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult({"col1": "a" * 200})
 
 
 GetJobRunner = Callable[[str, Optional[str], Optional[str], AppConfig], DummyJobRunner]

--- a/services/worker/tests/job_runners/test__job_runner_with_datasets_cache.py
+++ b/services/worker/tests/job_runners/test__job_runner_with_datasets_cache.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Optional
 
@@ -28,8 +28,8 @@ class DummyJobRunner(JobRunnerWithDatasetsCache):
         # ^ borrowing the type, so that the processing step exists and the job runner can be initialized
         # refactoring libcommon.processing_graph might help avoiding this
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult({"col1": "a" * 200})
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult({"col1": "a" * 200})
 
 
 GetJobRunner = Callable[[str, Optional[str], Optional[str], AppConfig], DummyJobRunner]

--- a/services/worker/tests/test_job_manager.py
+++ b/services/worker/tests/test_job_manager.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from http import HTTPStatus
 
 import pytest
@@ -8,12 +9,13 @@ from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.simple_cache import CachedResponseDocument, get_response, get_response_metadata, upsert_response
 
 from worker.config import AppConfig
-from worker.dtos import CompleteJobResult
+from worker.dtos import CompleteJobResult, JobResult, ShortcutJobResult
 from worker.job_manager import JobManager
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
 
 JOB_TYPE = "dataset-config-names"
 JOB_TYPE_2 = "dataset-info"
+JOB_WITH_SHORTCUTS_TYPE = "dataset-init"
 
 
 @pytest.fixture(autouse=True)
@@ -30,8 +32,24 @@ class DummyJobRunner(DatasetJobRunner):
     def get_job_type() -> str:
         return JOB_TYPE
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult({"key": "value"})
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult({"key": "value"})
+
+
+class DummyJobRunnerWithShortcuts(DatasetJobRunner):
+    @staticmethod
+    def get_job_type() -> str:
+        return JOB_WITH_SHORTCUTS_TYPE
+
+    def compute(self) -> Iterator[JobResult]:
+        yield ShortcutJobResult(
+            {"key": "value"}, {"dataset": self.dataset, "kind": "dataset-config-names", "config": None, "split": None}
+        )
+        yield JobResult({"key": "value"}, progress=0.5)
+        yield ShortcutJobResult(
+            {"key": "value"}, {"dataset": self.dataset, "kind": "dataset-is-valid", "config": None, "split": None}
+        )
+        yield JobResult({"key": "value"}, progress=1.0)
 
 
 def test_check_type(
@@ -94,7 +112,7 @@ def test_run_job_and_finish(priority: Priority, app_config: AppConfig) -> None:
     queue = Queue()
     assert JobDocument.objects().count() == 0
     queue.add_job(
-        job_type="dataset-config-names",
+        job_type=JOB_TYPE,
         dataset="dataset",
         revision="revision",
         config=None,
@@ -113,20 +131,73 @@ def test_run_job_and_finish(priority: Priority, app_config: AppConfig) -> None:
     job_manager = JobManager(job_info=job_info, app_config=app_config, job_runner=job_runner)
     assert job_manager.priority == priority
 
-    job_result = job_manager.run_job()
+    job_result = list(job_manager.run_job())[0]
     assert job_result["is_success"]
     assert job_result["output"] is not None
     assert job_result["output"]["content"] == {"key": "value"}
     assert job_result["duration"] is not None
     assert job_result["duration"] > 0
 
-    job_manager.finish(job_result=job_result)
+    job_manager.save_job_result(job_result)
+    job_manager.finish()
 
     # check that the job has been finished and deleted
     assert JobDocument.objects(pk=job_info["job_id"]).count() == 0
 
     # check that the cache entry has have been created
-    cached_response = get_response(kind="dataset-config-names", dataset="dataset", config=None, split=None)
+    cached_response = get_response(kind=JOB_TYPE, dataset="dataset", config=None, split=None)
+    assert cached_response is not None
+    assert cached_response["http_status"] == HTTPStatus.OK
+    assert cached_response["error_code"] is None
+    assert cached_response["content"] == {"key": "value"}
+    assert cached_response["dataset_git_revision"] == "revision"
+    assert cached_response["job_runner_version"] == processing_graph.get_processing_step(JOB_TYPE).job_runner_version
+    assert cached_response["progress"] == 1.0
+
+    cached_entry_metadata = get_response_metadata(kind=JOB_TYPE, dataset="dataset", config=None, split=None)
+    assert cached_entry_metadata is not None
+    assert cached_entry_metadata["failed_runs"] == 0
+
+    # check children jobs
+    child = processing_graph.get_children(JOB_TYPE).pop()
+    dataset_child_jobs = queue.get_dump_with_status(job_type=child.job_type, status=Status.WAITING)
+    assert len(dataset_child_jobs) == 1
+    assert dataset_child_jobs[0]["dataset"] == "dataset"
+    assert dataset_child_jobs[0]["revision"] == "revision"
+    assert dataset_child_jobs[0]["priority"] is priority.value
+
+
+def test_run_job_and_finish_with_shortcuts(app_config: AppConfig) -> None:
+    queue = Queue()
+    assert JobDocument.objects().count() == 0
+    queue.add_job(
+        job_type=JOB_WITH_SHORTCUTS_TYPE,
+        dataset="dataset",
+        revision="revision",
+        config=None,
+        split=None,
+        priority=Priority.NORMAL,
+        difficulty=50,
+    )
+    job_info = queue.start_job()
+
+    job_runner = DummyJobRunnerWithShortcuts(
+        job_info=job_info,
+        app_config=app_config,
+    )
+
+    job_manager = JobManager(job_info=job_info, app_config=app_config, job_runner=job_runner)
+
+    job_results = job_manager.run_job()
+    for job_result in job_results:
+        job_manager.save_job_result(job_result)
+    job_manager.finish()
+
+    # check that the job has been finished and deleted
+    assert JobDocument.objects(pk=job_info["job_id"]).count() == 0
+
+    # check that the cache entry has been created
+    cached_response = get_response(kind=JOB_WITH_SHORTCUTS_TYPE, dataset="dataset", config=None, split=None)
     assert cached_response is not None
     assert cached_response["http_status"] == HTTPStatus.OK
     assert cached_response["error_code"] is None
@@ -134,22 +205,46 @@ def test_run_job_and_finish(priority: Priority, app_config: AppConfig) -> None:
     assert cached_response["dataset_git_revision"] == "revision"
     assert (
         cached_response["job_runner_version"]
-        == processing_graph.get_processing_step("dataset-config-names").job_runner_version
+        == processing_graph.get_processing_step(JOB_WITH_SHORTCUTS_TYPE).job_runner_version
     )
     assert cached_response["progress"] == 1.0
 
     cached_entry_metadata = get_response_metadata(
-        kind="dataset-config-names", dataset="dataset", config=None, split=None
+        kind=JOB_WITH_SHORTCUTS_TYPE, dataset="dataset", config=None, split=None
     )
     assert cached_entry_metadata is not None
     assert cached_entry_metadata["failed_runs"] == 0
 
-    child = processing_graph.get_children("dataset-config-names").pop()
-    dataset_child_jobs = queue.get_dump_with_status(job_type=child.job_type, status=Status.WAITING)
-    assert len(dataset_child_jobs) == 1
-    assert dataset_child_jobs[0]["dataset"] == "dataset"
-    assert dataset_child_jobs[0]["revision"] == "revision"
-    assert dataset_child_jobs[0]["priority"] is priority.value
+    # check that the shortcut cache entry has been created
+    cached_response = get_response(kind=JOB_TYPE, dataset="dataset", config=None, split=None)
+    assert cached_response is not None
+    assert cached_response["http_status"] == HTTPStatus.OK
+    assert cached_response["error_code"] is None
+    assert cached_response["content"] == {"key": "value"}
+    assert cached_response["dataset_git_revision"] == "revision"
+    assert (
+        cached_response["job_runner_version"]
+        == processing_graph.get_processing_step(JOB_WITH_SHORTCUTS_TYPE).job_runner_version
+    )
+    assert cached_response["progress"] == 1.0
+
+    cached_entry_metadata = get_response_metadata(
+        kind=JOB_WITH_SHORTCUTS_TYPE, dataset="dataset", config=None, split=None
+    )
+    assert cached_entry_metadata is not None
+    assert cached_entry_metadata["failed_runs"] == 0
+
+    # check children jobs
+    children = processing_graph.get_children(JOB_WITH_SHORTCUTS_TYPE)
+    assert any(child.job_type == JOB_TYPE for child in children)
+    assert len(children) > 1
+    # dataset-config-names is doneusing a shortcut but not others like dataset-filetypes
+    dataset_child_jobs = queue.get_dump_with_status(job_type=JOB_TYPE, status=Status.WAITING)
+    assert len(dataset_child_jobs) == 0
+    for child in children:
+        if child.job_type != JOB_TYPE:
+            dataset_child_jobs = queue.get_dump_with_status(job_type=child.job_type, status=Status.WAITING)
+            assert len(dataset_child_jobs) == 1
 
 
 def test_job_runner_set_crashed(app_config: AppConfig) -> None:

--- a/services/worker/tests/test_job_manager.py
+++ b/services/worker/tests/test_job_manager.py
@@ -33,7 +33,7 @@ class DummyJobRunner(DatasetJobRunner):
         return JOB_TYPE
 
     def compute(self) -> Iterator[CompleteJobResult]:
-        yield CompleteJobResult({"key": "value"})
+        yield CompleteJobResult({"config_names": [{"dataset": self.dataset, "config": "default"}]})
 
 
 class DummyJobRunnerWithShortcuts(DatasetJobRunner):
@@ -43,12 +43,10 @@ class DummyJobRunnerWithShortcuts(DatasetJobRunner):
 
     def compute(self) -> Iterator[JobResult]:
         yield ShortcutJobResult(
-            {"key": "value"}, {"dataset": self.dataset, "kind": "dataset-config-names", "config": None, "split": None}
+            {"config_names": [{"dataset": self.dataset, "config": "default"}]},
+            {"dataset": self.dataset, "kind": "dataset-config-names", "config": None, "split": None},
         )
         yield JobResult({"key": "value"}, progress=0.5)
-        yield ShortcutJobResult(
-            {"key": "value"}, {"dataset": self.dataset, "kind": "dataset-is-valid", "config": None, "split": None}
-        )
         yield JobResult({"key": "value"}, progress=1.0)
 
 
@@ -134,7 +132,7 @@ def test_run_job_and_finish(priority: Priority, app_config: AppConfig) -> None:
     job_result = list(job_manager.run_job())[0]
     assert job_result["is_success"]
     assert job_result["output"] is not None
-    assert job_result["output"]["content"] == {"key": "value"}
+    assert job_result["output"]["content"] == {"config_names": [{"dataset": "dataset", "config": "default"}]}
     assert job_result["duration"] is not None
     assert job_result["duration"] > 0
 
@@ -149,7 +147,7 @@ def test_run_job_and_finish(priority: Priority, app_config: AppConfig) -> None:
     assert cached_response is not None
     assert cached_response["http_status"] == HTTPStatus.OK
     assert cached_response["error_code"] is None
-    assert cached_response["content"] == {"key": "value"}
+    assert cached_response["content"] == {"config_names": [{"dataset": "dataset", "config": "default"}]}
     assert cached_response["dataset_git_revision"] == "revision"
     assert cached_response["job_runner_version"] == processing_graph.get_processing_step(JOB_TYPE).job_runner_version
     assert cached_response["progress"] == 1.0
@@ -220,7 +218,7 @@ def test_run_job_and_finish_with_shortcuts(app_config: AppConfig) -> None:
     assert cached_response is not None
     assert cached_response["http_status"] == HTTPStatus.OK
     assert cached_response["error_code"] is None
-    assert cached_response["content"] == {"key": "value"}
+    assert cached_response["content"] == {"config_names": [{"dataset": "dataset", "config": "default"}]}
     assert cached_response["dataset_git_revision"] == "revision"
     assert (
         cached_response["job_runner_version"]
@@ -238,13 +236,18 @@ def test_run_job_and_finish_with_shortcuts(app_config: AppConfig) -> None:
     children = processing_graph.get_children(JOB_WITH_SHORTCUTS_TYPE)
     assert any(child.job_type == JOB_TYPE for child in children)
     assert len(children) > 1
-    # dataset-config-names is doneusing a shortcut but not others like dataset-filetypes
+    # dataset-config-names is done using a shortcut but not others like dataset-filetypes
     dataset_child_jobs = queue.get_dump_with_status(job_type=JOB_TYPE, status=Status.WAITING)
     assert len(dataset_child_jobs) == 0
     for child in children:
         if child.job_type != JOB_TYPE:
             dataset_child_jobs = queue.get_dump_with_status(job_type=child.job_type, status=Status.WAITING)
             assert len(dataset_child_jobs) == 1
+    # dataset-config-names children should be in the queue
+    children = processing_graph.get_children(JOB_TYPE)
+    for child in children:
+        dataset_child_jobs = queue.get_dump_with_status(job_type=child.job_type, status=Status.WAITING)
+        assert len(dataset_child_jobs) == 1
 
 
 def test_job_runner_set_crashed(app_config: AppConfig) -> None:

--- a/services/worker/tests/test_loop.py
+++ b/services/worker/tests/test_loop.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterator
+
 from libcommon.dtos import JobInfo
 from libcommon.resources import CacheMongoResource, QueueMongoResource
 
@@ -16,8 +18,8 @@ class DummyJobRunner(JobRunner):
     def get_job_type() -> str:
         return JOB_TYPE
 
-    def compute(self) -> CompleteJobResult:
-        return CompleteJobResult({"key": "value"})
+    def compute(self) -> Iterator[CompleteJobResult]:
+        yield CompleteJobResult({"key": "value"})
 
 
 class DummyJobRunnerFactory(BaseJobRunnerFactory):


### PR DESCRIPTION
Add the first jobs that allows shortcuts, this will be useful to accelerate the viewer's preparation for Parquet datasets (run all jobs at once)

## Details

- Job runners can now yield multiple job results, including ShortcutJobResult objects that shortcut other runners
- The AfterJobPlan takes this into account and creates new jobs based on the job result and the shortcut job results
- there is a new "dataset-init" job runner that shortcuts "dataset-config-names" to start with
- in a second step (future PR), "dataset-init" will also be able to shortcut Parquet-related job runners
- later it can also be useful to group jobs with low difficutly (e.g. info aggregation jobs when there are many configs and splits) and shortcut them as well, greatly reducing the number of jobs in the queue

Thanks to open models for the help coding this :p

struggling a bit to merge that one due to tests failing bc of a mix of network/github/hub-ci/app-tokens issues