### PR TITLE
Handle k8s sigterm

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -460,6 +460,7 @@ sseApi:
 
 workers:
   - deployName: "heavy"
+    terminationGracePeriodSeconds: 120
     prometheusMultiprocDirectory: "/tmp"
     uvicornHostname: "0.0.0.0"
     uvicornNumWorkers: "1"
@@ -489,6 +490,7 @@ workers:
         cpu: 8
         memory: "44Gi"
   - deployName: "medium"
+    terminationGracePeriodSeconds: 60
     prometheusMultiprocDirectory: "/tmp"
     uvicornHostname: "0.0.0.0"
     uvicornNumWorkers: "1"
@@ -518,6 +520,7 @@ workers:
         cpu: 2
         memory: "14Gi"
   - deployName: "light"
+    terminationGracePeriodSeconds: 30
     prometheusMultiprocDirectory: "/tmp"
     uvicornHostname: "0.0.0.0"
     uvicornNumWorkers: "1"

--- a/chart/env/staging.yaml
+++ b/chart/env/staging.yaml
@@ -261,6 +261,7 @@ sseApi:
 
 workers:
   - deployName: "all"
+    terminationGracePeriodSeconds: 30
     prometheusMultiprocDirectory: "/tmp"
     uvicornHostname: "0.0.0.0"
     uvicornNumWorkers: "1"
@@ -287,6 +288,7 @@ workers:
         cpu: 1
         memory: "4Gi"
   - deployName: "light"
+    terminationGracePeriodSeconds: 30
     prometheusMultiprocDirectory: "/tmp"
     uvicornHostname: "0.0.0.0"
     uvicornNumWorkers: "1"

--- a/chart/templates/worker/_deployment.yaml
+++ b/chart/templates/worker/_deployment.yaml
@@ -27,6 +27,7 @@ spec:
     metadata:
       labels: {{ include "labels.worker" (merge (dict "workerValues" .workerValues) $ ) | nindent 8 }}
     spec:
+      terminationGracePeriodSeconds: {{ default 30 .workerValues.terminationGracePeriodSeconds }}
       {{- include "dnsConfig" . | nindent 6 }}
       {{- include "image.imagePullSecrets" . | nindent 6 }}
       initContainers:

--- a/libs/libcommon/src/libcommon/queue/jobs.py
+++ b/libs/libcommon/src/libcommon/queue/jobs.py
@@ -972,11 +972,15 @@ class Queue:
     def get_zombies(self, max_seconds_without_heartbeat: float) -> list["JobInfo"]:
         """Deprecated: use get_stuck_jobs instead."""
         return [
-            job_info for job_info, reason in self.get_stuck_jobs(max_seconds_without_heartbeat) if reason == "missing heartbeats"
+            job_info
+            for job_info, reason in self.get_stuck_jobs(max_seconds_without_heartbeat)
+            if reason == "missing heartbeats"
         ]
 
     def get_terminated_jobs(self, max_seconds_after_termination: float) -> list["JobInfo"]:
         """Deprecated: use get_stuck_jobs instead."""
         return [
-            job_info for job_info, reason in self.get_stuck_jobs(max_seconds_after_termination) if reason == "terminated"
+            job_info
+            for job_info, reason in self.get_stuck_jobs(max_seconds_after_termination)
+            if reason == "terminated"
         ]

--- a/libs/libcommon/src/libcommon/queue/jobs.py
+++ b/libs/libcommon/src/libcommon/queue/jobs.py
@@ -189,6 +189,9 @@ class JobDocument(Document):
     created_at = DateTimeField(required=True)
     started_at = DateTimeField()
     last_heartbeat = DateTimeField()
+    # Time at which the worker process received SIGTERM for this job (set by the executor signal handler)
+    # If set and the job is still running, it means SIGKILL arrived before the job could finish
+    terminated_at = DateTimeField()
 
     def to_dict(self) -> JobDict:
         return {
@@ -915,30 +918,65 @@ class Queue:
         # no need to update metrics since it is just the last_heartbeat
         job.update(last_heartbeat=get_datetime())
 
-    def get_zombies(self, max_seconds_without_heartbeat: float) -> list[JobInfo]:
-        """Get the zombie jobs.
-        It returns jobs without recent heartbeats, which means they crashed at one point and became zombies.
-        Usually `max_seconds_without_heartbeat` is a factor of the time between two heartbeats.
+    def set_terminated(self, job_id: str) -> None:
+        """Mark a job as terminated (SIGTERM was sent to the worker running this job).
+        This is set by the executor signal handler when SIGTERM is received.
+        """
+        try:
+            job = self.get_job_with_id(job_id)
+            job.update(terminated_at=get_datetime())
+        except DoesNotExist:
+            logging.debug(f"Cannot set terminated for job {job_id}: job does not exist.")
+
+    def get_stuck_jobs(self, max_seconds_without_heartbeat: float) -> list[tuple["JobInfo", str]]:
+        """Get started jobs that are stuck: either missing heartbeats (crashed) or terminated but still running.
+
+        This is a single query that identifies both zombie jobs (crashed, no heartbeats) and
+        terminated-but-still-running jobs (SIGTERM received but didn't finish before SIGKILL).
+
+        Args:
+            max_seconds_without_heartbeat: maximum seconds since last heartbeat before considering a job stuck.
 
         Returns:
-            `list[JobInfo]`: an array of the zombie job infos.
+            `list[tuple[JobInfo, str]]`: list of (job_info, reason) tuples.
+                reason is either "missing heartbeats" (crashed) or "terminated" (SIGTERM received but didn't finish).
         """
         started_jobs = JobDocument.objects(status=Status.STARTED)
         if max_seconds_without_heartbeat <= 0:
             return []
-        zombies = [
-            job
-            for job in started_jobs
-            if (
+        now = get_datetime()
+        stuck: list[tuple["JobInfo", str]] = []
+        for job in started_jobs:
+            # Check for terminated jobs (SIGTERM received but still running)
+            if job.terminated_at is not None:
+                if (
+                    job.last_heartbeat is not None
+                    and now >= pytz.UTC.localize(job.terminated_at) + timedelta(seconds=max_seconds_without_heartbeat)
+                ) or (
+                    job.last_heartbeat is None
+                    and now >= pytz.UTC.localize(job.terminated_at) + timedelta(seconds=max_seconds_without_heartbeat)
+                ):
+                    stuck.append((job.info(), "terminated"))
+            # Check for zombie jobs (missing heartbeats, no SIGTERM)
+            elif (
                 job.last_heartbeat is not None
-                and get_datetime()
-                >= pytz.UTC.localize(job.last_heartbeat) + timedelta(seconds=max_seconds_without_heartbeat)
-            )
-            or (
+                and now >= pytz.UTC.localize(job.last_heartbeat) + timedelta(seconds=max_seconds_without_heartbeat)
+            ) or (
                 job.last_heartbeat is None
                 and job.started_at is not None
-                and get_datetime()
-                >= pytz.UTC.localize(job.started_at) + timedelta(seconds=max_seconds_without_heartbeat)
-            )
+                and now >= pytz.UTC.localize(job.started_at) + timedelta(seconds=max_seconds_without_heartbeat)
+            ):
+                stuck.append((job.info(), "missing heartbeats"))
+        return stuck
+
+    def get_zombies(self, max_seconds_without_heartbeat: float) -> list["JobInfo"]:
+        """Deprecated: use get_stuck_jobs instead."""
+        return [
+            job_info for job_info, reason in self.get_stuck_jobs(max_seconds_without_heartbeat) if reason == "missing heartbeats"
         ]
-        return [zombie.info() for zombie in zombies]
+
+    def get_terminated_jobs(self, max_seconds_after_termination: float) -> list["JobInfo"]:
+        """Deprecated: use get_stuck_jobs instead."""
+        return [
+            job_info for job_info, reason in self.get_stuck_jobs(max_seconds_after_termination) if reason == "terminated"
+        ]

--- a/services/worker/src/worker/executor.py
+++ b/services/worker/src/worker/executor.py
@@ -100,7 +100,7 @@ class WorkerExecutor:
         loop.create_task(every(self.heartbeat, seconds=self.heartbeat_interval_seconds))
         loop.create_task(
             every(
-                self.kill_zombies,
+                self.kill_stuck_jobs,
                 seconds=(
                     self.kill_zombies_interval_seconds * 0.5,
                     self.kill_zombies_interval_seconds * 1.5,
@@ -132,7 +132,17 @@ class WorkerExecutor:
     def sigterm_stop(self, web_app_executor: TCPExecutor) -> None:
         logging.error("Executor received SIGTERM")
         logging.error("Web app was not running" if not self.is_webapp_alive(web_app_executor) else "Reason unknown")
-        self.stop()
+        # Mark the current job as terminated so kill_stuck_jobs() can identify SIGTERM-caused crashes
+        worker_state = self.get_state()
+        if worker_state and worker_state["current_job_info"]:
+            job_id = worker_state["current_job_info"]["job_id"]
+            try:
+                Queue().set_terminated(job_id=job_id)
+                logging.info("Marked job %s as terminated (SIGTERM received).", job_id)
+            except Exception as error:
+                logging.warning("Failed to mark job %s as terminated: %s", job_id, error)
+        # Do not call self.stop() here - the signal handler returns and the event loop continues.
+        # The kill_terminated_jobs() task will detect the terminated job once the SIGKILL timeout is reached.
 
     def stop(self) -> None:
         for executor in self.executors:
@@ -164,15 +174,21 @@ class WorkerExecutor:
                 # Don't stop since the AfterJobPlan may be running
                 # self.stop()
 
-    def kill_zombies(self) -> None:
+    def kill_stuck_jobs(self) -> None:
+        """Detect and kill stuck jobs: both zombies (crashed) and terminated (SIGTERM but didn't finish)."""
         queue = Queue()
-        zombies = queue.get_zombies(max_seconds_without_heartbeat=self.max_seconds_without_heartbeat_for_zombies)
-        message = "Job manager crashed while running this job (missing heartbeats)."
-        for zombie in zombies:
-            job_runner = self.job_runner_factory.create_job_runner(zombie)
-            job_manager = JobManager(job_info=zombie, app_config=self.app_config, job_runner=job_runner)
-            job_manager.set_crashed(message=message)
-            logging.info(f"Killing zombie. Job info = {zombie}")
+        stuck = queue.get_stuck_jobs(max_seconds_without_heartbeat=self.max_seconds_without_heartbeat_for_zombies)
+        for job_info, reason in stuck:
+            job_runner = self.job_runner_factory.create_job_runner(job_info)
+            job_manager = JobManager(job_info=job_info, app_config=self.app_config, job_runner=job_runner)
+            if reason == "terminated":
+                message = (
+                    "Job has been terminated due to a temporary spike in resource usage and may be restarted later."
+                )
+            else:
+                message = "Job manager crashed while running this job (missing heartbeats)."
+            job_manager.set_stuck(message=message, reason=reason)
+            logging.info(f"Killing {reason} job. Job info = {job_info}")
 
     def kill_long_job(self, worker_loop_executor: OutputExecutor) -> None:
         worker_state = self.get_state()

--- a/services/worker/src/worker/job_manager.py
+++ b/services/worker/src/worker/job_manager.py
@@ -201,11 +201,11 @@ class JobManager:
                 "duration": get_duration_or_none(started_at),
             }
 
-    def set_crashed(self, message: str, cause: Optional[BaseException] = None) -> None:
+    def set_stuck(self, message: str, reason: str, cause: Optional[BaseException] = None) -> None:
         self.info(
             "response for"
             f" dataset={self.job_params['dataset']} revision={self.job_params['revision']} job_info={self.job_info}"
-            " had an error (crashed)"
+            f" had an error ('{reason}')"
         )
         error = JobManagerCrashedError(message=message, cause=cause)
         self.finish(

--- a/services/worker/tests/test_executor.py
+++ b/services/worker/tests/test_executor.py
@@ -198,6 +198,43 @@ def set_zombie_job_in_queue(queue_mongo_resource: QueueMongoResource) -> Iterato
 
 
 @fixture
+def set_terminated_job_in_queue(queue_mongo_resource: QueueMongoResource) -> Iterator[JobDocument]:
+    """Simulate a job that received SIGTERM (has terminated_at) but didn't finish before SIGKILL.
+    The job has no heartbeat after termination, mimicking the real-world scenario where
+    SIGKILL arrived before the job could complete or update its heartbeat."""
+    if not queue_mongo_resource.is_available():
+        raise RuntimeError("Mongo resource is not available")
+    job_info = get_job_info("terminated")
+    try:
+        JobDocument.get(job_id=job_info["job_id"]).delete()
+    except JobDoesNotExistError:
+        pass
+    now = get_datetime()
+    terminated_at = now - timedelta(seconds=20)  # terminated 20 seconds ago
+    last_heartbeat = terminated_at - timedelta(seconds=1)  # last heartbeat was before SIGTERM
+    job = JobDocument(
+        pk=job_info["job_id"],
+        type=job_info["type"],
+        dataset=job_info["params"]["dataset"],
+        revision=job_info["params"]["revision"],
+        config=job_info["params"]["config"],
+        split=job_info["params"]["split"],
+        unicity_id="unicity_id",
+        namespace="user",
+        priority=job_info["priority"],
+        status=Status.STARTED,
+        created_at=now - timedelta(days=1),
+        started_at=now - timedelta(days=1) + timedelta(milliseconds=1),
+        last_heartbeat=last_heartbeat,
+        terminated_at=terminated_at,
+        difficulty=job_info["difficulty"],
+    )
+    job.save()
+    yield job
+    job.delete()
+
+
+@fixture
 def job_runner_factory(
     app_config: AppConfig,
     libraries_resource: LibrariesResource,
@@ -260,7 +297,7 @@ def test_executor_heartbeat(
     assert last_heartbeat_datetime >= get_datetime() - timedelta(seconds=1)
 
 
-def test_executor_kill_zombies(
+def test_executor_kill_stuck_jobs(
     executor: WorkerExecutor,
     set_just_started_job_in_queue: JobDocument,
     set_long_running_job_in_queue: JobDocument,
@@ -270,7 +307,7 @@ def test_executor_kill_zombies(
     zombie = set_zombie_job_in_queue
     normal_job = set_just_started_job_in_queue
     tmp_dataset_repo_factory(zombie.dataset)
-    executor.kill_zombies()
+    executor.kill_stuck_jobs()
     assert JobDocument.objects(pk=zombie.pk).count() == 0
     assert JobDocument.objects(pk=normal_job.pk).get().status == Status.STARTED
     response = CachedResponseDocument.objects()[0]
@@ -297,7 +334,7 @@ def test_executor_start(
     tmp_dataset_repo_factory(zombie.dataset)
     # tmp_dataset_repo_factory(zombie.dataset)
     with patch.object(executor, "heartbeat", wraps=executor.heartbeat) as heartbeat_mock:
-        with patch.object(executor, "kill_zombies", wraps=executor.kill_zombies) as kill_zombies_mock:
+        with patch.object(executor, "kill_stuck_jobs", wraps=executor.kill_stuck_jobs) as kill_stuck_jobs_mock:
             with (
                 patch("worker.executor.START_WORKER_LOOP_PATH", __file__),
                 patch.dict(os.environ, {"WORKER_TEST_TIME": str(_TIME)}),
@@ -308,8 +345,66 @@ def test_executor_start(
     assert str(current_job.pk) == get_job_info()["job_id"]
     assert heartbeat_mock.call_count > 0
     assert JobDocument.objects(pk=set_just_started_job_in_queue.pk).get().last_heartbeat is not None
-    assert kill_zombies_mock.call_count > 0
+    assert kill_stuck_jobs_mock.call_count > 0
     assert JobDocument.objects(pk=set_zombie_job_in_queue.pk).count() == 0
+
+
+def test_executor_kill_terminated_jobs(
+    executor: WorkerExecutor,
+    set_terminated_job_in_queue: JobDocument,
+    tmp_dataset_repo_factory: Callable[[str], str],
+) -> None:
+    """Test that kill_stuck_jobs() detects jobs that received SIGTERM but didn't finish before SIGKILL."""
+    terminated_job = set_terminated_job_in_queue
+    tmp_dataset_repo_factory(terminated_job.dataset)
+
+    # Verify the job is in the expected state before the test
+    terminated_job.reload()
+    assert terminated_job.terminated_at is not None
+    assert terminated_job.status == Status.STARTED
+
+    # Run kill_stuck_jobs (which now handles both zombies and terminated jobs)
+    executor.kill_stuck_jobs()
+
+    # Job should be deleted (stuck)
+    assert JobDocument.objects(pk=terminated_job.pk).count() == 0
+
+    # Verify the cached error has the correct SIGTERM message
+    responses = CachedResponseDocument.objects()
+    assert len(responses) == 1
+    response = responses[0]
+    expected_message = "Job has been terminated due to a temporary spike in resource usage and may be restarted later."
+    expected_error = {"error": expected_message}
+    assert response.http_status == HTTPStatus.NOT_IMPLEMENTED
+    assert response.error_code == "JobManagerCrashedError"
+    assert response.dataset == terminated_job.dataset
+    assert response.config == terminated_job.config
+    assert response.split == terminated_job.split
+    assert response.content == expected_error
+    assert response.details == expected_error
+
+
+def test_executor_sigterm_stop_records_termination(
+    executor: WorkerExecutor,
+    set_just_started_job_in_queue: JobDocument,
+    set_worker_state: WorkerState,
+) -> None:
+    """Test that sigterm_stop() records the termination timestamp on the current job."""
+    job = set_just_started_job_in_queue
+    job.reload()
+    assert job.terminated_at is None
+
+    # Call sigterm_stop (simulating SIGTERM signal)
+    # We need to create a mock web_app_executor to avoid the alive check error
+    with patch.object(executor, "is_webapp_alive", return_value=True):
+        executor.sigterm_stop(web_app_executor=None)  # type: ignore[arg-type]
+
+    # The job should now have terminated_at set
+    job.reload()
+    assert job.terminated_at is not None
+
+    # Also verify the state file was read (no exception raised)
+    assert executor.get_state() is not None
 
 
 @pytest.mark.parametrize(

--- a/services/worker/tests/test_job_manager.py
+++ b/services/worker/tests/test_job_manager.py
@@ -152,10 +152,11 @@ def test_run_job_and_finish(priority: Priority, app_config: AppConfig) -> None:
     assert dataset_child_jobs[0]["priority"] is priority.value
 
 
-def test_job_runner_set_crashed(app_config: AppConfig) -> None:
+def test_job_runner_set_stuck(app_config: AppConfig) -> None:
     dataset = "dataset"
     revision = "revision"
     message = "I'm crashed :("
+    reason = "crashed"
     failed_runs = 2
 
     upsert_response(
@@ -189,7 +190,7 @@ def test_job_runner_set_crashed(app_config: AppConfig) -> None:
 
     job_manager = JobManager(job_info=job_info, app_config=app_config, job_runner=job_runner)
 
-    job_manager.set_crashed(message=message)
+    job_manager.set_stuck(message=message, reason=reason)
     response = CachedResponseDocument.objects()[0]
     expected_error = {"error": message}
     assert response.http_status == HTTPStatus.NOT_IMPLEMENTED


### PR DESCRIPTION
and give some time to jobs finish before stopping

this should reduce the amount of JobManagerCrashedError, and later be useful to restart terminated jobs before waiting for the daily backfill

thx to the open models that helped code this