### PR TITLE
fix(chart): give rows its secrets volume back

### DIFF
--- a/chart/templates/services/rows/deployment.yaml
+++ b/chart/templates/services/rows/deployment.yaml
@@ -31,10 +31,10 @@ spec:
       {{- include "image.imagePullSecrets" . | nindent 6 }}
       initContainers:
         {{ include "initContainerParquetMetadata" . | nindent 8 }}
-      {{- include "datasetsServer.csi.volumeBlock" (dict "context" $ "workload" "rows") | nindent 6 }}
       containers: {{ include "containerRows" . | nindent 8 }}
       nodeSelector: {{ toYaml .Values.rows.nodeSelector | nindent 8 }}
       tolerations: {{ toYaml .Values.rows.tolerations | nindent 8 }}
       volumes: 
         {{ include "volumeParquetMetadata" . | nindent 8 }}
+        {{- include "datasetsServer.csi.volume" (dict "context" $ "workload" "rows") | nindent 8 }}
       securityContext: {{ include "securityContext" . | nindent 8 }}


### PR DESCRIPTION
The ArgoCD sync of `datasets-server-prod` failed halfway through on:

```
Deployment.apps "prod-datasets-server-rows" is invalid:
  spec.template.spec.containers[0].volumeMounts[0].name: Not found: "secrets"
```

`rows` is the one workload that already declares its own `volumes:` key, for parquet-metadata, and it was using the helper that emits a whole `volumes:` block. Two identical keys in the same YAML mapping means the last one wins, so the CSI volume was silently dropped while the mount referring to it stayed.

It now uses the item-only helper under the existing key, like the other workloads that own a `volumes:` key.

## The check that would have caught it

`helm lint` passes either way, and so does a template render, because the YAML is valid. What catches it is comparing each container's mounts against the volumes declared in its own pod spec:

```
render every Deployment/Job/CronJob
  for each container: mounts - volumes  ->  must be empty
```

Before: `prod-datasets-server-rows mounts {'secrets'} with no volume`. After: no orphan anywhere.

## State of prod

The sync applied part of the change before failing, so `datasets-server-prod` is currently OutOfSync with some workloads on the new spec and some not. Re-syncing after this merges completes it.

Two other things came out of the same sync and are not fixed here:

- The `SecretProviderClasses` are ordinary resources, but the mongodb-migration Job is a PreSync hook, so ArgoCD ran the Job before creating the classes it mounts, and the Job sat in `ContainerCreating` on `SecretProviderClass ... not found`. I unblocked it by creating the 13 classes by hand. They need a hook or sync-wave annotation so they always land first.
- Once mounted, the migration Job read its secrets from files and completed normally, which is the first real workload to prove the mechanism end to end.