### PR TITLE
feat(chart): re-enable datasets-server workers/cron/migration at cutover

### DIFF
--- a/chart/env/prod-v2.yaml
+++ b/chart/env/prod-v2.yaml
@@ -1,29 +1,21 @@
-# Temporary override layered OVER env/prod.yaml (valueFiles: [env/prod.yaml, env/prod-v2.yaml])
-# for the parallel deploy of datasets-server on the dedicated datasets-prod-us-east-1 cluster
-# (ArgoCD app "datasets-server-prod-v2"), while production traffic still hits hub-prod.
-# Removed at the network cutover.
+# Override layered OVER env/prod.yaml (valueFiles: [env/prod.yaml, env/prod-v2.yaml]) for the
+# datasets-server deployment on the dedicated datasets-prod-us-east-1 cluster (ArgoCD app
+# "datasets-server-prod-v2").
 #
-# Changes here — everything else is inherited from prod.yaml:
-#   1. Rename the ALBs so they don't collide with hub-prod's (ALB names are unique per region).
-#   2. Disable the singleton cron jobs so they don't double-run against the SHARED prod mongo.
-#   3. Hold ALL workers back (workers: []).
-#   4. Disable the mongodbMigration pre-upgrade hook (mongodbMigration.enabled: false).
+# Only change vs prod.yaml: rename the ALBs so they don't collide with the hub's (ALB names are
+# unique per region). These are the permanent ALB names for this cluster.
 #
-# Why workers/migration are held back (differs from the original "shared atomic queue" plan): the
-# parquet-metadata EFS on this cluster is a READ-ONLY EFS-replication destination until the
-# cutover, so a worker here cannot write cache artifacts — it would only error real jobs in the
-# shared prod mongo queue; and the migration hook would run against the shared prod mongo. Both
-# restored at cutover.
+# The parallel-phase hold-backs have been REMOVED now that this cluster takes over the workload:
+# workers, the singleton cron jobs, and the mongodbMigration hook all inherit from prod.yaml again.
+# (They were temporary because the parquet-metadata EFS was a read-only replication destination and
+# the hub still owned the shared mongo queue — MERGE THIS ONLY AFTER the hub side is shut down.)
 #
 # NOT set here (kept out of this open-source repo): the ServiceAccount's
 # eks.amazonaws.com/role-arn (mongo IRSA) is injected in the private ArgoCD Application in
 # infra-deployments, so the AWS account id is not stored in this repo.
-#
-#   - external-dns hostname annotations are left in place but inert (external-dns is disabled on
-#     this cluster until the cutover).
 
-# --- 1. ALB renames (avoid name collision with hub-datasets-server-prod / -int) ---
-# Public ALB (CloudFront origin at cutover):
+# --- ALB renames (avoid name collision with hub-datasets-server-prod / -int) ---
+# Public ALB (CloudFront origin):
 ingress:
   annotations:
     alb.ingress.kubernetes.io/load-balancer-name: "datasets-server-prod"
@@ -54,28 +46,3 @@ webhook:
   ingressInternal:
     annotations:
       alb.ingress.kubernetes.io/load-balancer-name: "datasets-server-prod-int"
-
-# --- 2. Disable singleton cron jobs (hub-prod owns these; avoid double enqueue / post /
-#        duplicate metric series against the shared prod mongo) ---
-backfill:
-  enabled: false
-backfillRetryableErrors:
-  enabled: false
-postMessages:
-  enabled: false
-queueMetricsCollector:
-  enabled: false
-cacheMetricsCollector:
-  enabled: false
-
-# --- 3. Hold ALL workers back (read-only replica EFS + shared prod queue) ---
-# Empty list => the worker deployment/hpa/podmonitor templates (which `range .Values.workers`)
-# render nothing. TODO(cutover): remove this override to restore workers once the EFS is writable.
-# (The SA's mongo IRSA role-arn annotation is injected in the private infra-deployments app.)
-workers: []
-
-# --- 4. Disable the mongodbMigration pre-upgrade hook ---
-# It would otherwise run migrations against the SHARED prod mongo on every sync.
-# TODO(cutover): re-enable (remove this) when this cluster takes over.
-mongodbMigration:
-  enabled: false


### PR DESCRIPTION
## Context

The dedicated `datasets-prod-us-east-1` cluster runs datasets-server in parallel (ArgoCD app `datasets-server-prod-v2`) with the workload held back during the migration:
- workers held back (`workers: []`)
- singleton cron jobs disabled (backfill, backfillRetryableErrors, postMessages, queue/cacheMetricsCollector)
- `mongodbMigration` pre-upgrade hook disabled

These were temporary because the parquet-metadata EFS was a **read-only** replication destination and the hub still owned the shared mongo queue.

## Change

Strip those hold-backs from `chart/env/prod-v2.yaml` so workers, cron jobs and the migration hook **inherit from `prod.yaml`** again. Only the ALB renames (`datasets-server-prod` / `-int`) remain.

## ⚠️ Merge timing

**Merge this ONLY AFTER the hub side is shut down** (workers scaled to 0 + EFS replication cut → the datasets EFS is writable). Otherwise both clusters process the shared mongo queue and write cache artifacts to two different EFS filesystems.

This is the cutover "activation" step for the dedicated cluster.