### PR TITLE
fix(chart): raise rows memory limit to 8192Mi in prod

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -392,10 +392,10 @@ rows:
   resources:
     requests:
       cpu: 1
-      memory: "6500Mi"
+      memory: "8192Mi"
     limits:
       cpu: 4
-      memory: "6500Mi"
+      memory: "8192Mi"
 
 search:
   # Number of uvicorn workers for running the application


### PR DESCRIPTION
## Context

On 2026-07-24 (~17:50-18:40 UTC), all 12 replicas of `prod-datasets-server-rows` were repeatedly OOMKilled (exit 137) against the 6500Mi limit, with 10-18 restarts each over ~48 minutes, leaving the deployment degraded at 9/12 ready. Previous-container logs showed only normal `/rows` and `/healthcheck` 200 OK responses up to termination: memory pressure from heavy dataset transforms, not a crash bug.

## Change

Raise the `rows` memory request/limit from 6500Mi to 8192Mi (+26%) in prod, keeping requests == limits for guaranteed QoS.

## Capacity notes

Current rows nodes are Cast.ai-provisioned m7a.xlarge (~14.3Gi allocatable) packing 2 pods each; 2x8192Mi no longer fits there, so the autoscaler will reprovision (e.g. 3 pods per m7a.2xlarge, which packs cleanly).