### PR TITLE
chore(chart): make datasets-server serving ALB internal

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -275,7 +275,7 @@ ingress:
     alb.ingress.kubernetes.io/target-node-labels: role-datasets-server=true
     alb.ingress.kubernetes.io/healthcheck-path: "/healthcheck"
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80, "HTTPS": 443}]'
-    alb.ingress.kubernetes.io/scheme: "internet-facing"
+    alb.ingress.kubernetes.io/scheme: "internal"
     alb.ingress.kubernetes.io/group.name: "datasets-server"
     kubernetes.io/ingress.class: "alb"
     alb.ingress.kubernetes.io/group.order: "100"


### PR DESCRIPTION
Switch the datasets-server serving ALB (`datasets-server-prod`, public group `datasets-server`) from `internet-facing` to `internal`.

It is now reached **only** through the CloudFront VPC origin — the public custom origin was already dropped. Keeping the ALB internet-facing left public listeners reachable directly, which **bypasses CloudFront and its WAF** (the WAF is `CLOUDFRONT`-scoped, attached to the distribution, not the ALB). Making the ALB internal removes that public bypass; CloudFront keeps reaching it via the VPC origin (the intended use case for VPC origins).

Changing `scheme` recreates the ALB (scheme is immutable), so this must be merged as part of a coordinated, zero-downtime swap:

1. a temporary public ALB (`datasets-server-tmp`) carries the CloudFront traffic (temp custom origin, already in place);
2. merge this PR → ArgoCD recreates `datasets-server-prod` as internal;
3. the CloudFront VPC origin is repointed at the new internal ALB and traffic flipped back;
4. the temporary ALB + temp origin are removed.

⚠️ Do NOT merge standalone: merging without the temp origin carrying traffic would break the CloudFront origin during the ALB recreation.
