### PR TITLE
fix: temporarily disable raw Arrow datasets

### DIFF
--- a/libs/libcommon/src/libcommon/exceptions.py
+++ b/libs/libcommon/src/libcommon/exceptions.py
@@ -83,6 +83,7 @@ CacheableErrorCode = Literal[
     "DatasetGenerationCastError",
     "DatasetInBlockListError",
     "DatasetNotFoundError",
+    "DatasetWithArrowFilesNotSupportedError",
     "DatasetWithScriptNotSupportedError",
     "DatasetWithTooComplexDataFilesPatternsError",
     "DatasetWithTooManyConfigsError",
@@ -539,6 +540,14 @@ class DatasetWithScriptNotSupportedError(CacheableError):
 
 class NotSupportedError(CacheableError):
     pass
+
+
+class DatasetWithArrowFilesNotSupportedError(NotSupportedError):
+    """Datasets with Arrow IPC files are temporarily not supported."""
+
+    def __init__(self, message: str = "", cause: Optional[BaseException] = None):
+        message = message or "Datasets with Arrow IPC files are temporarily unavailable in the dataset viewer."
+        super().__init__(message, HTTPStatus.NOT_IMPLEMENTED, "DatasetWithArrowFilesNotSupportedError", cause, False)
 
 
 class NotSupportedDisabledRepositoryError(NotSupportedError):

--- a/services/worker/src/worker/job_runners/config/split_names.py
+++ b/services/worker/src/worker/job_runners/config/split_names.py
@@ -9,6 +9,7 @@ from datasets import get_dataset_split_names
 from datasets.data_files import EmptyDatasetError as _EmptyDatasetError
 from libcommon.dtos import FullSplitItem
 from libcommon.exceptions import (
+    DatasetWithArrowFilesNotSupportedError,
     DatasetWithScriptNotSupportedError,
     DatasetWithTooManySplitsError,
     EmptyDatasetError,
@@ -19,6 +20,7 @@ from libcommon.simple_cache import CachedArtifactError, CachedArtifactNotFoundEr
 
 from worker.dtos import CompleteJobResult, SplitsList
 from worker.job_runners.config.config_job_runner import ConfigJobRunnerWithDatasetsCache
+from worker.utils import safe_inspect
 
 
 def compute_split_names_from_streaming_response(
@@ -51,6 +53,8 @@ def compute_split_names_from_streaming_response(
           If the list of splits could not be obtained using the datasets library.
         [~`libcommon.exceptions.DatasetWithScriptNotSupportedError`]:
             If the dataset has a dataset script.
+        [~`libcommon.exceptions.DatasetWithArrowFilesNotSupportedError`]:
+            If the dataset has Arrow IPC files (temporarily not supported).
         [~`libcommon.exceptions.SplitNamesFromStreamingError`]:
             If the split names could not be obtained using the datasets library.
         [~`libcommon.exceptions.DatasetWithTooManySplitsError`]:
@@ -61,16 +65,19 @@ def compute_split_names_from_streaming_response(
     """
     logging.info(f"compute 'config-split-names' using streaming for {dataset=} {config=}")
     try:
-        split_name_items: list[FullSplitItem] = [
-            {"dataset": dataset, "config": config, "split": str(split)}
-            for split in get_dataset_split_names(
-                path=dataset,
-                config_name=config,
-                token=hf_token,
-            )
-        ]
+        with safe_inspect:
+            split_name_items: list[FullSplitItem] = [
+                {"dataset": dataset, "config": config, "split": str(split)}
+                for split in get_dataset_split_names(
+                    path=dataset,
+                    config_name=config,
+                    token=hf_token,
+                )
+            ]
     except _EmptyDatasetError as err:
         raise EmptyDatasetError("The dataset is empty.", cause=err) from err
+    except DatasetWithArrowFilesNotSupportedError:
+        raise
     except Exception as err:
         if isinstance(err, ValueError) and "trust_remote_code" in str(err):
             raise DatasetWithScriptNotSupportedError from err

--- a/services/worker/src/worker/job_runners/split/first_rows.py
+++ b/services/worker/src/worker/job_runners/split/first_rows.py
@@ -13,6 +13,7 @@ from datasets import IterableDataset, get_dataset_config_info
 from libcommon.constants import MAX_NUM_ROWS_PER_PAGE
 from libcommon.dtos import JobInfo, RowsContent, SplitFirstRowsResponse
 from libcommon.exceptions import (
+    DatasetWithArrowFilesNotSupportedError,
     DatasetWithScriptNotSupportedError,
     FeaturesError,
     InfoError,
@@ -29,7 +30,7 @@ from libcommon.viewer_utils.rows import create_first_rows_response
 from worker.config import AppConfig, FirstRowsConfig
 from worker.dtos import CompleteJobResult
 from worker.job_runners.split.split_job_runner import SplitJobRunnerWithDatasetsCache
-from worker.utils import get_rows_or_raise, raise_if_long_column_name, safe_load_dataset
+from worker.utils import get_rows_or_raise, raise_if_long_column_name, safe_inspect, safe_load_dataset
 
 
 def compute_first_rows_from_parquet_response(
@@ -211,6 +212,8 @@ def compute_first_rows_from_streaming_response(
           If the split rows could not be obtained using the datasets library in normal mode.
         [~`libcommon.exceptions.DatasetWithScriptNotSupportedError`]:
             If the dataset has a dataset script.
+        [~`libcommon.exceptions.DatasetWithArrowFilesNotSupportedError`]:
+            If the dataset has Arrow IPC files (temporarily not supported).
         [~`libcommon.exceptions.TooLongColumnNameError`]:
             If one of the columns' name is too long (> 500 characters)
 
@@ -220,7 +223,10 @@ def compute_first_rows_from_streaming_response(
     logging.info(f"compute 'split-first-rows' from streaming for {dataset=} {config=} {split=}")
     # get the features
     try:
-        info = get_dataset_config_info(path=dataset, config_name=config, token=hf_token)
+        with safe_inspect:
+            info = get_dataset_config_info(path=dataset, config_name=config, token=hf_token)
+    except DatasetWithArrowFilesNotSupportedError:
+        raise
     except Exception as err:
         if isinstance(err, ValueError) and "trust_remote_code" in str(err):
             raise DatasetWithScriptNotSupportedError from err
@@ -244,6 +250,8 @@ def compute_first_rows_from_streaming_response(
             if not isinstance(iterable_dataset, IterableDataset):
                 raise TypeError("load_dataset should return an IterableDataset.")
             features = iterable_dataset.features
+        except DatasetWithArrowFilesNotSupportedError:
+            raise
         except Exception as err:
             if isinstance(err, ValueError) and "trust_remote_code" in str(err):
                 raise DatasetWithScriptNotSupportedError from err

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -30,6 +30,7 @@ from datasets import (
     load_dataset,
 )
 from datasets.features.features import decode_nested_example
+from datasets.packaged_modules.arrow.arrow import Arrow
 from datasets.utils.file_utils import SINGLE_FILE_COMPRESSION_EXTENSION_TO_PROTOCOL, is_relative_path
 from huggingface_hub import HfFileSystem, HfFileSystemFile
 from huggingface_hub.errors import RepositoryNotFoundError
@@ -39,6 +40,7 @@ from libcommon.dtos import RowsContent
 from libcommon.exceptions import (
     ConfigNotFoundError,
     DatasetNotFoundError,
+    DatasetWithArrowFilesNotSupportedError,
     DatasetWithScriptNotSupportedError,
     PreviousStepFormatError,
     SplitNotFoundError,
@@ -400,6 +402,8 @@ def safe_load_dataset_builder(
     builder_cls = get_dataset_builder_class(dataset_module, dataset_name=dataset_name)
 
     # Safety checks
+    if issubclass(builder_cls, Arrow):
+        raise DatasetWithArrowFilesNotSupportedError()
     config_data_files = builder_cls.builder_configs[name].data_files
     if config_data_files is not None:
         for split in config_data_files:

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -154,6 +154,8 @@ def get_rows_or_raise(
             token=token,
             column_names=column_names,
         )
+    except DatasetWithArrowFilesNotSupportedError:
+        raise
     except Exception as err:
         if isinstance(err, ValueError) and "trust_remote_code" in str(err):
             raise DatasetWithScriptNotSupportedError from err
@@ -376,7 +378,7 @@ def safe_load_dataset_builder(
         raise ValueError(f"Invalid dataset: {path}")
     for key in kwargs:
         if key == "download_mode":
-            if kwargs[key] != DownloadMode.REUSE_DATASET_IF_EXISTS:
+            if kwargs[key] is not None and kwargs[key] != DownloadMode.REUSE_DATASET_IF_EXISTS:
                 raise ValueError(f"not supported in safe_load_dataset_builder: {key}")
         elif kwargs[key] is not None:
             raise ValueError(f"not supported in safe_load_dataset_builder: {key}")
@@ -427,6 +429,11 @@ def safe_load_dataset_builder(
     )
 
     return builder_instance
+
+
+# `datasets.inspect` binds `load_dataset_builder` at import time, so `datasets.load` is not the
+# right patch target for `get_dataset_config_info` and `get_dataset_split_names`
+safe_inspect = patch("datasets.inspect.load_dataset_builder", safe_load_dataset_builder)
 
 
 @overload

--- a/services/worker/tests/job_runners/config/test_split_names.py
+++ b/services/worker/tests/job_runners/config/test_split_names.py
@@ -5,10 +5,11 @@ from collections.abc import Callable
 from dataclasses import replace
 from http import HTTPStatus
 from typing import Any, Optional
+from unittest.mock import patch
 
 import pytest
 from libcommon.dtos import Priority
-from libcommon.exceptions import CustomError, PreviousStepFormatError
+from libcommon.exceptions import CustomError, DatasetWithArrowFilesNotSupportedError, PreviousStepFormatError
 from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.simple_cache import (
     CachedArtifactError,
@@ -20,6 +21,7 @@ from worker.config import AppConfig
 from worker.job_runners.config.split_names import (
     ConfigSplitNamesJobRunner,
     compute_split_names_from_info_response,
+    compute_split_names_from_streaming_response,
 )
 from worker.resources import LibrariesResource
 
@@ -239,3 +241,14 @@ def test_compute(app_config: AppConfig, get_job_runner: GetJobRunner, hub_public
     job_runner.post_compute()
     content = response.content
     assert len(content["splits"]) == 1
+
+
+def test_compute_split_names_from_streaming_response_preserves_arrow_files_error() -> None:
+    with (
+        patch(
+            "worker.job_runners.config.split_names.get_dataset_split_names",
+            side_effect=DatasetWithArrowFilesNotSupportedError(),
+        ),
+        pytest.raises(DatasetWithArrowFilesNotSupportedError),
+    ):
+        compute_split_names_from_streaming_response(dataset="namespace/dataset", config="default", max_number=10)

--- a/services/worker/tests/test_utils.py
+++ b/services/worker/tests/test_utils.py
@@ -6,11 +6,18 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from datasets import get_dataset_config_info, get_dataset_split_names
 from datasets.packaged_modules.arrow.arrow import Arrow
 from datasets.packaged_modules.csv.csv import Csv
 from libcommon.exceptions import DatasetWithArrowFilesNotSupportedError
 
-from worker.utils import FileExtension, get_file_extension, safe_load_dataset_builder
+from worker.utils import (
+    FileExtension,
+    get_file_extension,
+    get_rows_or_raise,
+    safe_inspect,
+    safe_load_dataset_builder,
+)
 
 
 @pytest.mark.parametrize(
@@ -85,6 +92,37 @@ def test_safe_load_dataset_builder_allows_non_arrow_builder() -> None:
         patch("datasets.load.dataset_module_factory", return_value=_get_dataset_module()),
         patch("datasets.load.get_dataset_builder_class", return_value=CsvBuilder),
     ):
-        builder = safe_load_dataset_builder(path="namespace/dataset", name="default")
+        # data_files=None and download_mode=None mirror what `datasets.inspect` passes
+        builder = safe_load_dataset_builder(
+            path="namespace/dataset", name="default", data_files=None, download_mode=None
+        )
 
     assert isinstance(builder, CsvBuilder)
+
+
+def test_safe_inspect_rejects_arrow_builder_in_get_dataset_config_info() -> None:
+    with (
+        patch("datasets.load.dataset_module_factory", return_value=_get_dataset_module()),
+        patch("datasets.load.get_dataset_builder_class", return_value=Arrow),
+        safe_inspect,
+        pytest.raises(DatasetWithArrowFilesNotSupportedError),
+    ):
+        get_dataset_config_info(path="namespace/dataset", config_name="default")
+
+
+def test_safe_inspect_rejects_arrow_builder_in_get_dataset_split_names() -> None:
+    with (
+        patch("datasets.load.dataset_module_factory", return_value=_get_dataset_module()),
+        patch("datasets.load.get_dataset_builder_class", return_value=Arrow),
+        safe_inspect,
+        pytest.raises(DatasetWithArrowFilesNotSupportedError),
+    ):
+        get_dataset_split_names(path="namespace/dataset", config_name="default")
+
+
+def test_get_rows_or_raise_preserves_arrow_files_error() -> None:
+    with (
+        patch("worker.utils.get_rows", side_effect=DatasetWithArrowFilesNotSupportedError()),
+        pytest.raises(DatasetWithArrowFilesNotSupportedError),
+    ):
+        get_rows_or_raise(dataset="namespace/dataset", config="default", split="train", rows_max_number=10, token=None)

--- a/services/worker/tests/test_utils.py
+++ b/services/worker/tests/test_utils.py
@@ -1,10 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2024 The HuggingFace Authors.
 
+from http import HTTPStatus
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
+from datasets.packaged_modules.arrow.arrow import Arrow
+from datasets.packaged_modules.csv.csv import Csv
+from libcommon.exceptions import DatasetWithArrowFilesNotSupportedError
 
-from worker.utils import FileExtension, get_file_extension
+from worker.utils import FileExtension, get_file_extension, safe_load_dataset_builder
 
 
 @pytest.mark.parametrize(
@@ -45,3 +51,40 @@ from worker.utils import FileExtension, get_file_extension
 def test_get_file_extension(filename: str, expected_extension: FileExtension) -> None:
     assert get_file_extension(filename).extension == expected_extension.extension
     assert get_file_extension(filename).uncompressed_extension == expected_extension.uncompressed_extension
+
+
+def _get_dataset_module() -> SimpleNamespace:
+    return SimpleNamespace(
+        builder_configs_parameters=SimpleNamespace(default_config_name="default"),
+        builder_kwargs={"base_path": "hf://datasets/namespace/dataset@revision"},
+        dataset_infos={},
+        hash="revision",
+    )
+
+
+def test_safe_load_dataset_builder_rejects_arrow_builder() -> None:
+    with (
+        patch("datasets.load.dataset_module_factory", return_value=_get_dataset_module()),
+        patch("datasets.load.get_dataset_builder_class", return_value=Arrow),
+        pytest.raises(DatasetWithArrowFilesNotSupportedError) as error_info,
+    ):
+        safe_load_dataset_builder(path="namespace/dataset", name="default")
+
+    assert error_info.value.code == "DatasetWithArrowFilesNotSupportedError"
+    assert error_info.value.status_code == HTTPStatus.NOT_IMPLEMENTED
+
+
+def test_safe_load_dataset_builder_allows_non_arrow_builder() -> None:
+    class CsvBuilder(Csv):  # type: ignore[misc]
+        builder_configs = {"default": SimpleNamespace(data_files=None)}
+
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+    with (
+        patch("datasets.load.dataset_module_factory", return_value=_get_dataset_module()),
+        patch("datasets.load.get_dataset_builder_class", return_value=CsvBuilder),
+    ):
+        builder = safe_load_dataset_builder(path="namespace/dataset", name="default")
+
+    assert isinstance(builder, CsvBuilder)


### PR DESCRIPTION
## Summary

- temporarily reject the packaged raw Arrow builder in `safe_load_dataset_builder`
- return a cacheable HTTP 501 response instead of reading Arrow IPC files
- cover both the blocked Arrow builder and an allowed non-Arrow builder with unit tests

## Context

This is an immediate containment measure while huggingface/datasets#8350 is reviewed and deployed. The guard is placed in the shared safe builder loader so it covers both streaming first rows and Parquet conversion workers. It can be removed after the validated datasets dependency and the hardened PyArrow runtime are deployed.

## Validation

- `poetry run python -m pytest tests/test_utils.py -q`, 25 passed
- `poetry run ruff check` and `poetry run ruff format --check` on the changed files
- mypy and Bandit on the changed files
- `git diff --check`