### PR TITLE
fix: upgrade nginx to 1.27.0 to address CVE-2026-42533

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ x-service-env: &service-env
 
 services:
   reverse-proxy:
-    image: docker.io/nginx:1.25.3
+    image: docker.io/nginx:1.27.0
     volumes:
       - ./services/reverse-proxy/nginx-templates/:/etc/nginx/templates:ro
       - storage:${STORAGE_DIRECTORY}:ro


### PR DESCRIPTION
Bump nginx from 1.25.3 to 1.27.0 to mitigate CVE-2026-42533 heap buffer overflow vulnerability.