### PR TITLE
feat(libcommon): add pymongo aws extra for MONGODB-AWS auth

### DIFF
--- a/front/admin_ui/poetry.lock
+++ b/front/admin_ui/poetry.lock
@@ -344,6 +344,26 @@ files = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.41.5"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "boto3-1.41.5-py3-none-any.whl", hash = "sha256:bb278111bfb4c33dca8342bda49c9db7685e43debbfa00cc2a5eb854dd54b745"},
+    {file = "boto3-1.41.5.tar.gz", hash = "sha256:bc7806bee681dfdff2fe2b74967b107a56274f1e66ebe4d20dc8eee1ea408d17"},
+]
+
+[package.dependencies]
+botocore = ">=1.41.5,<1.42.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.15.0,<0.16.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
 name = "botocore"
 version = "1.41.5"
 description = "Low-level, data-driven core of boto 3."
@@ -1831,7 +1851,7 @@ psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.13.4"
 pylance = "^1.0.4"
-pymongo = {version = "^4.15.1", extras = ["srv"]}
+pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
 pytz = "^2020.1"
@@ -3388,6 +3408,7 @@ files = [
 
 [package.dependencies]
 dnspython = ">=2.6.1,<3.0.0"
+pymongo-auth-aws = {version = ">=1.1.0,<2.0.0", optional = true, markers = "extra == \"aws\""}
 
 [package.extras]
 aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
@@ -3398,6 +3419,25 @@ ocsp = ["certifi (>=2023.7.22) ; os_name == \"nt\" or sys_platform == \"darwin\"
 snappy = ["python-snappy (>=0.6.0)"]
 test = ["importlib-metadata (>=7.0) ; python_version < \"3.13\"", "pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "pymongo-auth-aws"
+version = "1.3.0"
+description = "MONGODB-AWS authentication support for PyMongo"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pymongo_auth_aws-1.3.0-py3-none-any.whl", hash = "sha256:367f6d853da428a02e9e450422756133715d40f8141f47ae5d98f139a88c0ce5"},
+    {file = "pymongo_auth_aws-1.3.0.tar.gz", hash = "sha256:d0fa893958dc525ca29f601c34f2ca73c860f66bc6511ec0a7da6eb7ea44e94f"},
+]
+
+[package.dependencies]
+boto3 = "*"
+botocore = "*"
+
+[package.extras]
+test = ["dnspython (>=2.6.1)", "pymongo", "pytest"]
 
 [[package]]
 name = "pymongoarrow"
@@ -3714,6 +3754,24 @@ fsspec = "==2024.6.0.*"
 [package.extras]
 awscli = ["aiobotocore[awscli] (>=2.5.4,<3.0.0)"]
 boto3 = ["aiobotocore[boto3] (>=2.5.4,<3.0.0)"]
+
+[[package]]
+name = "s3transfer"
+version = "0.15.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.15.0-py3-none-any.whl", hash = "sha256:6f8bf5caa31a0865c4081186689db1b2534cef721d104eb26101de4b9d6a5852"},
+    {file = "s3transfer-0.15.0.tar.gz", hash = "sha256:d36fac8d0e3603eff9b5bfa4282c7ce6feb0301a633566153cbd0b93d11d8379"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
 
 [[package]]
 name = "safehttpx"

--- a/jobs/cache_maintenance/poetry.lock
+++ b/jobs/cache_maintenance/poetry.lock
@@ -328,6 +328,26 @@ linting = ["black", "isort", "pycodestyle"]
 testing = ["pytest (>=6,!=7.0.0)", "pytest-xdist (>=2)"]
 
 [[package]]
+name = "boto3"
+version = "1.41.5"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "boto3-1.41.5-py3-none-any.whl", hash = "sha256:bb278111bfb4c33dca8342bda49c9db7685e43debbfa00cc2a5eb854dd54b745"},
+    {file = "boto3-1.41.5.tar.gz", hash = "sha256:bc7806bee681dfdff2fe2b74967b107a56274f1e66ebe4d20dc8eee1ea408d17"},
+]
+
+[package.dependencies]
+botocore = ">=1.41.5,<1.42.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.15.0,<0.16.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
 name = "botocore"
 version = "1.41.5"
 description = "Low-level, data-driven core of boto 3."
@@ -1368,7 +1388,7 @@ psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.13.4"
 pylance = "^1.0.4"
-pymongo = {version = "^4.15.1", extras = ["srv"]}
+pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
 pytz = "^2020.1"
@@ -3380,6 +3400,7 @@ files = [
 
 [package.dependencies]
 dnspython = ">=2.6.1,<3.0.0"
+pymongo-auth-aws = {version = ">=1.1.0,<2.0.0", optional = true, markers = "extra == \"aws\""}
 
 [package.extras]
 aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
@@ -3390,6 +3411,25 @@ ocsp = ["certifi (>=2023.7.22) ; os_name == \"nt\" or sys_platform == \"darwin\"
 snappy = ["python-snappy (>=0.6.0)"]
 test = ["importlib-metadata (>=7.0) ; python_version < \"3.13\"", "pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "pymongo-auth-aws"
+version = "1.3.0"
+description = "MONGODB-AWS authentication support for PyMongo"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pymongo_auth_aws-1.3.0-py3-none-any.whl", hash = "sha256:367f6d853da428a02e9e450422756133715d40f8141f47ae5d98f139a88c0ce5"},
+    {file = "pymongo_auth_aws-1.3.0.tar.gz", hash = "sha256:d0fa893958dc525ca29f601c34f2ca73c860f66bc6511ec0a7da6eb7ea44e94f"},
+]
+
+[package.dependencies]
+boto3 = "*"
+botocore = "*"
+
+[package.extras]
+test = ["dnspython (>=2.6.1)", "pymongo", "pytest"]
 
 [[package]]
 name = "pymongoarrow"
@@ -3765,6 +3805,24 @@ fsspec = "==2024.6.0.*"
 [package.extras]
 awscli = ["aiobotocore[awscli] (>=2.5.4,<3.0.0)"]
 boto3 = ["aiobotocore[boto3] (>=2.5.4,<3.0.0)"]
+
+[[package]]
+name = "s3transfer"
+version = "0.15.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.15.0-py3-none-any.whl", hash = "sha256:6f8bf5caa31a0865c4081186689db1b2534cef721d104eb26101de4b9d6a5852"},
+    {file = "s3transfer-0.15.0.tar.gz", hash = "sha256:d36fac8d0e3603eff9b5bfa4282c7ce6feb0301a633566153cbd0b93d11d8379"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
 
 [[package]]
 name = "setuptools"

--- a/jobs/mongodb_migration/poetry.lock
+++ b/jobs/mongodb_migration/poetry.lock
@@ -328,6 +328,26 @@ linting = ["black", "isort", "pycodestyle"]
 testing = ["pytest (>=6,!=7.0.0)", "pytest-xdist (>=2)"]
 
 [[package]]
+name = "boto3"
+version = "1.41.5"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "boto3-1.41.5-py3-none-any.whl", hash = "sha256:bb278111bfb4c33dca8342bda49c9db7685e43debbfa00cc2a5eb854dd54b745"},
+    {file = "boto3-1.41.5.tar.gz", hash = "sha256:bc7806bee681dfdff2fe2b74967b107a56274f1e66ebe4d20dc8eee1ea408d17"},
+]
+
+[package.dependencies]
+botocore = ">=1.41.5,<1.42.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.15.0,<0.16.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
 name = "botocore"
 version = "1.41.5"
 description = "Low-level, data-driven core of boto 3."
@@ -1368,7 +1388,7 @@ psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.13.4"
 pylance = "^1.0.4"
-pymongo = {version = "^4.15.1", extras = ["srv"]}
+pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
 pytz = "^2020.1"
@@ -3380,6 +3400,7 @@ files = [
 
 [package.dependencies]
 dnspython = ">=2.6.1,<3.0.0"
+pymongo-auth-aws = {version = ">=1.1.0,<2.0.0", optional = true, markers = "extra == \"aws\""}
 
 [package.extras]
 aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
@@ -3390,6 +3411,25 @@ ocsp = ["certifi (>=2023.7.22) ; os_name == \"nt\" or sys_platform == \"darwin\"
 snappy = ["python-snappy (>=0.6.0)"]
 test = ["importlib-metadata (>=7.0) ; python_version < \"3.13\"", "pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "pymongo-auth-aws"
+version = "1.3.0"
+description = "MONGODB-AWS authentication support for PyMongo"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pymongo_auth_aws-1.3.0-py3-none-any.whl", hash = "sha256:367f6d853da428a02e9e450422756133715d40f8141f47ae5d98f139a88c0ce5"},
+    {file = "pymongo_auth_aws-1.3.0.tar.gz", hash = "sha256:d0fa893958dc525ca29f601c34f2ca73c860f66bc6511ec0a7da6eb7ea44e94f"},
+]
+
+[package.dependencies]
+boto3 = "*"
+botocore = "*"
+
+[package.extras]
+test = ["dnspython (>=2.6.1)", "pymongo", "pytest"]
 
 [[package]]
 name = "pymongoarrow"
@@ -3765,6 +3805,24 @@ fsspec = "==2024.6.0.*"
 [package.extras]
 awscli = ["aiobotocore[awscli] (>=2.5.4,<3.0.0)"]
 boto3 = ["aiobotocore[boto3] (>=2.5.4,<3.0.0)"]
+
+[[package]]
+name = "s3transfer"
+version = "0.15.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.15.0-py3-none-any.whl", hash = "sha256:6f8bf5caa31a0865c4081186689db1b2534cef721d104eb26101de4b9d6a5852"},
+    {file = "s3transfer-0.15.0.tar.gz", hash = "sha256:d36fac8d0e3603eff9b5bfa4282c7ce6feb0301a633566153cbd0b93d11d8379"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
 
 [[package]]
 name = "setuptools"

--- a/libs/libapi/poetry.lock
+++ b/libs/libapi/poetry.lock
@@ -328,6 +328,26 @@ linting = ["black", "isort", "pycodestyle"]
 testing = ["pytest (>=6,!=7.0.0)", "pytest-xdist (>=2)"]
 
 [[package]]
+name = "boto3"
+version = "1.41.5"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "boto3-1.41.5-py3-none-any.whl", hash = "sha256:bb278111bfb4c33dca8342bda49c9db7685e43debbfa00cc2a5eb854dd54b745"},
+    {file = "boto3-1.41.5.tar.gz", hash = "sha256:bc7806bee681dfdff2fe2b74967b107a56274f1e66ebe4d20dc8eee1ea408d17"},
+]
+
+[package.dependencies]
+botocore = ">=1.41.5,<1.42.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.15.0,<0.16.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
 name = "botocore"
 version = "1.41.5"
 description = "Low-level, data-driven core of boto 3."
@@ -1387,7 +1407,7 @@ psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.13.4"
 pylance = "^1.0.4"
-pymongo = {version = "^4.15.1", extras = ["srv"]}
+pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
 pytz = "^2020.1"
@@ -3417,6 +3437,7 @@ files = [
 
 [package.dependencies]
 dnspython = ">=2.6.1,<3.0.0"
+pymongo-auth-aws = {version = ">=1.1.0,<2.0.0", optional = true, markers = "extra == \"aws\""}
 
 [package.extras]
 aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
@@ -3427,6 +3448,25 @@ ocsp = ["certifi (>=2023.7.22) ; os_name == \"nt\" or sys_platform == \"darwin\"
 snappy = ["python-snappy (>=0.6.0)"]
 test = ["importlib-metadata (>=7.0) ; python_version < \"3.13\"", "pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "pymongo-auth-aws"
+version = "1.3.0"
+description = "MONGODB-AWS authentication support for PyMongo"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pymongo_auth_aws-1.3.0-py3-none-any.whl", hash = "sha256:367f6d853da428a02e9e450422756133715d40f8141f47ae5d98f139a88c0ce5"},
+    {file = "pymongo_auth_aws-1.3.0.tar.gz", hash = "sha256:d0fa893958dc525ca29f601c34f2ca73c860f66bc6511ec0a7da6eb7ea44e94f"},
+]
+
+[package.dependencies]
+boto3 = "*"
+botocore = "*"
+
+[package.extras]
+test = ["dnspython (>=2.6.1)", "pymongo", "pytest"]
 
 [[package]]
 name = "pymongoarrow"
@@ -3817,6 +3857,24 @@ fsspec = "==2024.6.0.*"
 [package.extras]
 awscli = ["aiobotocore[awscli] (>=2.5.4,<3.0.0)"]
 boto3 = ["aiobotocore[boto3] (>=2.5.4,<3.0.0)"]
+
+[[package]]
+name = "s3transfer"
+version = "0.15.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.15.0-py3-none-any.whl", hash = "sha256:6f8bf5caa31a0865c4081186689db1b2534cef721d104eb26101de4b9d6a5852"},
+    {file = "s3transfer-0.15.0.tar.gz", hash = "sha256:d36fac8d0e3603eff9b5bfa4282c7ce6feb0301a633566153cbd0b93d11d8379"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
 
 [[package]]
 name = "setuptools"

--- a/libs/libcommon/poetry.lock
+++ b/libs/libcommon/poetry.lock
@@ -329,7 +329,7 @@ version = "1.34.106"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "boto3-1.34.106-py3-none-any.whl", hash = "sha256:d3be4e1dd5d546a001cd4da805816934cbde9d395316546e9411fec341ade5cf"},
     {file = "boto3-1.34.106.tar.gz", hash = "sha256:6165b8cf1c7e625628ab28b32f9027064c8f5e5fca1c38d7fc228cd22069a19f"},
@@ -3414,6 +3414,7 @@ files = [
 
 [package.dependencies]
 dnspython = ">=2.6.1,<3.0.0"
+pymongo-auth-aws = {version = ">=1.1.0,<2.0.0", optional = true, markers = "extra == \"aws\""}
 
 [package.extras]
 aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
@@ -3424,6 +3425,25 @@ ocsp = ["certifi (>=2023.7.22) ; os_name == \"nt\" or sys_platform == \"darwin\"
 snappy = ["python-snappy (>=0.6.0)"]
 test = ["importlib-metadata (>=7.0) ; python_version < \"3.13\"", "pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "pymongo-auth-aws"
+version = "1.3.0"
+description = "MONGODB-AWS authentication support for PyMongo"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pymongo_auth_aws-1.3.0-py3-none-any.whl", hash = "sha256:367f6d853da428a02e9e450422756133715d40f8141f47ae5d98f139a88c0ce5"},
+    {file = "pymongo_auth_aws-1.3.0.tar.gz", hash = "sha256:d0fa893958dc525ca29f601c34f2ca73c860f66bc6511ec0a7da6eb7ea44e94f"},
+]
+
+[package.dependencies]
+boto3 = "*"
+botocore = "*"
+
+[package.extras]
+test = ["dnspython (>=2.6.1)", "pymongo", "pytest"]
 
 [[package]]
 name = "pymongoarrow"
@@ -3845,7 +3865,7 @@ version = "0.10.4"
 description = "An Amazon S3 Transfer Manager"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "s3transfer-0.10.4-py3-none-any.whl", hash = "sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e"},
     {file = "s3transfer-0.10.4.tar.gz", hash = "sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7"},
@@ -5451,4 +5471,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "3.14.5"
-content-hash = "fb75ebe080be26d052110b01883b8d6c72dfbfb79951331893965497427a08df"
+content-hash = "5385f5e67e97d771d77d5c480016fc75fe2da3fe9f6afe8e5b84269923974369"

--- a/libs/libcommon/pyproject.toml
+++ b/libs/libcommon/pyproject.toml
@@ -34,7 +34,7 @@ pydantic = "^2.13.4"
 pylance = "^1.0.4"
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
-pymongo = { extras = ["srv"], version = "^4.15.1" }
+pymongo = { extras = ["srv", "aws"], version = "^4.15.1" }
 pytz = "^2020.1"
 s3fs = "2024.6.0"  # Aligned with fsspec[s3] version
 soundfile = ">=0.12.1"

--- a/services/admin/poetry.lock
+++ b/services/admin/poetry.lock
@@ -328,6 +328,26 @@ linting = ["black", "isort", "pycodestyle"]
 testing = ["pytest (>=6,!=7.0.0)", "pytest-xdist (>=2)"]
 
 [[package]]
+name = "boto3"
+version = "1.41.5"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "boto3-1.41.5-py3-none-any.whl", hash = "sha256:bb278111bfb4c33dca8342bda49c9db7685e43debbfa00cc2a5eb854dd54b745"},
+    {file = "boto3-1.41.5.tar.gz", hash = "sha256:bc7806bee681dfdff2fe2b74967b107a56274f1e66ebe4d20dc8eee1ea408d17"},
+]
+
+[package.dependencies]
+botocore = ">=1.41.5,<1.42.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.15.0,<0.16.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
 name = "botocore"
 version = "1.41.5"
 description = "Low-level, data-driven core of boto 3."
@@ -1391,7 +1411,7 @@ psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.13.4"
 pylance = "^1.0.4"
-pymongo = {version = "^4.15.1", extras = ["srv"]}
+pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
 pytz = "^2020.1"
@@ -3421,6 +3441,7 @@ files = [
 
 [package.dependencies]
 dnspython = ">=2.6.1,<3.0.0"
+pymongo-auth-aws = {version = ">=1.1.0,<2.0.0", optional = true, markers = "extra == \"aws\""}
 
 [package.extras]
 aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
@@ -3431,6 +3452,25 @@ ocsp = ["certifi (>=2023.7.22) ; os_name == \"nt\" or sys_platform == \"darwin\"
 snappy = ["python-snappy (>=0.6.0)"]
 test = ["importlib-metadata (>=7.0) ; python_version < \"3.13\"", "pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "pymongo-auth-aws"
+version = "1.3.0"
+description = "MONGODB-AWS authentication support for PyMongo"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pymongo_auth_aws-1.3.0-py3-none-any.whl", hash = "sha256:367f6d853da428a02e9e450422756133715d40f8141f47ae5d98f139a88c0ce5"},
+    {file = "pymongo_auth_aws-1.3.0.tar.gz", hash = "sha256:d0fa893958dc525ca29f601c34f2ca73c860f66bc6511ec0a7da6eb7ea44e94f"},
+]
+
+[package.dependencies]
+boto3 = "*"
+botocore = "*"
+
+[package.extras]
+test = ["dnspython (>=2.6.1)", "pymongo", "pytest"]
 
 [[package]]
 name = "pymongoarrow"
@@ -3824,6 +3864,24 @@ fsspec = "==2024.6.0.*"
 [package.extras]
 awscli = ["aiobotocore[awscli] (>=2.5.4,<3.0.0)"]
 boto3 = ["aiobotocore[boto3] (>=2.5.4,<3.0.0)"]
+
+[[package]]
+name = "s3transfer"
+version = "0.15.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.15.0-py3-none-any.whl", hash = "sha256:6f8bf5caa31a0865c4081186689db1b2534cef721d104eb26101de4b9d6a5852"},
+    {file = "s3transfer-0.15.0.tar.gz", hash = "sha256:d36fac8d0e3603eff9b5bfa4282c7ce6feb0301a633566153cbd0b93d11d8379"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
 
 [[package]]
 name = "setuptools"

--- a/services/api/poetry.lock
+++ b/services/api/poetry.lock
@@ -328,6 +328,26 @@ linting = ["black", "isort", "pycodestyle"]
 testing = ["pytest (>=6,!=7.0.0)", "pytest-xdist (>=2)"]
 
 [[package]]
+name = "boto3"
+version = "1.41.5"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "boto3-1.41.5-py3-none-any.whl", hash = "sha256:bb278111bfb4c33dca8342bda49c9db7685e43debbfa00cc2a5eb854dd54b745"},
+    {file = "boto3-1.41.5.tar.gz", hash = "sha256:bc7806bee681dfdff2fe2b74967b107a56274f1e66ebe4d20dc8eee1ea408d17"},
+]
+
+[package.dependencies]
+botocore = ">=1.41.5,<1.42.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.15.0,<0.16.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
 name = "botocore"
 version = "1.41.5"
 description = "Low-level, data-driven core of boto 3."
@@ -1428,7 +1448,7 @@ psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.13.4"
 pylance = "^1.0.4"
-pymongo = {version = "^4.15.1", extras = ["srv"]}
+pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
 pytz = "^2020.1"
@@ -3458,6 +3478,7 @@ files = [
 
 [package.dependencies]
 dnspython = ">=2.6.1,<3.0.0"
+pymongo-auth-aws = {version = ">=1.1.0,<2.0.0", optional = true, markers = "extra == \"aws\""}
 
 [package.extras]
 aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
@@ -3468,6 +3489,25 @@ ocsp = ["certifi (>=2023.7.22) ; os_name == \"nt\" or sys_platform == \"darwin\"
 snappy = ["python-snappy (>=0.6.0)"]
 test = ["importlib-metadata (>=7.0) ; python_version < \"3.13\"", "pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "pymongo-auth-aws"
+version = "1.3.0"
+description = "MONGODB-AWS authentication support for PyMongo"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pymongo_auth_aws-1.3.0-py3-none-any.whl", hash = "sha256:367f6d853da428a02e9e450422756133715d40f8141f47ae5d98f139a88c0ce5"},
+    {file = "pymongo_auth_aws-1.3.0.tar.gz", hash = "sha256:d0fa893958dc525ca29f601c34f2ca73c860f66bc6511ec0a7da6eb7ea44e94f"},
+]
+
+[package.dependencies]
+boto3 = "*"
+botocore = "*"
+
+[package.extras]
+test = ["dnspython (>=2.6.1)", "pymongo", "pytest"]
 
 [[package]]
 name = "pymongoarrow"
@@ -3999,6 +4039,24 @@ fsspec = "==2024.6.0.*"
 [package.extras]
 awscli = ["aiobotocore[awscli] (>=2.5.4,<3.0.0)"]
 boto3 = ["aiobotocore[boto3] (>=2.5.4,<3.0.0)"]
+
+[[package]]
+name = "s3transfer"
+version = "0.15.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.15.0-py3-none-any.whl", hash = "sha256:6f8bf5caa31a0865c4081186689db1b2534cef721d104eb26101de4b9d6a5852"},
+    {file = "s3transfer-0.15.0.tar.gz", hash = "sha256:d36fac8d0e3603eff9b5bfa4282c7ce6feb0301a633566153cbd0b93d11d8379"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
 
 [[package]]
 name = "setuptools"

--- a/services/rows/poetry.lock
+++ b/services/rows/poetry.lock
@@ -333,7 +333,7 @@ version = "1.41.5"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "boto3-1.41.5-py3-none-any.whl", hash = "sha256:bb278111bfb4c33dca8342bda49c9db7685e43debbfa00cc2a5eb854dd54b745"},
     {file = "boto3-1.41.5.tar.gz", hash = "sha256:bc7806bee681dfdff2fe2b74967b107a56274f1e66ebe4d20dc8eee1ea408d17"},
@@ -1449,7 +1449,7 @@ psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.13.4"
 pylance = "^1.0.4"
-pymongo = {version = "^4.15.1", extras = ["srv"]}
+pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
 pytz = "^2020.1"
@@ -3524,6 +3524,7 @@ files = [
 
 [package.dependencies]
 dnspython = ">=2.6.1,<3.0.0"
+pymongo-auth-aws = {version = ">=1.1.0,<2.0.0", optional = true, markers = "extra == \"aws\""}
 
 [package.extras]
 aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
@@ -3534,6 +3535,25 @@ ocsp = ["certifi (>=2023.7.22) ; os_name == \"nt\" or sys_platform == \"darwin\"
 snappy = ["python-snappy (>=0.6.0)"]
 test = ["importlib-metadata (>=7.0) ; python_version < \"3.13\"", "pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "pymongo-auth-aws"
+version = "1.3.0"
+description = "MONGODB-AWS authentication support for PyMongo"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pymongo_auth_aws-1.3.0-py3-none-any.whl", hash = "sha256:367f6d853da428a02e9e450422756133715d40f8141f47ae5d98f139a88c0ce5"},
+    {file = "pymongo_auth_aws-1.3.0.tar.gz", hash = "sha256:d0fa893958dc525ca29f601c34f2ca73c860f66bc6511ec0a7da6eb7ea44e94f"},
+]
+
+[package.dependencies]
+boto3 = "*"
+botocore = "*"
+
+[package.extras]
+test = ["dnspython (>=2.6.1)", "pymongo", "pytest"]
 
 [[package]]
 name = "pymongoarrow"
@@ -4092,7 +4112,7 @@ version = "0.15.0"
 description = "An Amazon S3 Transfer Manager"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "s3transfer-0.15.0-py3-none-any.whl", hash = "sha256:6f8bf5caa31a0865c4081186689db1b2534cef721d104eb26101de4b9d6a5852"},
     {file = "s3transfer-0.15.0.tar.gz", hash = "sha256:d36fac8d0e3603eff9b5bfa4282c7ce6feb0301a633566153cbd0b93d11d8379"},

--- a/services/search/poetry.lock
+++ b/services/search/poetry.lock
@@ -328,6 +328,26 @@ linting = ["black", "isort", "pycodestyle"]
 testing = ["pytest (>=6,!=7.0.0)", "pytest-xdist (>=2)"]
 
 [[package]]
+name = "boto3"
+version = "1.41.5"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "boto3-1.41.5-py3-none-any.whl", hash = "sha256:bb278111bfb4c33dca8342bda49c9db7685e43debbfa00cc2a5eb854dd54b745"},
+    {file = "boto3-1.41.5.tar.gz", hash = "sha256:bc7806bee681dfdff2fe2b74967b107a56274f1e66ebe4d20dc8eee1ea408d17"},
+]
+
+[package.dependencies]
+botocore = ">=1.41.5,<1.42.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.15.0,<0.16.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
 name = "botocore"
 version = "1.41.5"
 description = "Low-level, data-driven core of boto 3."
@@ -1428,7 +1448,7 @@ psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.13.4"
 pylance = "^1.0.4"
-pymongo = {version = "^4.15.1", extras = ["srv"]}
+pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
 pytz = "^2020.1"
@@ -3458,6 +3478,7 @@ files = [
 
 [package.dependencies]
 dnspython = ">=2.6.1,<3.0.0"
+pymongo-auth-aws = {version = ">=1.1.0,<2.0.0", optional = true, markers = "extra == \"aws\""}
 
 [package.extras]
 aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
@@ -3468,6 +3489,25 @@ ocsp = ["certifi (>=2023.7.22) ; os_name == \"nt\" or sys_platform == \"darwin\"
 snappy = ["python-snappy (>=0.6.0)"]
 test = ["importlib-metadata (>=7.0) ; python_version < \"3.13\"", "pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "pymongo-auth-aws"
+version = "1.3.0"
+description = "MONGODB-AWS authentication support for PyMongo"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pymongo_auth_aws-1.3.0-py3-none-any.whl", hash = "sha256:367f6d853da428a02e9e450422756133715d40f8141f47ae5d98f139a88c0ce5"},
+    {file = "pymongo_auth_aws-1.3.0.tar.gz", hash = "sha256:d0fa893958dc525ca29f601c34f2ca73c860f66bc6511ec0a7da6eb7ea44e94f"},
+]
+
+[package.dependencies]
+boto3 = "*"
+botocore = "*"
+
+[package.extras]
+test = ["dnspython (>=2.6.1)", "pymongo", "pytest"]
 
 [[package]]
 name = "pymongoarrow"
@@ -3999,6 +4039,24 @@ fsspec = "==2024.6.0.*"
 [package.extras]
 awscli = ["aiobotocore[awscli] (>=2.5.4,<3.0.0)"]
 boto3 = ["aiobotocore[boto3] (>=2.5.4,<3.0.0)"]
+
+[[package]]
+name = "s3transfer"
+version = "0.15.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.15.0-py3-none-any.whl", hash = "sha256:6f8bf5caa31a0865c4081186689db1b2534cef721d104eb26101de4b9d6a5852"},
+    {file = "s3transfer-0.15.0.tar.gz", hash = "sha256:d36fac8d0e3603eff9b5bfa4282c7ce6feb0301a633566153cbd0b93d11d8379"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
 
 [[package]]
 name = "setuptools"

--- a/services/sse-api/poetry.lock
+++ b/services/sse-api/poetry.lock
@@ -328,6 +328,26 @@ linting = ["black", "isort", "pycodestyle"]
 testing = ["pytest (>=6,!=7.0.0)", "pytest-xdist (>=2)"]
 
 [[package]]
+name = "boto3"
+version = "1.41.5"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "boto3-1.41.5-py3-none-any.whl", hash = "sha256:bb278111bfb4c33dca8342bda49c9db7685e43debbfa00cc2a5eb854dd54b745"},
+    {file = "boto3-1.41.5.tar.gz", hash = "sha256:bc7806bee681dfdff2fe2b74967b107a56274f1e66ebe4d20dc8eee1ea408d17"},
+]
+
+[package.dependencies]
+botocore = ">=1.41.5,<1.42.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.15.0,<0.16.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
 name = "botocore"
 version = "1.41.5"
 description = "Low-level, data-driven core of boto 3."
@@ -1463,7 +1483,7 @@ psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.13.4"
 pylance = "^1.0.4"
-pymongo = {version = "^4.15.1", extras = ["srv"]}
+pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
 pytz = "^2020.1"
@@ -3537,6 +3557,7 @@ files = [
 
 [package.dependencies]
 dnspython = ">=2.6.1,<3.0.0"
+pymongo-auth-aws = {version = ">=1.1.0,<2.0.0", optional = true, markers = "extra == \"aws\""}
 
 [package.extras]
 aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
@@ -3547,6 +3568,25 @@ ocsp = ["certifi (>=2023.7.22) ; os_name == \"nt\" or sys_platform == \"darwin\"
 snappy = ["python-snappy (>=0.6.0)"]
 test = ["importlib-metadata (>=7.0) ; python_version < \"3.13\"", "pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "pymongo-auth-aws"
+version = "1.3.0"
+description = "MONGODB-AWS authentication support for PyMongo"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pymongo_auth_aws-1.3.0-py3-none-any.whl", hash = "sha256:367f6d853da428a02e9e450422756133715d40f8141f47ae5d98f139a88c0ce5"},
+    {file = "pymongo_auth_aws-1.3.0.tar.gz", hash = "sha256:d0fa893958dc525ca29f601c34f2ca73c860f66bc6511ec0a7da6eb7ea44e94f"},
+]
+
+[package.dependencies]
+boto3 = "*"
+botocore = "*"
+
+[package.extras]
+test = ["dnspython (>=2.6.1)", "pymongo", "pytest"]
 
 [[package]]
 name = "pymongoarrow"
@@ -4097,6 +4137,24 @@ fsspec = "==2024.6.0.*"
 [package.extras]
 awscli = ["aiobotocore[awscli] (>=2.5.4,<3.0.0)"]
 boto3 = ["aiobotocore[boto3] (>=2.5.4,<3.0.0)"]
+
+[[package]]
+name = "s3transfer"
+version = "0.15.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.15.0-py3-none-any.whl", hash = "sha256:6f8bf5caa31a0865c4081186689db1b2534cef721d104eb26101de4b9d6a5852"},
+    {file = "s3transfer-0.15.0.tar.gz", hash = "sha256:d36fac8d0e3603eff9b5bfa4282c7ce6feb0301a633566153cbd0b93d11d8379"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
 
 [[package]]
 name = "setuptools"

--- a/services/webhook/poetry.lock
+++ b/services/webhook/poetry.lock
@@ -328,6 +328,26 @@ linting = ["black", "isort", "pycodestyle"]
 testing = ["pytest (>=6,!=7.0.0)", "pytest-xdist (>=2)"]
 
 [[package]]
+name = "boto3"
+version = "1.41.5"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "boto3-1.41.5-py3-none-any.whl", hash = "sha256:bb278111bfb4c33dca8342bda49c9db7685e43debbfa00cc2a5eb854dd54b745"},
+    {file = "boto3-1.41.5.tar.gz", hash = "sha256:bc7806bee681dfdff2fe2b74967b107a56274f1e66ebe4d20dc8eee1ea408d17"},
+]
+
+[package.dependencies]
+botocore = ">=1.41.5,<1.42.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.15.0,<0.16.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
 name = "botocore"
 version = "1.41.5"
 description = "Low-level, data-driven core of boto 3."
@@ -1428,7 +1448,7 @@ psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.13.4"
 pylance = "^1.0.4"
-pymongo = {version = "^4.15.1", extras = ["srv"]}
+pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
 pytz = "^2020.1"
@@ -3458,6 +3478,7 @@ files = [
 
 [package.dependencies]
 dnspython = ">=2.6.1,<3.0.0"
+pymongo-auth-aws = {version = ">=1.1.0,<2.0.0", optional = true, markers = "extra == \"aws\""}
 
 [package.extras]
 aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
@@ -3468,6 +3489,25 @@ ocsp = ["certifi (>=2023.7.22) ; os_name == \"nt\" or sys_platform == \"darwin\"
 snappy = ["python-snappy (>=0.6.0)"]
 test = ["importlib-metadata (>=7.0) ; python_version < \"3.13\"", "pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "pymongo-auth-aws"
+version = "1.3.0"
+description = "MONGODB-AWS authentication support for PyMongo"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pymongo_auth_aws-1.3.0-py3-none-any.whl", hash = "sha256:367f6d853da428a02e9e450422756133715d40f8141f47ae5d98f139a88c0ce5"},
+    {file = "pymongo_auth_aws-1.3.0.tar.gz", hash = "sha256:d0fa893958dc525ca29f601c34f2ca73c860f66bc6511ec0a7da6eb7ea44e94f"},
+]
+
+[package.dependencies]
+boto3 = "*"
+botocore = "*"
+
+[package.extras]
+test = ["dnspython (>=2.6.1)", "pymongo", "pytest"]
 
 [[package]]
 name = "pymongoarrow"
@@ -3999,6 +4039,24 @@ fsspec = "==2024.6.0.*"
 [package.extras]
 awscli = ["aiobotocore[awscli] (>=2.5.4,<3.0.0)"]
 boto3 = ["aiobotocore[boto3] (>=2.5.4,<3.0.0)"]
+
+[[package]]
+name = "s3transfer"
+version = "0.15.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.15.0-py3-none-any.whl", hash = "sha256:6f8bf5caa31a0865c4081186689db1b2534cef721d104eb26101de4b9d6a5852"},
+    {file = "s3transfer-0.15.0.tar.gz", hash = "sha256:d36fac8d0e3603eff9b5bfa4282c7ce6feb0301a633566153cbd0b93d11d8379"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
 
 [[package]]
 name = "setuptools"

--- a/services/worker/poetry.lock
+++ b/services/worker/poetry.lock
@@ -394,7 +394,7 @@ version = "1.41.5"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "boto3-1.41.5-py3-none-any.whl", hash = "sha256:bb278111bfb4c33dca8342bda49c9db7685e43debbfa00cc2a5eb854dd54b745"},
     {file = "boto3-1.41.5.tar.gz", hash = "sha256:bc7806bee681dfdff2fe2b74967b107a56274f1e66ebe4d20dc8eee1ea408d17"},
@@ -1862,7 +1862,7 @@ psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.13.4"
 pylance = "^1.0.4"
-pymongo = {version = "^4.15.1", extras = ["srv"]}
+pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
 pytz = "^2020.1"
@@ -4307,6 +4307,7 @@ files = [
 
 [package.dependencies]
 dnspython = ">=2.6.1,<3.0.0"
+pymongo-auth-aws = {version = ">=1.1.0,<2.0.0", optional = true, markers = "extra == \"aws\""}
 
 [package.extras]
 aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
@@ -4317,6 +4318,25 @@ ocsp = ["certifi (>=2023.7.22) ; os_name == \"nt\" or sys_platform == \"darwin\"
 snappy = ["python-snappy (>=0.6.0)"]
 test = ["importlib-metadata (>=7.0) ; python_version < \"3.13\"", "pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "pymongo-auth-aws"
+version = "1.3.0"
+description = "MONGODB-AWS authentication support for PyMongo"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pymongo_auth_aws-1.3.0-py3-none-any.whl", hash = "sha256:367f6d853da428a02e9e450422756133715d40f8141f47ae5d98f139a88c0ce5"},
+    {file = "pymongo_auth_aws-1.3.0.tar.gz", hash = "sha256:d0fa893958dc525ca29f601c34f2ca73c860f66bc6511ec0a7da6eb7ea44e94f"},
+]
+
+[package.dependencies]
+boto3 = "*"
+botocore = "*"
+
+[package.extras]
+test = ["dnspython (>=2.6.1)", "pymongo", "pytest"]
 
 [[package]]
 name = "pymongoarrow"
@@ -4954,7 +4974,7 @@ version = "0.15.0"
 description = "An Amazon S3 Transfer Manager"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "s3transfer-0.15.0-py3-none-any.whl", hash = "sha256:6f8bf5caa31a0865c4081186689db1b2534cef721d104eb26101de4b9d6a5852"},
     {file = "s3transfer-0.15.0.tar.gz", hash = "sha256:d36fac8d0e3603eff9b5bfa4282c7ce6feb0301a633566153cbd0b93d11d8379"},


### PR DESCRIPTION
The rotated prod `MONGO_URL` now uses `authSource=$external&authMechanism=MONGODB-AWS` (IAM auth via IRSA instead of a static password). Every service currently crashes on startup with:

```
MONGODB-AWS authentication requires pymongo-auth-aws: install with: python -m pip install 'pymongo[aws]'
```

This adds the `aws` extra to pymongo in libcommon and relocks the 12 dependent projects (adds `pymongo-auth-aws`, plus `boto3`/`s3transfer` where not already present).
