### PR TITLE
fix(chart): don't swallow apiVersion in serviceaccount template

### DIFF
--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2024 The HuggingFace Authors.
 
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
The right-side whitespace chomp in `{{- if .Values.serviceAccount.create -}}` glues `apiVersion: v1` onto the preceding copyright comment line, so the rendered ServiceAccount manifest has no apiVersion:

```yaml
# Copyright 2024 The HuggingFace Authors.apiVersion: v1
kind: ServiceAccount
```

This makes the Argo CD sync of `datasets-server-prod` fail with `failed to discover server resources for group version : groupVersion shouldn't be empty` (introduced by #3359, blocks the prod restart).

Verified with `helm template chart --show-only templates/serviceaccount.yaml --set serviceAccount.create=true`: apiVersion now renders on its own line.