### PR TITLE
feat: Preserve row-level agent traces when first rows fit

### DIFF
--- a/libs/libcommon/src/libcommon/viewer_utils/rows.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/rows.py
@@ -2,13 +2,14 @@
 # Copyright 2022 The HuggingFace Authors.
 
 
+from copy import deepcopy
 from typing import Optional, Protocol
 
 import PIL
 from datasets import Audio, Features, Image, Pdf, Value, Video
 from datasets.packaged_modules.json.json import AGENT_TRACES_FEATURES
 
-from libcommon.dtos import Row, RowsContent, SplitFirstRowsResponse
+from libcommon.dtos import Row, RowItem, RowsContent, SplitFirstRowsResponse
 from libcommon.exceptions import (
     RowsPostProcessingError,
     TooBigContentError,
@@ -20,6 +21,18 @@ from libcommon.viewer_utils.features import get_cell_value, to_features_list
 from libcommon.viewer_utils.truncate_rows import create_truncated_row_items
 
 URL_COLUMN_RATIO = 0.3
+
+
+def create_response_with_rows(
+    response_features_only: SplitFirstRowsResponse,
+    row_items: list[RowItem],
+    rows_content: RowsContent,
+    truncated: bool,
+) -> SplitFirstRowsResponse:
+    response = response_features_only.copy()
+    response["rows"] = row_items
+    response["truncated"] = (not rows_content.all_fetched) or truncated
+    return response
 
 
 def transform_rows(
@@ -197,17 +210,29 @@ def create_first_rows_response(
         )
     ]
     row_items, truncated = create_truncated_row_items(
-        rows=transformed_rows,
+        rows=deepcopy(transformed_rows) if features == AGENT_TRACES_FEATURES else transformed_rows,
         min_cell_bytes=min_cell_bytes,
         rows_max_bytes=rows_max_bytes - surrounding_json_size,
         rows_min_number=rows_min_number,
         columns_to_keep_untruncated=columns_to_keep_untruncated,
         truncated_columns=rows_content.truncated_columns,
     )
+    response = create_response_with_rows(response_features_only, row_items, rows_content, truncated)
 
-    response = response_features_only
-    response["rows"] = row_items
-    response["truncated"] = (not rows_content.all_fetched) or truncated
+    if features == AGENT_TRACES_FEATURES:
+        row_items_with_trace, truncated_with_trace = create_truncated_row_items(
+            rows=deepcopy(transformed_rows),
+            min_cell_bytes=min_cell_bytes,
+            rows_max_bytes=rows_max_bytes - surrounding_json_size,
+            rows_min_number=rows_min_number,
+            columns_to_keep_untruncated=[*columns_to_keep_untruncated, "trace"],
+            truncated_columns=rows_content.truncated_columns,
+        )
+        response_with_trace = create_response_with_rows(
+            response_features_only, row_items_with_trace, rows_content, truncated_with_trace
+        )
+        if get_json_size(response_with_trace) <= rows_max_bytes:
+            response = response_with_trace
 
     # return the response
     return response

--- a/libs/libcommon/tests/viewer_utils/test_rows.py
+++ b/libs/libcommon/tests/viewer_utils/test_rows.py
@@ -7,12 +7,14 @@ from typing import Literal
 import pandas as pd
 import pytest
 from datasets import Dataset
+from datasets.packaged_modules.json.json import AGENT_TRACES_FEATURES
 from datasets.table import embed_table_storage
 
 from libcommon.constants import MAX_NUM_ROWS_PER_PAGE
+from libcommon.dtos import Row, RowsContent
 from libcommon.exceptions import TooBigContentError
 from libcommon.storage_client import StorageClient
-from libcommon.viewer_utils.rows import create_first_rows_response
+from libcommon.viewer_utils.rows import GetRowsContent, create_first_rows_response
 
 from ..constants import (
     CI_HUB_ENDPOINT,
@@ -65,6 +67,87 @@ def test_create_first_rows_response(
 
 
 NUM_ROWS = 15
+
+
+def get_agent_trace_rows_content(rows: list[Row]) -> GetRowsContent:
+    def _get_rows_content(rows_max_number: int) -> RowsContent:
+        rows_to_return = rows[:rows_max_number]
+        return RowsContent(
+            rows=rows_to_return,
+            all_fetched=len(rows) <= rows_max_number,
+            truncated_columns=[],
+        )
+
+    return _get_rows_content
+
+
+def get_agent_trace_row(trace: object) -> Row:
+    return {
+        "harness": "hermes",
+        "session_id": "hermes-session",
+        "prompt": "Run pwd and date.",
+        "messages": [{"role": "assistant", "content": "a" * 5_000}],
+        "tools": [],
+        "metadata": {"trace_type": "hermes"},
+        "sent_at": "2026-06-05T13:22:48.307Z",
+        "num_user_messages": 1,
+        "num_tool_calls": 1,
+        "trace": trace,
+        "file_path": "sessions.jsonl",
+    }
+
+
+def test_create_first_rows_response_keeps_agent_trace_when_it_fits(storage_client: StorageClient) -> None:
+    trace = [{"role": "user", "content": "keep this row-level trace"}]
+
+    response = create_first_rows_response(
+        dataset="dataset",
+        revision=DEFAULT_REVISION,
+        config=DEFAULT_CONFIG,
+        split=DEFAULT_SPLIT,
+        storage_client=storage_client,
+        hf_endpoint=CI_HUB_ENDPOINT,
+        hf_token=None,
+        features=AGENT_TRACES_FEATURES,
+        get_rows_content=get_agent_trace_rows_content([get_agent_trace_row(trace)]),
+        min_cell_bytes=DEFAULT_MIN_CELL_BYTES,
+        rows_max_bytes=2_000,
+        rows_max_number=DEFAULT_ROWS_MAX_NUMBER,
+        rows_min_number=DEFAULT_ROWS_MIN_NUMBER,
+        columns_max_number=DEFAULT_COLUMNS_MAX_NUMBER,
+    )
+
+    row = response["rows"][0]
+    assert row["row"]["trace"] == trace
+    assert "trace" not in row["truncated_cells"]
+    assert "messages" in row["truncated_cells"]
+
+
+def test_create_first_rows_response_truncates_agent_trace_when_it_does_not_fit(
+    storage_client: StorageClient,
+) -> None:
+    trace = [{"role": "user", "content": "x" * 5_000}]
+
+    response = create_first_rows_response(
+        dataset="dataset",
+        revision=DEFAULT_REVISION,
+        config=DEFAULT_CONFIG,
+        split=DEFAULT_SPLIT,
+        storage_client=storage_client,
+        hf_endpoint=CI_HUB_ENDPOINT,
+        hf_token=None,
+        features=AGENT_TRACES_FEATURES,
+        get_rows_content=get_agent_trace_rows_content([get_agent_trace_row(trace)]),
+        min_cell_bytes=DEFAULT_MIN_CELL_BYTES,
+        rows_max_bytes=2_000,
+        rows_max_number=DEFAULT_ROWS_MAX_NUMBER,
+        rows_min_number=DEFAULT_ROWS_MIN_NUMBER,
+        columns_max_number=DEFAULT_COLUMNS_MAX_NUMBER,
+    )
+
+    row = response["rows"][0]
+    assert isinstance(row["row"]["trace"], str)
+    assert "trace" in row["truncated_cells"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- let `split-first-rows` keep the full `trace` cell for agent-trace datasets when the response still fits the configured byte budget
- fall back to the existing truncation behavior when keeping `trace` would exceed the response budget
- add regression coverage for both the preserved-trace and fallback-truncation paths

## Why

Hermes exports can store multiple sessions in one `sessions.jsonl` file. The dataset rows already contain a parsed row-level `trace`, but the shared `file_path` points every session at the same multi-session source file. Keeping the row-level trace available when it fits gives the Hub trace UI enough data to render a session detail without requiring one repo file per Hermes session.

## Validation

- `uvx ruff format libs/libcommon/src/libcommon/viewer_utils/rows.py libs/libcommon/tests/viewer_utils/test_rows.py`
- `uvx ruff check libs/libcommon/src/libcommon/viewer_utils/rows.py libs/libcommon/tests/viewer_utils/test_rows.py`
- `cd libs/libcommon && uv run python -m pytest -q tests/viewer_utils/test_rows.py -k agent_trace -s`
- Sanity checked live `armand0e/hermes-test` rows through the patched helper: `trace` remains untruncated and the response is ~376 KB under a 1 MB budget.

Full `tests/viewer_utils/test_rows.py` does not complete in this local environment because existing audio fixture setup requires FFmpeg libraries for TorchCodec (`libavutil.so.*` missing).
