### PR TITLE
fix(libcommon): disable the Lance format

### DIFF
--- a/libs/libcommon/pyproject.toml
+++ b/libs/libcommon/pyproject.toml
@@ -96,6 +96,7 @@ untyped_calls_exclude = "huggingface_hub"
 module = [
     "datasets.*",
     "fitz.*",
+    "lance.*",
     "networkx.*",
     "prometheus_client.*",
     "pyarrow.*",

--- a/libs/libcommon/src/libcommon/__init__.py
+++ b/libs/libcommon/src/libcommon/__init__.py
@@ -4,6 +4,7 @@
 from datasets import config as _datasets_config
 
 from libcommon import fsspec  # noqa: F401 (always configure fsspec)
+from libcommon import packaged_modules  # noqa: F401 (always disable unsafe dataset formats)
 
 # This is just to make `datasets` faster:
 # no need to check for a Parquet export since we will build it

--- a/libs/libcommon/src/libcommon/__init__.py
+++ b/libs/libcommon/src/libcommon/__init__.py
@@ -3,8 +3,7 @@
 
 from datasets import config as _datasets_config
 
-from libcommon import fsspec  # noqa: F401 (always configure fsspec)
-from libcommon import packaged_modules  # noqa: F401 (always disable unsafe dataset formats)
+from libcommon import fsspec, packaged_modules  # noqa: F401 (configure fsspec, disable unsafe formats)
 
 # This is just to make `datasets` faster:
 # no need to check for a Parquet export since we will build it

--- a/libs/libcommon/src/libcommon/packaged_modules.py
+++ b/libs/libcommon/src/libcommon/packaged_modules.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 The HuggingFace Authors.
+
+import importlib
+from typing import Any, NoReturn
+
+# The Lance decoder reads variable-width values without validating the offsets stored in the file,
+# so a crafted .lance file makes the worker return adjacent heap memory or segfault. The dataset
+# entry point can be hardened with read_params={"validate_on_decode": True}, but LanceFileReader,
+# which datasets uses for standalone .lance files, exposes no such option. Refuse the format until
+# the offsets are validated upstream.
+LANCE_DISABLED_MESSAGE = "The Lance format is not supported."
+
+lance_module = importlib.import_module("datasets.packaged_modules.lance.lance")
+
+
+def _refuse_lance(*args: Any, **kwargs: Any) -> NoReturn:
+    raise NotImplementedError(LANCE_DISABLED_MESSAGE)
+
+
+# Refuse in the builder rather than unregistering the format: .lance files keep resolving to this
+# module, so they fail explicitly instead of falling back to whichever module matches the Lance
+# metadata files.
+setattr(lance_module.Lance, "_split_generators", _refuse_lance)

--- a/libs/libcommon/tests/test_packaged_modules.py
+++ b/libs/libcommon/tests/test_packaged_modules.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 The HuggingFace Authors.
+
+from pathlib import Path
+
+import datasets
+import lance
+import lance.file
+import pyarrow as pa
+import pytest
+
+
+@pytest.mark.parametrize("as_dataset_dir", [True, False])
+def test_lance_data_is_refused(tmp_path: Path, as_dataset_dir: bool) -> None:
+    table = pa.table({"category": pa.array([b"alpha", b"beta", b"gamma"], type=pa.binary())})
+    if as_dataset_dir:
+        lance.write_dataset(table, str(tmp_path / "data.lance"))
+    else:
+        with lance.file.LanceFileWriter(str(tmp_path / "data.lance")) as writer:
+            writer.write_batch(table)
+
+    with pytest.raises(NotImplementedError, match="Lance format is not supported"):
+        datasets.load_dataset(str(tmp_path), split="train")


### PR DESCRIPTION
## Context

The Lance decoder reads variable-width values without validating the offsets stored in the file (`VariableWidthBlock::into_arrow()` calls `build_unchecked()`, since `validate_on_decode` defaults to false). A crafted `.lance` file therefore makes the worker return memory adjacent to the file buffer.

Measured locally with our pinned `pylance` 1.0.4, patching a single 4-byte dictionary offset in a 706-byte file:

| patched offset | bytes returned |
| --- | --- |
| 500 | 491 |
| 5 000 | 4 991 |
| 100 000 | 99 991 |
| 2 000 000 | 1 999 991 |

A different offset value (`total + 1`) segfaults the worker instead, which surfaces as `Job manager crashed while running this job (missing heartbeats)`.

Both behaviours were confirmed on production with temporary public datasets, now deleted. 33 of 100 returned rows carried 100 bytes of out-of-bounds data each, including a recognisable `0x00007ff9a8000090` mmap pointer. The leaked bytes are baked into the parquet conversion and then served persistently by `/rows`.

## Why disable rather than harden

`lance.dataset()` accepts `read_params={"validate_on_decode": True}`, and that does turn the leak into a clean error. But `datasets` also uses `lance.file.LanceFileReader` for standalone `.lance` files, and that reader exposes no equivalent option in 1.0.4, so the second path stays exploitable. Refusing the format is the only complete mitigation available from this repo.

Bumping `pylance` is explicitly not a mitigation: the leak depends on the format the file was written in, not on the version that reads it. A file written by `pylance` 7.0.0 leaks when read by 1.0.4, and the attacker picks the writer.

## Implementation

`libcommon.packaged_modules` replaces `Lance._split_generators` with a function that raises, and is imported from `libcommon/__init__.py` alongside the existing `fsspec` allow-list.

Unregistering the format from the `datasets` registries was the first approach and it is worse: removing `latest_version_hint.json` from `_MODULE_TO_METADATA_FILE_NAMES` makes it fall through to the JSON module, which silently produces a bogus one-row dataset instead of refusing. Refusing inside the builder keeps `.lance` mapped to the Lance module so the failure is explicit.

## Follow-up

- Upstream in `datasets`: pass `read_params={"validate_on_decode": True}`.
- Upstream in `lance`: validate the offsets, and expose the option on `LanceFileReader`.
- Revert this commit once both are released and pinned.
- `compatible_libraries.py` still advertises Lance as a compatible library, which is now inconsistent but cosmetic. Left untouched.