### PR TITLE
fix(chart): create the SecretProviderClasses before the migration hook

### DIFF
--- a/chart/templates/secretproviderclasses.yaml
+++ b/chart/templates/secretproviderclasses.yaml
@@ -8,6 +8,15 @@ metadata:
   name: {{ include "name" $ }}-{{ $workload }}-secrets
   namespace: {{ $.Release.Namespace }}
   labels: {{ include "hf.labels.commons" $ | nindent 4 }}
+  annotations:
+    # A hook, and at a lighter weight than the mongodb-migration job, because that job is a pre-upgrade
+    # hook that mounts one of these. Ordinary resources are applied after every pre-upgrade hook has
+    # finished, so the job would wait forever on a class that cannot exist yet, which is exactly what it
+    # did on the first two attempts. Deleted only just before the next hook run, so it stays in place for
+    # the pods that mount it in between.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   provider: {{ $csi.provider | quote }}
   parameters:


### PR DESCRIPTION
The `datasets-server-prod` sync hung twice on the same thing, and both times I unblocked it by creating the 13 classes with `kubectl` by hand.

```
MountVolume.SetUp failed for volume "secrets": failed to get secretproviderclass
  datasets-server/prod-datasets-server-mongodb-migration-secrets, not found
```

The mongodb-migration job is a `pre-upgrade` hook at weight `-1` and mounts one of these classes. The classes were ordinary resources, and ordinary resources are applied only once every pre-upgrade hook has finished. So the job waits on a class that cannot exist yet, and the sync waits on the job.

## Fix

The classes become hooks too, at weight `-2` so they land before the job:

```yaml
"helm.sh/hook": pre-install,pre-upgrade
"helm.sh/hook-weight": "-2"
"helm.sh/hook-delete-policy": before-hook-creation
```

The delete policy matters. A post-hook policy would remove each class as soon as the hook phase ended, leaving the running pods mounting something that no longer exists. `before-hook-creation` keeps it in place between syncs and only replaces it just before the next hook run.

## Why it was not caught

Nothing in a `helm template` or a `helm lint` shows it: the manifests are all correct, it is purely the order ArgoCD applies them in. It only appears against a chart that has a pre-upgrade hook needing one of them, which is this chart and this job.