### PR TITLE
disable memory check on light workers

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -531,8 +531,8 @@ workers:
     uvicornPort: 8080
     workerDifficultyMax: 40
     workerDifficultyMin: 0
-    maxMemoryPct: 80
-    maxSystemMemoryPct: 80
+    maxMemoryPct: 0
+    maxSystemMemoryPct: 0
     # Increased probe timeouts for light workers due to limited resources
     startupProbe:
       failureThreshold: 120


### PR DESCRIPTION
Even if they receive sigterm from k8s, they have the time to finish. Plus we can fit as many as possible on one pod, being close to the limit

follows #3354 