### PR TITLE
perf(libcommon): read metrics, backfill candidates and admin reports from secondaries

### DIFF
--- a/libs/libcommon/src/libcommon/queue/jobs.py
+++ b/libs/libcommon/src/libcommon/queue/jobs.py
@@ -20,6 +20,7 @@ from mongoengine import Document
 from mongoengine.errors import DoesNotExist
 from mongoengine.fields import DateTimeField, EnumField, IntField, StringField
 from mongoengine.queryset.queryset import QuerySet
+from pymongo.read_preferences import ReadPreference
 from pymongoarrow.api import Schema, find_pandas_all
 
 from libcommon.constants import (
@@ -824,7 +825,9 @@ class Queue:
 
         return {
             (metric["job_type"], metric["status"], metric["dataset_status"]): metric["total"]
-            for metric in JobDocument.objects().aggregate(
+            for metric in JobDocument.objects()
+            .read_preference(ReadPreference.SECONDARY_PREFERRED)
+            .aggregate(
                 [
                     # NOTE: Removed unnecessary $sort before $group - was causing COLLSCAN
                     {
@@ -869,13 +872,19 @@ class Queue:
         return {
             WorkerSize.heavy.name: JobDocument.objects(
                 dataset__nin=blocked_datasets, difficulty__lte=100, difficulty__gt=70
-            ).count(),
+            )
+            .read_preference(ReadPreference.SECONDARY_PREFERRED)
+            .count(),
             WorkerSize.medium.name: JobDocument.objects(
                 dataset__nin=blocked_datasets, difficulty__lte=70, difficulty__gt=40
-            ).count(),
+            )
+            .read_preference(ReadPreference.SECONDARY_PREFERRED)
+            .count(),
             WorkerSize.light.name: JobDocument.objects(
                 dataset__nin=blocked_datasets, difficulty__lte=40, difficulty__gt=0
-            ).count(),
+            )
+            .read_preference(ReadPreference.SECONDARY_PREFERRED)
+            .count(),
         }
 
     def get_dump_with_status(self, status: Status, job_type: str) -> list[JobDict]:
@@ -888,7 +897,12 @@ class Queue:
         Returns:
             `list[JobDict]`: a list of jobs with the given status and the given type
         """
-        return [d.to_dict() for d in JobDocument.objects(status=status.value, type=job_type)]
+        return [
+            d.to_dict()
+            for d in JobDocument.objects(status=status.value, type=job_type).read_preference(
+                ReadPreference.SECONDARY_PREFERRED
+            )
+        ]
 
     def get_dump_by_pending_status(self, job_type: str) -> DumpByPendingStatus:
         """Get the dump of the jobs by pending status for a given job type.
@@ -907,7 +921,12 @@ class Queue:
         Returns:
             `list[JobDict]`: an array of the pending jobs for the dataset and the given job type
         """
-        return [d.to_dict() for d in JobDocument.objects(type=job_type, dataset=dataset)]
+        return [
+            d.to_dict()
+            for d in JobDocument.objects(type=job_type, dataset=dataset).read_preference(
+                ReadPreference.SECONDARY_PREFERRED
+            )
+        ]
 
     def heartbeat(self, job_id: str) -> None:
         """Update the job `last_heartbeat` field with the current date.

--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -25,6 +25,7 @@ from mongoengine.fields import (
     StringField,
 )
 from mongoengine.queryset.queryset import QuerySet
+from pymongo.read_preferences import ReadPreference
 from pymongoarrow.api import Schema, find_pandas_all
 
 from libcommon.constants import (
@@ -602,11 +603,19 @@ def get_previous_step_or_raise(
 
 
 def get_all_datasets() -> set[str]:
-    return set(CachedResponseDocument.objects().distinct("dataset"))
+    # only used to build the backfill candidate list, which is re-checked per dataset against the primary
+    return set(
+        CachedResponseDocument.objects().read_preference(ReadPreference.SECONDARY_PREFERRED).distinct("dataset")
+    )
 
 
 def get_datasets_with_retryable_errors() -> set[str]:
-    return set(CachedResponseDocument.objects(error_code__in=ERROR_CODES_TO_RETRY).distinct("dataset"))
+    # only used to build the backfill candidate list, which is re-checked per dataset against the primary
+    return set(
+        CachedResponseDocument.objects(error_code__in=ERROR_CODES_TO_RETRY)
+        .read_preference(ReadPreference.SECONDARY_PREFERRED)
+        .distinct("dataset")
+    )
 
 
 def is_successful_response(kind: str, dataset: str, config: Optional[str] = None, split: Optional[str] = None) -> bool:
@@ -648,7 +657,9 @@ def get_responses_count_by_kind_status_and_error_code() -> EntriesTotalByKindSta
     """
     return {
         (metric["kind"], metric["http_status"], metric["error_code"]): metric["total"]
-        for metric in CachedResponseDocument.objects().aggregate(
+        for metric in CachedResponseDocument.objects()
+        .read_preference(ReadPreference.SECONDARY_PREFERRED)
+        .aggregate(
             [
                 {"$sort": {"kind": 1, "http_status": 1, "error_code": 1}},
                 {
@@ -736,7 +747,9 @@ def get_cache_reports(kind: str, cursor: Optional[str], limit: int) -> CacheRepo
             raise InvalidCursor("Invalid cursor.") from err
     if limit <= 0:
         raise InvalidLimit("Invalid limit.")
-    objects = list(queryset.order_by("+id").exclude("content").limit(limit))
+    objects = list(
+        queryset.read_preference(ReadPreference.SECONDARY_PREFERRED).order_by("+id").exclude("content").limit(limit)
+    )
     return {
         "cache_reports": [
             {
@@ -769,7 +782,11 @@ def get_outdated_split_full_names_for_step(kind: str, current_version: int) -> l
 
 
 def get_dataset_responses_without_content_for_kind(kind: str, dataset: str) -> list[CacheReport]:
-    responses = CachedResponseDocument.objects(kind=kind, dataset=dataset).exclude("content")
+    responses = (
+        CachedResponseDocument.objects(kind=kind, dataset=dataset)
+        .read_preference(ReadPreference.SECONDARY_PREFERRED)
+        .exclude("content")
+    )
     return [
         {
             "kind": response.kind,
@@ -833,7 +850,7 @@ def get_cache_reports_with_content(kind: str, cursor: Optional[str], limit: int)
             raise InvalidCursor("Invalid cursor.") from err
     if limit <= 0:
         raise InvalidLimit("Invalid limit.")
-    objects = list(queryset.order_by("+id").limit(limit))
+    objects = list(queryset.read_preference(ReadPreference.SECONDARY_PREFERRED).order_by("+id").limit(limit))
     return {
         "cache_reports_with_content": [
             {
@@ -953,7 +970,9 @@ def get_datasets_with_last_updated_kind(kind: str, days: int) -> list[str]:
         str(dataset["datasets"])
         for dataset in CachedResponseDocument.objects(
             kind=kind, http_status=HTTPStatus.OK, updated_at__gt=get_datetime(days=days)
-        ).aggregate(pipeline)
+        )
+        .read_preference(ReadPreference.SECONDARY_PREFERRED)
+        .aggregate(pipeline)
     ]
 
 


### PR DESCRIPTION
## Summary

The primary of `mongodb-datasets-server-prod` fires `PerconaCPUPressureHigh`/`Critical` regularly. Eg:
https://huggingface.slack.com/archives/C0B82F7F94L/p1785807034132629
https://huggingface.slack.com/archives/C0B82F7F94L/p1785806134148849

A chunk of the recurring read load comes from queries that scan whole collections on a schedule but do not need to read their own writes:

- `queue-metrics-collector` runs every 10 minutes in prod and does a full `$group` over `jobsBlue` plus three `count()` calls with `dataset__nin` (not indexable).
- `cache-metrics-collector` runs every 3 hours and does a full `$group` over `cachedResponsesBlue`.
- `backfill` (daily) and `backfill-retryable-errors` (every 2 hours) call `distinct("dataset")` over the whole cache collection.
- The admin cache/queue report endpoints read purely for display.

This routes all of them to `secondaryPreferred`, the same thing the sse-api hub-cache watcher already does.

## What moved

`libs/libcommon/src/libcommon/simple_cache.py`
- `get_responses_count_by_kind_status_and_error_code`
- `get_datasets_with_last_updated_kind`
- `get_all_datasets`, `get_datasets_with_retryable_errors`
- `get_cache_reports`, `get_cache_reports_with_content`, `get_dataset_responses_without_content_for_kind`

`libs/libcommon/src/libcommon/queue/jobs.py`
- `get_jobs_total_by_type_status_and_dataset_status`
- `get_jobs_count_by_worker_size` (all three counts)
- `get_dump_with_status`, `get_dataset_pending_jobs_for_type`

## What deliberately stayed on the primary

| Call site | Reason |
|---|---|
| `get_cache_entries_df`, `get_pending_jobs_df` | feed `DatasetBackfillPlan` in `orchestrator.py` — read state, then create/delete jobs |
| `get_blocked_datasets` | called in the job claiming path (`jobs.py:415`); a freshly blocked dataset must be visible immediately |
| `get_response*` (API services) | user-facing, reads right after a webhook write |
| `mongodb_migration/check.py` `$sample` | migration correctness verification, must read authoritatively |

The two `distinct` calls only build a backfill *candidate* list; `backfill_dataset` still re-checks each dataset against the primary, so a stale candidate list can at worst defer a dataset to the next run. That invariant is noted in a comment next to each.