### PR TITLE
chore(chart): harden worker pod security context

### DIFF
--- a/chart/templates/worker/_container.tpl
+++ b/chart/templates/worker/_container.tpl
@@ -43,6 +43,9 @@
   {{ include "volumeMountParquetMetadataRW" . | nindent 2 }}
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
   resources: {{ toYaml .workerValues.resources | nindent 4 }}
   readinessProbe:
     failureThreshold: {{ if .workerValues.readinessProbe }}{{ .workerValues.readinessProbe.failureThreshold | default 30 }}{{ else }}30{{ end }}

--- a/chart/templates/worker/_deployment.yaml
+++ b/chart/templates/worker/_deployment.yaml
@@ -27,6 +27,10 @@ spec:
     metadata:
       labels: {{ include "labels.worker" (merge (dict "workerValues" .workerValues) $ ) | nindent 8 }}
     spec:
+      # Workers process untrusted user datasets and never call the Kubernetes
+      # API, so they should not carry an in-cluster credential. Disabling
+      # ServiceAccount-token automount removes it from the blast radius.
+      automountServiceAccountToken: false
       terminationGracePeriodSeconds: {{ default 30 .workerValues.terminationGracePeriodSeconds }}
       {{- include "dnsConfig" . | nindent 6 }}
       {{- include "image.imagePullSecrets" . | nindent 6 }}
@@ -37,5 +41,8 @@ spec:
       tolerations: {{ toYaml .workerValues.tolerations | nindent 8 }}
       volumes:
         {{ include "volumeParquetMetadata" . | nindent 8 }}
-      securityContext: {{ include "securityContext" . | nindent 8 }}
+      securityContext:
+        {{- include "securityContext" . | nindent 8 }}
+        seccompProfile:
+          type: RuntimeDefault
 {{- end -}}


### PR DESCRIPTION
## What

Least-privilege hardening for the `worker` pods (which process untrusted user datasets):

- `automountServiceAccountToken: false` on the worker pod — workers never call the Kubernetes API, so they shouldn't mount an in-cluster ServiceAccount token.
- Pod `securityContext.seccompProfile: RuntimeDefault`.
- Container `securityContext.capabilities.drop: [ALL]` (`allowPrivilegeEscalation: false` was already set).

## Why

Workers ingest and parse arbitrary user-provided datasets, so they are the highest-risk pods in the deployment. These are standard defense-in-depth controls that reduce what a compromised worker process can reach — most importantly, dropping the ServiceAccount token means a worker cannot talk to the Kubernetes API at all.

## Scope

Worker pods only; other services (api, sse-api, admin, search, jobs) are unchanged.

## Test

- `helm lint chart/` passes.
- `helm template chart/` renders; the worker Deployment shows all three settings and the full output parses as valid YAML. Other Deployments are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
