### PR TITLE
fix(libcommon): prevent cross-dataset video asset signing

### DIFF
--- a/libs/libcommon/src/libcommon/viewer_utils/asset.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/asset.py
@@ -245,12 +245,8 @@ def create_video_file(
     # dataset_git_revision of cache responses when the data will be accessed.
     # This is useful to allow moving files to a newer revision without having
     # to modify the cached rows content.
-    if "path" in encoded_video and isinstance(encoded_video["path"], str) and "://" in encoded_video["path"]:
-        # in general video files are stored in the dataset repository, we can just get the URL
-        # (`datasets` doesn't embed the video bytes in Parquet when the file is already on HF)
-        object_path = encoded_video["path"].replace(revision, DATASET_GIT_REVISION_PLACEHOLDER)
-    elif "bytes" in encoded_video and isinstance(encoded_video["bytes"], bytes):
-        # (rare and not very important) otherwise we attempt to upload video data from webdataset/parquet files but don't process them
+    if "bytes" in encoded_video and isinstance(encoded_video["bytes"], bytes):
+        # (rare and not very important) we attempt to upload video data from webdataset/parquet files but don't process them
         object_path = storage_client.generate_object_path(
             dataset=dataset,
             revision=DATASET_GIT_REVISION_PLACEHOLDER,
@@ -264,6 +260,15 @@ def create_video_file(
         if storage_client.overwrite or not storage_client.exists(path):
             with storage_client._fs.open(storage_client.get_full_path(path), "wb") as f:
                 f.write(encoded_video["bytes"])
+    elif (
+        encoded_video.get("bytes") is None
+        and "path" in encoded_video
+        and isinstance(encoded_video["path"], str)
+        and encoded_video["path"].startswith(f"hf://datasets/{dataset}@")
+    ):
+        # in general video files are stored in the dataset repository, we can just get the URL
+        # (`datasets` doesn't embed the video bytes in Parquet when the file is already on HF)
+        object_path = encoded_video["path"].replace(revision, DATASET_GIT_REVISION_PLACEHOLDER)
     else:
         raise ValueError("The video cell doesn't contain a valid path or bytes")
     src = storage_client.get_url(object_path, revision=revision)

--- a/libs/libcommon/tests/viewer_utils/test_assets.py
+++ b/libs/libcommon/tests/viewer_utils/test_assets.py
@@ -14,10 +14,12 @@ from libcommon.viewer_utils.asset import (
     create_audio_file,
     create_image_file,
     create_pdf_file,
+    create_video_file,
 )
 
 from ..constants import (
     ASSETS_BASE_URL,
+    CI_HUB_ENDPOINT,
     DEFAULT_COLUMN_NAME,
     DEFAULT_CONFIG,
     DEFAULT_REVISION,
@@ -124,6 +126,74 @@ def test_create_pdf_file(
     assert image is not None
     assert image.size == (value["thumbnail"]["width"], value["thumbnail"]["height"])
     assert value["size_bytes"] == expected_size
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        None,
+        "https://datasets-server.huggingface.co/assets/victim/private/--/revision/--/default/train/0/video.mp4",
+        "https://datasets-server.huggingface.co/cached-assets/victim/private/--/revision/--/default/train/0/video.mp4",
+    ],
+)
+def test_create_video_file_stores_embedded_bytes(
+    path: str | None, storage_client_with_url_preparator: StorageClient
+) -> None:
+    video_bytes = b"embedded video bytes"
+    value = create_video_file(
+        dataset="attacker/dataset",
+        revision="revision",
+        config="config",
+        split="split",
+        row_idx=7,
+        column="col",
+        filename="video.mp4",
+        encoded_video={"path": path, "bytes": video_bytes},
+        storage_client=storage_client_with_url_preparator,
+    )
+    video_key = "attacker/dataset/--/revision/--/config/split/7/col/video.mp4"
+
+    assert value == {"src": f"{ASSETS_BASE_URL}/{video_key}"}
+    assert storage_client_with_url_preparator.exists(video_key)
+    with storage_client_with_url_preparator._fs.open(
+        storage_client_with_url_preparator.get_full_path(video_key), "rb"
+    ) as video_file:
+        assert video_file.read() == video_bytes
+
+
+def test_create_video_file_reuses_same_dataset_hf_path(
+    storage_client_with_url_preparator: StorageClient,
+) -> None:
+    value = create_video_file(
+        dataset="owner/dataset",
+        revision="revision",
+        config="config",
+        split="split",
+        row_idx=7,
+        column="col",
+        filename="video.mp4",
+        encoded_video={"path": "hf://datasets/owner/dataset@revision/video.mp4", "bytes": None},
+        storage_client=storage_client_with_url_preparator,
+    )
+
+    assert value == {"src": f"{CI_HUB_ENDPOINT}/datasets/owner/dataset/resolve/revision/video.mp4"}
+
+
+def test_create_video_file_rejects_cross_dataset_hf_path(
+    storage_client_with_url_preparator: StorageClient,
+) -> None:
+    with pytest.raises(ValueError, match="The video cell doesn't contain a valid path or bytes"):
+        create_video_file(
+            dataset="owner/dataset",
+            revision="revision",
+            config="config",
+            split="split",
+            row_idx=7,
+            column="col",
+            filename="video.mp4",
+            encoded_video={"path": "hf://datasets/victim/private@revision/video.mp4", "bytes": None},
+            storage_client=storage_client_with_url_preparator,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- prioritize embedded video bytes over untrusted cell paths
- only reuse path-only video URLs when they belong to the current dataset's `hf://` namespace
- add regression coverage for cross-dataset `/assets` and `/cached-assets` URLs

## Security impact

This prevents a public dataset from using a `Video` cell as a signing oracle for assets belonging to another dataset, including private cached assets.