### PR TITLE
feat(chart): prod-v2 override for the dedicated datasets cluster

### DIFF
--- a/chart/env/prod-v2.yaml
+++ b/chart/env/prod-v2.yaml
@@ -3,14 +3,22 @@
 # (ArgoCD app "datasets-server-prod-v2"), while production traffic still hits hub-prod.
 # Removed at the network cutover.
 #
-# Only two kinds of change here — everything else is inherited from prod.yaml:
+# Changes here — everything else is inherited from prod.yaml:
 #   1. Rename the ALBs so they don't collide with hub-prod's (ALB names are unique per region).
 #   2. Disable the singleton cron jobs so they don't double-run against the SHARED prod mongo.
+#   3. Hold ALL workers back (workers: []).
+#   4. Disable the mongodbMigration pre-upgrade hook (mongodbMigration.enabled: false).
 #
-# NOT changed on purpose:
-#   - Workers: they pull from the same atomic mongo queue as hub-prod, so a job is processed
-#     exactly once regardless of which cluster's worker grabs it (extra capacity, not double work).
-#   - mongodbMigration: same image tag as prod => migrations already applied => re-run is a no-op.
+# Why workers/migration are held back (differs from the original "shared atomic queue" plan): the
+# parquet-metadata EFS on this cluster is a READ-ONLY EFS-replication destination until the
+# cutover, so a worker here cannot write cache artifacts — it would only error real jobs in the
+# shared prod mongo queue; and the migration hook would run against the shared prod mongo. Both
+# restored at cutover.
+#
+# NOT set here (kept out of this open-source repo): the ServiceAccount's
+# eks.amazonaws.com/role-arn (mongo IRSA) is injected in the private ArgoCD Application in
+# infra-deployments, so the AWS account id is not stored in this repo.
+#
 #   - external-dns hostname annotations are left in place but inert (external-dns is disabled on
 #     this cluster until the cutover).
 
@@ -58,4 +66,16 @@ postMessages:
 queueMetricsCollector:
   enabled: false
 cacheMetricsCollector:
+  enabled: false
+
+# --- 3. Hold ALL workers back (read-only replica EFS + shared prod queue) ---
+# Empty list => the worker deployment/hpa/podmonitor templates (which `range .Values.workers`)
+# render nothing. TODO(cutover): remove this override to restore workers once the EFS is writable.
+# (The SA's mongo IRSA role-arn annotation is injected in the private infra-deployments app.)
+workers: []
+
+# --- 4. Disable the mongodbMigration pre-upgrade hook ---
+# It would otherwise run migrations against the SHARED prod mongo on every sync.
+# TODO(cutover): re-enable (remove this) when this cluster takes over.
+mongodbMigration:
   enabled: false

--- a/chart/env/prod-v2.yaml
+++ b/chart/env/prod-v2.yaml
@@ -1,0 +1,61 @@
+# Temporary override layered OVER env/prod.yaml (valueFiles: [env/prod.yaml, env/prod-v2.yaml])
+# for the parallel deploy of datasets-server on the dedicated datasets-prod-us-east-1 cluster
+# (ArgoCD app "datasets-server-prod-v2"), while production traffic still hits hub-prod.
+# Removed at the network cutover.
+#
+# Only two kinds of change here — everything else is inherited from prod.yaml:
+#   1. Rename the ALBs so they don't collide with hub-prod's (ALB names are unique per region).
+#   2. Disable the singleton cron jobs so they don't double-run against the SHARED prod mongo.
+#
+# NOT changed on purpose:
+#   - Workers: they pull from the same atomic mongo queue as hub-prod, so a job is processed
+#     exactly once regardless of which cluster's worker grabs it (extra capacity, not double work).
+#   - mongodbMigration: same image tag as prod => migrations already applied => re-run is a no-op.
+#   - external-dns hostname annotations are left in place but inert (external-dns is disabled on
+#     this cluster until the cutover).
+
+# --- 1. ALB renames (avoid name collision with hub-datasets-server-prod / -int) ---
+# Public ALB (CloudFront origin at cutover):
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/load-balancer-name: "datasets-server-prod"
+
+# Internal ALB (/api/private, control-plane) — shared across services via the ingress group,
+# so the name must be overridden on every service that defines ingressInternal.
+admin:
+  ingressInternal:
+    annotations:
+      alb.ingress.kubernetes.io/load-balancer-name: "datasets-server-prod-int"
+api:
+  ingressInternal:
+    annotations:
+      alb.ingress.kubernetes.io/load-balancer-name: "datasets-server-prod-int"
+rows:
+  ingressInternal:
+    annotations:
+      alb.ingress.kubernetes.io/load-balancer-name: "datasets-server-prod-int"
+search:
+  ingressInternal:
+    annotations:
+      alb.ingress.kubernetes.io/load-balancer-name: "datasets-server-prod-int"
+sseApi:
+  ingressInternal:
+    annotations:
+      alb.ingress.kubernetes.io/load-balancer-name: "datasets-server-prod-int"
+webhook:
+  ingressInternal:
+    annotations:
+      alb.ingress.kubernetes.io/load-balancer-name: "datasets-server-prod-int"
+
+# --- 2. Disable singleton cron jobs (hub-prod owns these; avoid double enqueue / post /
+#        duplicate metric series against the shared prod mongo) ---
+backfill:
+  enabled: false
+backfillRetryableErrors:
+  enabled: false
+postMessages:
+  enabled: false
+queueMetricsCollector:
+  enabled: false
+cacheMetricsCollector:
+  enabled: false

--- a/chart/templates/jobs/mongodb-migration/job.yaml
+++ b/chart/templates/jobs/mongodb-migration/job.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 The HuggingFace Authors.
 
-{{- if .Values.images.jobs.mongodbMigration }}
+{{- if and .Values.images.jobs.mongodbMigration .Values.mongodbMigration.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -308,6 +308,9 @@ discussions:
 # --- jobs (pre-install/upgrade hooks) ---
 
 mongodbMigration:
+  # Whether to run the mongo migration pre-upgrade hook. Disable e.g. for a parallel deploy that
+  # shares an already-migrated prod mongo.
+  enabled: true
   # Name of the mongo db database used for storing the migrations history
   mongoDatabase: "datasets_server_maintenance"
 


### PR DESCRIPTION
## Context

Companion to the `infra-deployments` PR that adds the `datasets-server-prod-v2` ArgoCD Application (parallel deploy of datasets-server on the dedicated `datasets-prod-us-east-1` cluster, while production traffic still hits hub-prod). That Application uses `valueFiles: [env/prod.yaml, env/prod-v2.yaml]`, so this file is a thin override on top of prod.

## Changes (`chart/env/prod-v2.yaml`)

**1. ALB renames** — the datasets cluster creates its own ALBs; the names must differ from hub-prod's (ALB names are unique per region):
- public: `hub-datasets-server-prod` → `datasets-server-prod`
- internal: `hub-datasets-server-prod-int` → `datasets-server-prod-int` (overridden on every service that defines `ingressInternal`: admin, api, rows, search, sseApi, webhook)

**2. Disable singleton cron jobs** so they don't double-run against the shared prod mongo: `backfill`, `backfillRetryableErrors`, `postMessages`, `queueMetricsCollector`, `cacheMetricsCollector`.

## Left unchanged on purpose
- **Workers**: they pull from the same atomic mongo queue as hub-prod → each job is processed exactly once whichever cluster grabs it (extra capacity, not double work). Scaling them to 0 for a pure standby would require redefining the whole `workers` list (Helm replaces lists) — happy to do that instead if preferred.
- **mongodbMigration**: same image tag as prod → migrations already applied → re-run is a no-op.
- **external-dns** hostname annotations: left in place but inert (external-dns is disabled on this cluster until cutover).

## Prerequisite
Terraform `projects/datasets/20-*` (EFS PVCs, IRSA S3 role, mongo VPCE, namespace) must be applied first, or the pods won't start.

Removed at the network cutover.