### PR TITLE
Revert "fix(chart): create the SecretProviderClasses before the migration hook"

### DIFF
--- a/chart/templates/secretproviderclasses.yaml
+++ b/chart/templates/secretproviderclasses.yaml
@@ -8,15 +8,6 @@ metadata:
   name: {{ include "name" $ }}-{{ $workload }}-secrets
   namespace: {{ $.Release.Namespace }}
   labels: {{ include "hf.labels.commons" $ | nindent 4 }}
-  annotations:
-    # A hook, and at a lighter weight than the mongodb-migration job, because that job is a pre-upgrade
-    # hook that mounts one of these. Ordinary resources are applied after every pre-upgrade hook has
-    # finished, so the job would wait forever on a class that cannot exist yet, which is exactly what it
-    # did on the first two attempts. Deleted only just before the next hook run, so it stays in place for
-    # the pods that mount it in between.
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   provider: {{ $csi.provider | quote }}
   parameters:


### PR DESCRIPTION
Reverts #3391. **Merge before the next sync of `datasets-server-prod`.**

Making the classes Helm hooks was wrong. ArgoCD keeps hook resources out of the regular desired state, so the 13 live classes immediately showed as prunable:

```
===== SecretProviderClass datasets-server/prod-datasets-server-admin-secrets =====
1,76d0
< apiVersion: secrets-store.csi.x-k8s.io/v1
...
```

Every line removed, nothing in their place. The next sync would have deleted all 13 and taken the mounts of every running pod with them.

## What the original was fixing, and why it does not need this

The mongodb-migration job is a `pre-upgrade` hook that mounts one of these classes, and ordinary resources are applied only after the hook phase. So the job waits on a class that cannot exist yet.

That is a **bootstrap** problem, not a recurring one. It only bites when the classes do not exist at all, which is true exactly once: the first time CSI mode is turned on for a cluster. As ordinary resources they persist between syncs, so every later sync finds them already there and the hook mounts fine.

I hit it twice today only because the settings were reverted in between and the classes were pruned along the way.

## Enabling this on another cluster

Apply the classes once by hand before the first sync, or expect to unblock the first sync:

```bash
helm template <release> chart -f chart/env/<env>.yaml --namespace <ns> \
  --set secrets.infisical.csi.enabled=true ... \
  | yq 'select(.kind == "SecretProviderClass")' | kubectl apply -f -
```

Solving it properly means making the migration job an ordinary resource with a sync wave instead of a pre-upgrade hook, which is a larger change than this rollout should carry.